### PR TITLE
Add backreferences to examples

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -60,6 +60,7 @@ clean:
 	rm -rf modules/misc/autosummary
 	rm -rf modules/ml/autosummary
 	rm -rf modules/ml/clustering/autosummary
+	rm -rf backreferences
 
 .PHONY: html
 html:

--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,0 +1,7 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}
+
+.. include:: {{package}}/backreferences/{{fullname}}.examples

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,31 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+   
+.. include:: {{package}}/backreferences/{{fullname}}.examples

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx_rtd_theme',
               'sphinx_gallery.gen_gallery',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.doctest' ]
+              'sphinx.ext.doctest']
 
 autodoc_default_flags = ['members', 'inherited-members']
 
@@ -112,9 +112,9 @@ html_logo = "logos/notitle_logo/notitle_logo.png"
 # documentation.
 #
 html_theme_options = {
-        'logo_only': True,
-        'style_nav_header_background': 'Gainsboro',
-    }
+    'logo_only': True,
+    'style_nav_header_background': 'Gainsboro',
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -230,6 +230,7 @@ sphinx_gallery_conf = {
         'skfda': None,
     },
     'backreferences_dir': 'backreferences',
+    'doc_module': 'skfda',
 }
 
 autosummary_generate = True


### PR DESCRIPTION
Adds a link to related examples in the documentation of classes and functions. Note that some examples use wild imports, and should be changed for this to catch the imported objects.