### PR TITLE
Correct 'amplitude' -> 'phase' in phase_distance function documentation

### DIFF
--- a/skfda/misc/metrics.py
+++ b/skfda/misc/metrics.py
@@ -491,7 +491,7 @@ def amplitude_distance(fdata1, fdata2, *, lam=0., eval_points=None, **kwargs):
 
 
 def phase_distance(fdata1, fdata2, *, lam=0., eval_points=None, **kwargs):
-    r"""Compute the amplitude distance btween two functional objects.
+    r"""Compute the phase distance btween two functional objects.
 
     Let :math:`f_i` and :math:`f_j` be two functional observations, and let
     :math:`\gamma_{ij}` the corresponding warping used in the elastic


### PR DESCRIPTION
Noticed a small error in the docs