### PR TITLE
Renamed attributes related with dimensions of functions:

### DIFF
--- a/examples/plot_landmark_shift.py
+++ b/examples/plot_landmark_shift.py
@@ -103,7 +103,7 @@ l2 = fd_restricted.plot(label="Restricted samples")
 #
 
 fd = skfda.datasets.make_multimodal_samples(n_samples=3, points_per_dim=30,
-                                            ndim_domain=2, random_state=1)
+                                            dim_domain=2, random_state=1)
 
 fd.plot()
 
@@ -111,7 +111,7 @@ fd.plot()
 # In this case the landmarks will be defined by tuples with 2 coordinates.
 #
 
-landmarks = skfda.datasets.make_multimodal_landmarks(n_samples=3, ndim_domain=2,
+landmarks = skfda.datasets.make_multimodal_landmarks(n_samples=3, dim_domain=2,
                                                      random_state=1).squeeze()
 print(landmarks)
 

--- a/examples/plot_representation.py
+++ b/examples/plot_representation.py
@@ -56,11 +56,11 @@ first_curve.plot()
 ###############################################################################
 # This representation allows also functions with arbitrary dimensions of the
 # domain and codomain.
-fd = skfda.datasets.make_multimodal_samples(n_samples=1, ndim_domain=2,
-                                            ndim_image=2)
+fd = skfda.datasets.make_multimodal_samples(n_samples=1, dim_domain=2,
+                                            dim_codomain=2)
 
-print(fd.ndim_domain)
-print(fd.ndim_codomain)
+print(fd.dim_domain)
+print(fd.dim_codomain)
 
 fd.plot()
 

--- a/skfda/_neighbors/base.py
+++ b/skfda/_neighbors/base.py
@@ -639,7 +639,7 @@ class NeighborsFunctionalRegressorMixin:
             (float): Coefficient of determination.
 
         """
-        if y.ndim_image != 1 or y.ndim_domain != 1:
+        if y.dim_codomain != 1 or y.dim_domain != 1:
             raise ValueError("Score not implemented for multivariate "
                              "functional data.")
 

--- a/skfda/datasets/_real_datasets.py
+++ b/skfda/datasets/_real_datasets.py
@@ -460,8 +460,8 @@ def fetch_weather(return_X_y: bool = False):
     weather_daily = np.asarray(data["dailyAv"])
 
     # Axes 0 and 1 must be transposed since in the downloaded dataset the
-    # data_matrix shape is (nfeatures, n_samples, ndim_image) while our
-    # data_matrix shape is (n_samples, nfeatures, ndim_image).
+    # data_matrix shape is (nfeatures, n_samples, dim_codomain) while our
+    # data_matrix shape is (n_samples, nfeatures, dim_codomain).
     temp_prec_daily = np.transpose(weather_daily[:, :, 0:2], axes=(1, 0, 2))
 
     curves = FDataGrid(data_matrix=temp_prec_daily,

--- a/skfda/exploratory/depth/_depth.py
+++ b/skfda/exploratory/depth/_depth.py
@@ -98,7 +98,7 @@ def _rank_samples(fdatagrid):
 
 
     """
-    if fdatagrid.ndim_image > 1:
+    if fdatagrid.dim_codomain > 1:
         raise ValueError("Currently multivariate data is not allowed")
 
     ranks = np.zeros(fdatagrid.data_matrix.shape[:-1])
@@ -150,7 +150,7 @@ def band_depth(fdatagrid, *, pointwise=False):
         nchoose2 = n * (n - 1) / 2
 
         ranks = _rank_samples(fdatagrid)
-        axis = tuple(range(1, fdatagrid.ndim_domain + 1))
+        axis = tuple(range(1, fdatagrid.dim_domain + 1))
         n_samples_above = fdatagrid.n_samples - np.amax(ranks, axis=axis)
         n_samples_below = np.amin(ranks, axis=axis) - 1
         depth = ((n_samples_below * n_samples_above + fdatagrid.n_samples - 1)
@@ -207,7 +207,7 @@ def modified_band_depth(fdatagrid, *, pointwise=False):
     n_samples_above = fdatagrid.n_samples - ranks
     n_samples_below = ranks - 1
     match = n_samples_above * n_samples_below
-    axis = tuple(range(1, fdatagrid.ndim_domain + 1))
+    axis = tuple(range(1, fdatagrid.dim_domain + 1))
 
     if pointwise:
         depth_pointwise = (match + fdatagrid.n_samples - 1) / nchoose2
@@ -302,7 +302,7 @@ def fraiman_muniz_depth(fdatagrid, *, pointwise=False):
 
 
     """
-    if fdatagrid.ndim_domain > 1 or fdatagrid.ndim_image > 1:
+    if fdatagrid.dim_domain > 1 or fdatagrid.dim_codomain > 1:
         raise ValueError("Currently multivariate data is not allowed")
 
     pointwise_depth = np.array([

--- a/skfda/exploratory/depth/multivariate.py
+++ b/skfda/exploratory/depth/multivariate.py
@@ -10,7 +10,7 @@ def _stagel_donoho_outlyingness(X, *, pointwise=False):
     if pointwise is False:
         raise NotImplementedError("Only implemented pointwise")
 
-    if X.ndim_codomain == 1:
+    if X.dim_codomain == 1:
         # Special case, can be computed exactly
         m = X.data_matrix[..., 0]
 

--- a/skfda/exploratory/outliers/_directional_outlyingness.py
+++ b/skfda/exploratory/outliers/_directional_outlyingness.py
@@ -147,7 +147,7 @@ def directional_outlyingness_stats(
         Analysis 131 (2019): 50-65.
 
     """
-    if fdatagrid.ndim_domain > 1:
+    if fdatagrid.dim_domain > 1:
         raise NotImplementedError("Only support 1 dimension on the domain.")
 
     if (pointwise_weights is not None and
@@ -193,7 +193,7 @@ def directional_outlyingness_stats(
                                                   fdatagrid.sample_points[0],
                                                   axis=1)
     assert mean_dir_outlyingness.shape == (
-        fdatagrid.n_samples, fdatagrid.ndim_codomain)
+        fdatagrid.n_samples, fdatagrid.dim_codomain)
 
     # Calculation variation directional outlyingness
     norm = np.square(la.norm(dir_outlyingness -
@@ -437,7 +437,7 @@ class DirectionalOutlierDetector(BaseEstimator, OutlierMixin):
         # (approximation of the tail of the distance distribution).
 
         # One per dimension (mean dir out) plus one (variational dir out)
-        dimension = X.ndim_codomain + 1
+        dimension = X.dim_codomain + 1
         if self._force_asymptotic:
             self.scaling_, self.cutoff_value_ = self._parameters_asymptotic(
                 sample_size=X.n_samples,

--- a/skfda/exploratory/visualization/_boxplot.py
+++ b/skfda/exploratory/visualization/_boxplot.py
@@ -102,18 +102,18 @@ class Boxplot(FDataBoxplot):
 
     Attributes:
         fdatagrid (FDataGrid): Object containing the data.
-        median (array, (fdatagrid.ndim_image, nsample_points)): contains
+        median (array, (fdatagrid.dim_codomain, nsample_points)): contains
             the median/s.
-        central_envelope (array, (fdatagrid.ndim_image, 2, nsample_points)):
+        central_envelope (array, (fdatagrid.dim_codomain, 2, nsample_points)):
             contains the central envelope/s.
-        non_outlying_envelope (array, (fdatagrid.ndim_image, 2,
+        non_outlying_envelope (array, (fdatagrid.dim_codomain, 2,
             nsample_points)):
             contains the non-outlying envelope/s.
         colormap (matplotlib.colors.LinearSegmentedColormap): Colormap from
             which the colors to represent the central regions are selected.
-        envelopes (array, (fdatagrid.ndim_image * ncentral_regions, 2,
+        envelopes (array, (fdatagrid.dim_codomain * ncentral_regions, 2,
             nsample_points)): contains the region envelopes.
-        outliers (array, (fdatagrid.ndim_image, fdatagrid.n_samples)):
+        outliers (array, (fdatagrid.dim_codomain, fdatagrid.n_samples)):
             contains the outliers.
         barcol (string): Color of the envelopes and vertical lines.
         outliercol (string): Color of the ouliers.
@@ -229,7 +229,7 @@ class Boxplot(FDataBoxplot):
         """
         FDataBoxplot.__init__(self, factor)
 
-        if fdatagrid.ndim_domain != 1:
+        if fdatagrid.dim_domain != 1:
             raise ValueError(
                 "Function only supports FDataGrid with domain dimension 1.")
 
@@ -315,7 +315,7 @@ class Boxplot(FDataBoxplot):
 
     def plot(self, fig=None, ax=None, nrows=None, ncols=None):
         """Visualization of the functional boxplot of the fdatagrid
-        (ndim_domain=1).
+        (dim_domain=1).
 
         Args:
             fig (figure object, optional): figure over with the graphs are
@@ -351,7 +351,7 @@ class Boxplot(FDataBoxplot):
 
         outliers = self.fdatagrid[self.outliers]
 
-        for m in range(self.fdatagrid.ndim_image):
+        for m in range(self.fdatagrid.dim_codomain):
 
             # Outliers
             for o in outliers:
@@ -429,11 +429,11 @@ class SurfaceBoxplot(FDataBoxplot):
 
     Attributes:
         fdatagrid (FDataGrid): Object containing the data.
-        median (array, (fdatagrid.ndim_image, lx, ly)): contains
+        median (array, (fdatagrid.dim_codomain, lx, ly)): contains
             the median/s.
-        central_envelope (array, (fdatagrid.ndim_image, 2, lx, ly)):
+        central_envelope (array, (fdatagrid.dim_codomain, 2, lx, ly)):
             contains the central envelope/s.
-        non_outlying_envelope (array,(fdatagrid.ndim_image, 2, lx, ly)):
+        non_outlying_envelope (array,(fdatagrid.dim_codomain, 2, lx, ly)):
             contains the non-outlying envelope/s.
         colormap (matplotlib.colors.LinearSegmentedColormap): Colormap from
             which the colors to represent the central regions are selected.
@@ -525,7 +525,7 @@ class SurfaceBoxplot(FDataBoxplot):
         """
         FDataBoxplot.__init__(self, factor)
 
-        if fdatagrid.ndim_domain != 2:
+        if fdatagrid.dim_domain != 2:
             raise ValueError(
                 "Class only supports FDataGrid with domain dimension 2.")
 
@@ -593,7 +593,7 @@ class SurfaceBoxplot(FDataBoxplot):
         self._outcol = value
 
     def plot(self, fig=None, ax=None, nrows=None, ncols=None):
-        """Visualization of the surface boxplot of the fdatagrid (ndim_domain=2).
+        """Visualization of the surface boxplot of the fdatagrid (dim_domain=2).
 
          Args:
              fig (figure object, optional): figure over with the graphs are
@@ -623,7 +623,7 @@ class SurfaceBoxplot(FDataBoxplot):
         ly = len(y)
         X, Y = np.meshgrid(x, y)
 
-        for m in range(self.fdatagrid.ndim_image):
+        for m in range(self.fdatagrid.dim_codomain):
 
             # mean sample
             ax[m].plot_wireframe(X, Y, np.squeeze(self.median[..., m]).T,

--- a/skfda/exploratory/visualization/_magnitude_shape_plot.py
+++ b/skfda/exploratory/visualization/_magnitude_shape_plot.py
@@ -163,8 +163,9 @@ class MagnitudeShapePlot:
 
         """
 
-        if fdatagrid.ndim_image > 1:
-            raise NotImplementedError("Only support 1 dimension on the image.")
+        if fdatagrid.dim_codomain > 1:
+            raise NotImplementedError(
+                "Only support 1 dimension on the codomain.")
 
         self.outlier_detector = DirectionalOutlierDetector(**kwargs)
 

--- a/skfda/exploratory/visualization/clustering_plots.py
+++ b/skfda/exploratory/visualization/clustering_plots.py
@@ -148,7 +148,7 @@ def _plot_clusters(estimator, fdatagrid, fig, ax, nrows, ncols, labels,
         ncols(int): designates the number of columns of the figure to plot
             the different dimensions of the image. Only specified if fig
             and ax are None.
-        labels (numpy.ndarray, int: (n_samples, ndim_image)): 2-dimensional
+        labels (numpy.ndarray, int: (n_samples, dim_codomain)): 2-dimensional
             matrix where each row contains the number of cluster cluster
             that observation belongs to.
         sample_labels (list of str): contains in order the labels of each
@@ -208,7 +208,7 @@ def _plot_clusters(estimator, fdatagrid, fig, ax, nrows, ncols, labels,
             mpatches.Patch(color=cluster_colors[i],
                            label=cluster_labels[i]))
 
-    for j in range(fdatagrid.ndim_image):
+    for j in range(fdatagrid.dim_codomain):
         for i in range(fdatagrid.n_samples):
             ax[j].plot(fdatagrid.sample_points[0],
                        fdatagrid.data_matrix[i, :, j],

--- a/skfda/misc/_math.py
+++ b/skfda/misc/_math.py
@@ -179,7 +179,7 @@ def inner_product(fdatagrid, fdatagrid2):
                [ 1.  , 0.5 ]])
 
     """
-    if fdatagrid.ndim_domain != 1:
+    if fdatagrid.dim_domain != 1:
         raise NotImplementedError("This method only works when the dimension "
                                   "of the domain of the FDatagrid object is "
                                   "one.")

--- a/skfda/misc/metrics.py
+++ b/skfda/misc/metrics.py
@@ -25,8 +25,8 @@ def _cast_to_grid(fdata1, fdata2, eval_points=None, _check=True, **kwargs):
     if not _check:
         return fdata1, fdata2
 
-    elif (fdata2.ndim_image != fdata1.ndim_image or
-          fdata2.ndim_domain != fdata1.ndim_domain):
+    elif (fdata2.dim_codomain != fdata1.dim_codomain or
+          fdata2.dim_domain != fdata1.dim_domain):
         raise ValueError("Objects should have the same dimensions")
 
     # Case different domain ranges
@@ -97,14 +97,14 @@ def vectorial_norm(fdatagrid, p=2):
         First we will construct an example dataset with curves in
         :math:`\mathbb{R}^2`.
 
-        >>> fd = make_multimodal_samples(ndim_image=2, random_state=0)
-        >>> fd.ndim_image
+        >>> fd = make_multimodal_samples(dim_codomain=2, random_state=0)
+        >>> fd.dim_codomain
         2
 
         We will apply the euclidean norm
 
         >>> fd = vectorial_norm(fd, p=2)
-        >>> fd.ndim_image
+        >>> fd.dim_codomain
         1
 
     """
@@ -279,7 +279,7 @@ def norm_lp(fdatagrid, p=2, p2=2):
     if not (p == 'inf' or np.isinf(p)) and p < 1:
         raise ValueError(f"p must be equal or greater than 1.")
 
-    if fdatagrid.ndim_image > 1:
+    if fdatagrid.dim_codomain > 1:
         if p2 == 'inf':
             p2 = np.inf
         data_matrix = np.linalg.norm(fdatagrid.data_matrix, ord=p2, axis=-1,
@@ -289,12 +289,12 @@ def norm_lp(fdatagrid, p=2, p2=2):
 
     if p == 'inf' or np.isinf(p):
 
-        if fdatagrid.ndim_domain == 1:
+        if fdatagrid.dim_domain == 1:
             res = np.max(data_matrix[..., 0], axis=1)
         else:
             res = np.array([np.max(sample) for sample in data_matrix])
 
-    elif fdatagrid.ndim_domain == 1:
+    elif fdatagrid.dim_domain == 1:
 
         # Computes the norm, approximating the integral with Simpson's rule.
         res = scipy.integrate.simps(data_matrix[..., 0] ** p,

--- a/skfda/ml/clustering/base_kmeans.py
+++ b/skfda/ml/clustering/base_kmeans.py
@@ -36,7 +36,7 @@ class BaseKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             init (FDataGrid, optional): Contains the initial centers of the
                 different clusters the algorithm starts with. Its data_marix
                 must be of the shape (n_clusters, fdatagrid.ncol,
-                fdatagrid.ndim_image). Defaults to None, and the centers are
+                fdatagrid.dim_codomain). Defaults to None, and the centers are
                 initialized randomly.
             metric (optional): metric that acceps two FDataGrid objects and
             returns a matrix with shape (fdatagrid1.n_samples,
@@ -72,7 +72,7 @@ class BaseKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
                 are classified into different groups.
         """
 
-        if fdatagrid.ndim_domain > 1:
+        if fdatagrid.dim_domain > 1:
             raise NotImplementedError(
                 "Only support 1 dimension on the domain.")
 
@@ -94,9 +94,9 @@ class BaseKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
                           "because the init parameter is set.")
 
         if self.init is not None and self.init.shape != (
-                self.n_clusters, fdatagrid.ncol, fdatagrid.ndim_image):
+                self.n_clusters, fdatagrid.ncol, fdatagrid.dim_codomain):
             raise ValueError("The init FDataGrid data_matrix should be of "
-                             "shape (n_clusters, n_features, ndim_image) and "
+                             "shape (n_clusters, n_features, dim_codomain) and "
                              "gives the initial centers.")
 
         if self.max_iter < 1:
@@ -247,7 +247,7 @@ class BaseKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
                 convention.
 
         Returns:
-            score (numpy.array: (fdatagrid.ndim_image)): negative *inertia_*
+            score (numpy.array: (fdatagrid.dim_codomain)): negative *inertia_*
                 attribute.
 
         """
@@ -314,7 +314,7 @@ class KMeans(BaseKMeans):
             classified. Defaults to 2.
         init (FDataGrid, optional): Contains the initial centers of the
             different clusters the algorithm starts with. Its data_marix must
-            be of the shape (n_clusters, fdatagrid.ncol, fdatagrid.ndim_image).
+            be of the shape (n_clusters, fdatagrid.ncol, fdatagrid.dim_codomain).
             Defaults to None, and the centers are initialized randomly.
         metric (optional): metric that acceps two FDataGrid objects and returns
             a matrix with shape (fdatagrid1.n_samples, fdatagrid2.n_samples).
@@ -333,15 +333,15 @@ class KMeans(BaseKMeans):
             See :term:`Glossary <random_state>`.
 
     Attributes:
-        labels_ (numpy.ndarray: (n_samples, ndim_image)): 2-dimensional matrix
+        labels_ (numpy.ndarray: (n_samples, dim_codomain)): 2-dimensional matrix
             in which each row contains the cluster that observation belongs to.
         cluster_centers_ (FDataGrid object): data_matrix of shape
-            (n_clusters, ncol, ndim_image) and contains the centroids for
+            (n_clusters, ncol, dim_codomain) and contains the centroids for
             each cluster.
-        inertia_ (numpy.ndarray, (fdatagrid.ndim_image)): Sum of squared
+        inertia_ (numpy.ndarray, (fdatagrid.dim_codomain)): Sum of squared
             distances of samples to their closest cluster center for each
             dimension.
-        n_iter_ (numpy.ndarray, (fdatagrid.ndim_image)): number of iterations
+        n_iter_ (numpy.ndarray, (fdatagrid.dim_codomain)): number of iterations
             the algorithm was run for each dimension.
 
     Example:
@@ -374,7 +374,7 @@ class KMeans(BaseKMeans):
             init (FDataGrid, optional): Contains the initial centers of the
                 different clusters the algorithm starts with. Its data_marix
                 must be of the shape (n_clusters, fdatagrid.ncol,
-                fdatagrid.ndim_image). Defaults to None, and the centers are
+                fdatagrid.dim_codomain). Defaults to None, and the centers are
                 initialized randomly.
             metric (optional): metric that acceps two FDataGrid objects and
                 returns a matrix with shape (fdatagrid1.n_samples,
@@ -416,7 +416,7 @@ class KMeans(BaseKMeans):
                 array where each row contains the cluster that observation
                 belongs to.
 
-                centers (numpy.ndarray: (n_clusters, ncol, ndim_image)):
+                centers (numpy.ndarray: (n_clusters, ncol, dim_codomain)):
                 Contains the centroids for each cluster.
 
                 distances_to_centers (numpy.ndarray: (n_samples, n_clusters)):
@@ -426,7 +426,7 @@ class KMeans(BaseKMeans):
         """
         repetitions = 0
         centers_old = np.zeros(
-            (self.n_clusters, fdatagrid.ncol, fdatagrid.ndim_image))
+            (self.n_clusters, fdatagrid.ncol, fdatagrid.dim_codomain))
 
         if self.init is None:
             centers = self._init_centroids(fdatagrid, random_state)
@@ -466,7 +466,7 @@ class KMeans(BaseKMeans):
         clustering_values = np.empty(
             (self.n_init, fdatagrid.n_samples)).astype(int)
         centers = np.empty((self.n_init, self.n_clusters,
-                            fdatagrid.ncol, fdatagrid.ndim_image))
+                            fdatagrid.ncol, fdatagrid.dim_codomain))
         distances_to_centers = np.empty(
             (self.n_init, fdatagrid.n_samples, self.n_clusters))
         distances_to_their_center = np.empty(
@@ -560,7 +560,7 @@ class FuzzyKMeans(BaseKMeans):
             classified. Defaults to 2.
         init (FDataGrid, optional): Contains the initial centers of the
             different clusters the algorithm starts with. Its data_marix must
-            be of the shape (n_clusters, fdatagrid.ncol, fdatagrid.ndim_image).
+            be of the shape (n_clusters, fdatagrid.ncol, fdatagrid.dim_codomain).
             Defaults to None, and the centers are initialized randomly.
         metric (optional): metric that acceps two FDataGrid objects and returns
             a matrix with shape (fdatagrid1.n_samples, fdatagrid2.n_samples).
@@ -583,15 +583,15 @@ class FuzzyKMeans(BaseKMeans):
             returned in the fuzzy algorithm. Defaults to 3.
 
     Attributes:
-        labels_ (numpy.ndarray: (n_samples, ndim_image)): 2-dimensional matrix
+        labels_ (numpy.ndarray: (n_samples, dim_codomain)): 2-dimensional matrix
             in which each row contains the cluster that observation belongs to.
         cluster_centers_ (FDataGrid object): data_matrix of shape
-            (n_clusters, ncol, ndim_image) and contains the centroids for
+            (n_clusters, ncol, dim_codomain) and contains the centroids for
             each cluster.
-        inertia_ (numpy.ndarray, (fdatagrid.ndim_image)): Sum of squared
+        inertia_ (numpy.ndarray, (fdatagrid.dim_codomain)): Sum of squared
             distances of samples to their closest cluster center for each
             dimension.
-        n_iter_ (numpy.ndarray, (fdatagrid.ndim_image)): number of iterations
+        n_iter_ (numpy.ndarray, (fdatagrid.dim_codomain)): number of iterations
             the algorithm was run for each dimension.
 
 
@@ -625,7 +625,7 @@ class FuzzyKMeans(BaseKMeans):
             init (FDataGrid, optional): Contains the initial centers of the
                 different clusters the algorithm starts with. Its data_marix
                 must be of the shape (n_clusters, fdatagrid.ncol,
-                fdatagrid.ndim_image).
+                fdatagrid.dim_codomain).
                 Defaults to None, and the centers are initialized randomly.
             metric (optional): metric that acceps two FDataGrid objects and
                 returns a matrix with shape (fdatagrid1.n_samples,
@@ -672,7 +672,7 @@ class FuzzyKMeans(BaseKMeans):
                 2-dimensional matrix where each row contains the membership
                 value that observation has to each cluster.
 
-                centers (numpy.ndarray: (n_clusters, ncol, ndim_image)):
+                centers (numpy.ndarray: (n_clusters, ncol, dim_codomain)):
                 Contains the centroids for each cluster.
 
                 distances_to_centers (numpy.ndarray: (n_samples, n_clusters)):
@@ -683,7 +683,7 @@ class FuzzyKMeans(BaseKMeans):
         """
         repetitions = 0
         centers_old = np.zeros(
-            (self.n_clusters, fdatagrid.ncol, fdatagrid.ndim_image))
+            (self.n_clusters, fdatagrid.ncol, fdatagrid.dim_codomain))
         U = np.empty((fdatagrid.n_samples, self.n_clusters))
         distances_to_centers = np.empty((fdatagrid.n_samples, self.n_clusters))
 
@@ -750,7 +750,7 @@ class FuzzyKMeans(BaseKMeans):
             (self.n_init, fdatagrid.n_samples, self.n_clusters))
         centers = np.empty(
             (self.n_init, self.n_clusters, fdatagrid.ncol,
-             fdatagrid.ndim_image))
+             fdatagrid.dim_codomain))
         distances_to_centers = np.empty(
             (self.n_init, fdatagrid.n_samples, self.n_clusters))
         distances_to_their_center = np.empty(

--- a/skfda/preprocessing/registration/_elastic.py
+++ b/skfda/preprocessing/registration/_elastic.py
@@ -56,13 +56,13 @@ def to_srsf(fdatagrid, eval_points=None):
 
     """
 
-    if fdatagrid.ndim_domain > 1:
+    if fdatagrid.dim_domain > 1:
         raise ValueError("Only support functional objects with unidimensional "
                          "domain.")
 
-    elif fdatagrid.ndim_image > 1:
+    elif fdatagrid.dim_codomain > 1:
         raise ValueError("Only support functional objects with unidimensional "
-                         "image.")
+                         "codomain.")
 
     elif eval_points is None:
         eval_points = fdatagrid.sample_points[0]
@@ -119,11 +119,11 @@ def from_srsf(fdatagrid, initial=None, *, eval_points=None):
 
     """
 
-    if fdatagrid.ndim_domain > 1:
+    if fdatagrid.dim_domain > 1:
         raise ValueError("Only support functional objects with "
                          "unidimensional domain.")
 
-    elif fdatagrid.ndim_image > 1:
+    elif fdatagrid.dim_codomain > 1:
         raise ValueError("Only support functional objects with unidimensional "
                          "image.")
 
@@ -141,7 +141,8 @@ def from_srsf(fdatagrid, initial=None, *, eval_points=None):
 
     if initial is not None:
         initial = np.atleast_1d(initial)
-        initial = initial.reshape(fdatagrid.n_samples, 1, fdatagrid.ndim_image)
+        initial = initial.reshape(
+            fdatagrid.n_samples, 1, fdatagrid.dim_codomain)
         initial = np.repeat(initial, len(eval_points), axis=1)
         f_data_matrix += initial
 
@@ -259,7 +260,7 @@ def elastic_registration_warping(fdatagrid, template=None, *, lam=0.,
     """
 
     # Check of params
-    if fdatagrid.ndim_domain != 1 or fdatagrid.ndim_image != 1:
+    if fdatagrid.dim_domain != 1 or fdatagrid.dim_codomain != 1:
 
         raise ValueError("Not supported multidimensional functional objects.")
 
@@ -268,7 +269,7 @@ def elastic_registration_warping(fdatagrid, template=None, *, lam=0.,
                                 **kwargs)
 
     elif ((template.n_samples != 1 and template.n_samples != fdatagrid.n_samples)
-          or template.ndim_domain != 1 or template.ndim_image != 1):
+          or template.dim_domain != 1 or template.dim_codomain != 1):
 
         raise ValueError("The template should contain one sample to align all"
                          "the curves to the same function or the same number "
@@ -572,11 +573,11 @@ def elastic_mean(fdatagrid, *, lam=0., center=True, iter=20, tol=1e-3,
 
     """
 
-    if fdatagrid.ndim_domain != 1 or fdatagrid.ndim_image != 1:
+    if fdatagrid.dim_domain != 1 or fdatagrid.dim_codomain != 1:
         raise ValueError("Not supported multidimensional functional objects.")
 
-    if fdatagrid_srsf is not None and (fdatagrid_srsf.ndim_domain != 1 or
-                                       fdatagrid_srsf.ndim_image != 1):
+    if fdatagrid_srsf is not None and (fdatagrid_srsf.dim_domain != 1 or
+                                       fdatagrid_srsf.dim_codomain != 1):
         raise ValueError("Not supported multidimensional functional objects.")
 
     elif fdatagrid_srsf is None:

--- a/skfda/preprocessing/registration/_landmark_registration.py
+++ b/skfda/preprocessing/registration/_landmark_registration.py
@@ -218,7 +218,7 @@ def landmark_registration_warping(fd, landmarks, *, location=None,
         FDataGrid(...)
     """
 
-    if fd.ndim_domain > 1:
+    if fd.dim_domain > 1:
         raise NotImplementedError("Method only implemented for objects with"
                                   "domain dimension up to 1.")
 

--- a/skfda/preprocessing/registration/_registration_utils.py
+++ b/skfda/preprocessing/registration/_registration_utils.py
@@ -131,7 +131,7 @@ def mse_decomposition(original_fdata, registered_fdata, warping_function=None,
 
     """
 
-    if registered_fdata.ndim_domain != 1 or registered_fdata.ndim_image != 1:
+    if registered_fdata.dim_domain != 1 or registered_fdata.dim_codomain != 1:
         raise NotImplementedError
 
     if original_fdata.n_samples != registered_fdata.n_samples:
@@ -268,7 +268,7 @@ def invert_warping(fdatagrid, *, eval_points=None):
 
     """
 
-    if fdatagrid.ndim_image != 1 or fdatagrid.ndim_domain != 1:
+    if fdatagrid.dim_codomain != 1 or fdatagrid.dim_domain != 1:
         raise ValueError("Multidimensional object not supported.")
 
     if eval_points is None:

--- a/skfda/preprocessing/registration/_shift_registration.py
+++ b/skfda/preprocessing/registration/_shift_registration.py
@@ -100,7 +100,7 @@ def shift_registration_deltas(fd, *, maxiter=5, tol=1e-2,
 
     # Initial estimation of the shifts
 
-    if fd.ndim_image > 1 or fd.ndim_domain > 1:
+    if fd.dim_codomain > 1 or fd.dim_domain > 1:
         raise NotImplementedError("Method for unidimensional data.")
 
     domain_range = fd.domain_range[0]

--- a/skfda/preprocessing/smoothing/_linear.py
+++ b/skfda/preprocessing/smoothing/_linear.py
@@ -14,7 +14,7 @@ from ... import FDataGrid
 
 
 def _check_r_to_r(f):
-    if f.ndim_domain != 1 or f.ndim_codomain != 1:
+    if f.dim_domain != 1 or f.dim_codomain != 1:
         raise NotImplementedError("Only accepts functions from R to R")
 
 

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -23,8 +23,8 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
     Attributes:
         n_samples (int): Number of samples.
-        ndim_domain (int): Dimension of the domain.
-        ndim_image (int): Dimension of the image.
+        dim_domain (int): Dimension of the domain.
+        dim_codomain (int): Dimension of the image.
         extrapolation (Extrapolation): Default extrapolation mode.
         dataset_label (str): name of the dataset.
         axes_labels (list): list containing the labels of the different
@@ -54,11 +54,11 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
         if labels is not None:
 
             labels = np.asarray(labels)
-            if len(labels) > (self.ndim_domain + self.ndim_image):
+            if len(labels) > (self.dim_domain + self.dim_codomain):
                 raise ValueError("There must be a label for each of the "
                                  "dimensions of the domain and the image.")
-            if len(labels) < (self.ndim_domain + self.ndim_image):
-                diff = (self.ndim_domain + self.ndim_image) - len(labels)
+            if len(labels) < (self.dim_domain + self.dim_codomain):
+                diff = (self.dim_domain + self.dim_codomain) - len(labels)
                 labels = np.concatenate((labels, diff * [None]))
 
         self._axes_labels = labels
@@ -76,7 +76,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
     @property
     @abstractmethod
-    def ndim_domain(self):
+    def dim_domain(self):
         """Return number of dimensions of the domain.
 
         Returns:
@@ -87,24 +87,14 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
     @property
     @abstractmethod
-    def ndim_image(self):
-        """Return number of dimensions of the image.
-
-        Returns:
-            int: Number of dimensions of the image.
-
-        """
-        pass
-
-    @property
-    def ndim_codomain(self):
+    def dim_codomain(self):
         """Return number of dimensions of the codomain.
 
         Returns:
             int: Number of dimensions of the codomain.
 
         """
-        return self.ndim_image
+        pass
 
     @property
     @abstractmethod
@@ -168,9 +158,9 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
         Returns:
             (np.ndarray): Numpy array with the eval_points, if
             evaluation_aligned is True with shape `number of evaluation points`
-            x `ndim_domain`. If the points are not aligned the shape of the
+            x `dim_domain`. If the points are not aligned the shape of the
             points will be `n_samples` x `number of evaluation points`
-            x `ndim_domain`.
+            x `dim_domain`.
 
         """
 
@@ -184,7 +174,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
         if evaluation_aligned:  # Samples evaluated at same eval points
 
             eval_points = eval_points.reshape((eval_points.shape[0],
-                                               self.ndim_domain))
+                                               self.dim_domain))
 
         else:  # Different eval_points for each sample
 
@@ -196,7 +186,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
             eval_points = eval_points.reshape((eval_points.shape[0],
                                                eval_points.shape[1],
-                                               self.ndim_domain))
+                                               self.dim_domain))
 
         return eval_points
 
@@ -205,8 +195,8 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         Args:
             eval_points (np.ndarray): Array with shape `n_eval_points` x
-                `ndim_domain` with the evaluation points, or shape ´n_samples´ x
-                `n_eval_points` x `ndim_domain` with different evaluation
+                `dim_domain` with the evaluation points, or shape ´n_samples´ x
+                `n_eval_points` x `dim_domain` with different evaluation
                 points for each sample.
 
         Returns:
@@ -266,7 +256,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 object.
 
         Returns:
-            (numpy.darray): Numpy array with ndim_domain + 1 dimensions with
+            (numpy.darray): Numpy array with dim_domain + 1 dimensions with
                 the result of the evaluation.
 
         Raises:
@@ -280,16 +270,16 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
             lengths = [len(ax) for ax in axes]
 
-            if len(axes) != self.ndim_domain:
+            if len(axes) != self.dim_domain:
                 raise ValueError(f"Length of axes should be "
-                                 f"{self.ndim_domain}")
+                                 f"{self.dim_domain}")
 
             eval_points = _coordinate_list(axes)
 
             res = self.evaluate(eval_points, derivative=derivative,
                                 extrapolation=extrapolation, keepdims=True)
 
-        elif self.ndim_domain == 1:
+        elif self.dim_domain == 1:
 
             eval_points = [ax.squeeze(0) for ax in axes]
 
@@ -303,14 +293,14 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             if len(axes) != self.n_samples:
                 raise ValueError("Should be provided a list of axis per "
                                  "sample")
-            elif len(axes[0]) != self.ndim_domain:
+            elif len(axes[0]) != self.dim_domain:
                 raise ValueError(f"Incorrect length of axes. "
-                                 f"({self.ndim_domain}) != {len(axes[0])}")
+                                 f"({self.dim_domain}) != {len(axes[0])}")
 
             lengths = [len(ax) for ax in axes[0]]
             eval_points = np.empty((self.n_samples,
                                     np.prod(lengths),
-                                    self.ndim_domain))
+                                    self.dim_domain))
 
             for i in range(self.n_samples):
                 eval_points[i] = _coordinate_list(axes[i])
@@ -324,8 +314,8 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
         if keepdims is None:
             keepdims = self.keepdims
 
-        if self.ndim_image != 1 or keepdims:
-            shape += [self.ndim_image]
+        if self.dim_codomain != 1 or keepdims:
+            shape += [self.dim_codomain]
 
         # Roll the list of result in a list
         return res.reshape(shape)
@@ -348,11 +338,11 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         Returns:
             (ndarray): Matrix with the points evaluated with shape
-            `n_samples` x `number of points evaluated` x `ndim_image`.
+            `n_samples` x `number of points evaluated` x `dim_codomain`.
 
         """
         res = np.empty((self.n_samples, index_matrix.shape[-1],
-                        self.ndim_image))
+                        self.dim_codomain))
 
         # Case aligned evaluation
         if index_matrix.ndim == 1:
@@ -377,13 +367,13 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                `(len(eval_points), ndim_domain)` with the evaluation points.
+                `(len(eval_points), dim_domain)` with the evaluation points.
                 Each entry represents the coordinate of a point.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape `(n_samples,
-                len(eval_points), ndim_image)` with the result of the
+                len(eval_points), dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th image
                 dimension of the i-th sample, at the j-th evaluation point.
 
@@ -401,13 +391,13 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                `(n_samples, len(eval_points), ndim_domain)` with the
+                `(n_samples, len(eval_points), dim_domain)` with the
                 evaluation points for each sample.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape `(n_samples,
-                len(eval_points), ndim_image)` with the result of the
+                len(eval_points), dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th image
                 dimension of the i-th sample, at the j-th evaluation point.
 
@@ -432,9 +422,9 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             grid (bool, optional): Whether to evaluate the results on a grid
                 spanned by the input arrays, or at points specified by the
                 input arrays. If true the eval_points should be a list of size
-                ndim_domain with the corresponding times for each axis. The
+                dim_domain with the corresponding times for each axis. The
                 return matrix has shape n_samples x len(t1) x len(t2) x ... x
-                len(t_ndim_domain) x ndim_image. If the domain dimension is 1
+                len(t_dim_domain) x dim_codomain. If the domain dimension is 1
                 the parameter has no efect. Defaults to False.
             keepdims (bool, optional): If the image dimension is equal to 1 and
                 keepdims is True the return matrix has shape
@@ -528,7 +518,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             keepdims = self.keepdims
 
         # Delete last axis if not keepdims and
-        if self.ndim_image == 1 and not keepdims:
+        if self.dim_codomain == 1 and not keepdims:
             res = res.reshape(res.shape[:-1])
 
         return res
@@ -551,9 +541,9 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             grid (bool, optional): Whether to evaluate the results on a grid
                 spanned by the input arrays, or at points specified by the
                 input arrays. If true the eval_points should be a list of size
-                ndim_domain with the corresponding times for each axis. The
+                dim_domain with the corresponding times for each axis. The
                 return matrix has shape n_samples x len(t1) x len(t2) x ... x
-                len(t_ndim_domain) x ndim_image. If the domain dimension is 1
+                len(t_dim_domain) x dim_codomain. If the domain dimension is 1
                 the parameter has no efect. Defaults to False.
             keepdims (bool, optional): If the image dimension is equal to 1 and
                 keepdims is True the return matrix has shape
@@ -629,18 +619,18 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         """
 
-        if self.ndim_domain == 1:
+        if self.dim_domain == 1:
             projection = None
         else:
             projection = '3d'
 
         if ncols is None and nrows is None:
-            ncols = int(np.ceil(np.sqrt(self.ndim_image)))
-            nrows = int(np.ceil(self.ndim_image / ncols))
+            ncols = int(np.ceil(np.sqrt(self.dim_codomain)))
+            nrows = int(np.ceil(self.dim_codomain / ncols))
         elif ncols is None and nrows is not None:
-            nrows = int(np.ceil(self.ndim_image / nrows))
+            nrows = int(np.ceil(self.dim_codomain / nrows))
         elif ncols is not None and nrows is None:
-            nrows = int(np.ceil(self.ndim_image / ncols))
+            nrows = int(np.ceil(self.dim_codomain / ncols))
 
         fig = plt.gcf()
         axes = fig.get_axes()
@@ -661,19 +651,19 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
             # If compatible uses the same figure
             if (same_projection and geometry == (nrows, ncols) and
-                    self.ndim_image == len(axes)):
+                    self.dim_codomain == len(axes)):
                 return fig, axes
 
             else:  # Create new figure if it is not compatible
                 fig = plt.figure()
 
-        for i in range(self.ndim_image):
+        for i in range(self.dim_codomain):
             fig.add_subplot(nrows, ncols, i + 1, projection=projection)
 
-        if ncols > 1 and self.axes_labels is not None and self.ndim_image > 1:
+        if ncols > 1 and self.axes_labels is not None and self.dim_codomain > 1:
             plt.subplots_adjust(wspace=0.4)
 
-        if nrows > 1 and self.axes_labels is not None and self.ndim_image > 1:
+        if nrows > 1 and self.axes_labels is not None and self.dim_codomain > 1:
             plt.subplots_adjust(hspace=0.4)
 
         ax = fig.get_axes()
@@ -694,9 +684,9 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             labels = None
         else:
 
-            labels = self.axes_labels[:self.ndim_domain].tolist()
+            labels = self.axes_labels[:self.dim_domain].tolist()
             image_label = np.atleast_1d(
-                self.axes_labels[self.ndim_domain:][key])
+                self.axes_labels[self.dim_domain:][key])
             labels.extend(image_label.tolist())
 
         return labels
@@ -713,19 +703,19 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             self.concatenate(*others, as_coordinates=True).
 
         """
-        # Labels should be None or a list of length self.ndim_domain +
-        # self.ndim_image.
+        # Labels should be None or a list of length self.dim_domain +
+        # self.dim_codomain.
 
         if self.axes_labels is None:
-            labels = (self.ndim_domain + self.ndim_image) * [None]
+            labels = (self.dim_domain + self.dim_codomain) * [None]
         else:
             labels = self.axes_labels.tolist()
 
         for other in others:
             if other.axes_labels is None:
-                labels.extend(other.ndim_image * [None])
+                labels.extend(other.dim_codomain * [None])
             else:
-                labels.extend(list(other.axes_labels[self.ndim_domain:]))
+                labels.extend(list(other.axes_labels[self.dim_domain:]))
 
         if all(label is None for label in labels):
             labels = None
@@ -750,7 +740,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             if self.dataset_label is not None:
                 fig.suptitle(self.dataset_label)
             ax = fig.get_axes()
-            if patches is not None and self.ndim_image > 1:
+            if patches is not None and self.dim_codomain > 1:
                 fig.legend(handles=patches)
             elif patches is not None:
                 ax[0].legend(handles=patches)
@@ -762,7 +752,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         if self.axes_labels is not None:
             if ax[0].name == '3d':
-                for i in range(self.ndim_image):
+                for i in range(self.dim_codomain):
                     if self.axes_labels[0] is not None:
                         ax[i].set_xlabel(self.axes_labels[0])
                     if self.axes_labels[1] is not None:
@@ -770,7 +760,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                     if self.axes_labels[i + 2] is not None:
                         ax[i].set_zlabel(self.axes_labels[i + 2])
             else:
-                for i in range(self.ndim_image):
+                for i in range(self.dim_codomain):
                     if self.axes_labels[0] is not None:
                         ax[i].set_xlabel(self.axes_labels[0])
                     if self.axes_labels[i + 1] is not None:
@@ -803,7 +793,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 * ax (list): axes in which the graphs are plotted.
 
         """
-        if self.ndim_domain > 2:
+        if self.dim_domain > 2:
             raise NotImplementedError("Plot only supported for functional data"
                                       "modeled in at most 3 dimensions.")
 
@@ -811,11 +801,11 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             raise ValueError("fig and axes parameters cannot be passed as "
                              "arguments at the same time.")
 
-        if fig is not None and len(fig.get_axes()) != self.ndim_image:
+        if fig is not None and len(fig.get_axes()) != self.dim_codomain:
             raise ValueError("Number of axes of the figure must be equal to"
                              "the dimension of the image.")
 
-        if ax is not None and len(ax) != self.ndim_image:
+        if ax is not None and len(ax) != self.dim_codomain:
             raise ValueError("Number of axes must be equal to the dimension "
                              "of the image.")
 
@@ -827,7 +817,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                              " fig is None and ax is None.")
 
         if ((nrows is not None and ncols is not None)
-                and ((nrows * ncols) < self.ndim_image)):
+                and ((nrows * ncols) < self.dim_codomain)):
             raise ValueError("The number of columns and the number of rows "
                              "specified is incorrect.")
 
@@ -891,8 +881,8 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             label_names (list of str): name of each of the groups which appear
                 in a legend, there must be one for each one. Defaults to None
                 and the legend is not shown.
-            **kwargs: if ndim_domain is 1, keyword arguments to be passed to
-                the matplotlib.pyplot.plot function; if ndim_domain is 2,
+            **kwargs: if dim_domain is 1, keyword arguments to be passed to
+                the matplotlib.pyplot.plot function; if dim_domain is 2,
                 keyword arguments to be passed to the
                 matplotlib.pyplot.plot_surface function.
 
@@ -976,7 +966,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 sample_colors = np.empty((self.n_samples,)).astype(str)
                 next_color = True
 
-        if self.ndim_domain == 1:
+        if self.dim_domain == 1:
 
             if npoints is None:
                 npoints = constants.N_POINTS_UNIDIMENSIONAL_PLOT_MESH
@@ -985,7 +975,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             eval_points = np.linspace(*domain_range[0], npoints)
             mat = self(eval_points, derivative=derivative, keepdims=True)
 
-            for i in range(self.ndim_image):
+            for i in range(self.dim_codomain):
                 for j in range(self.n_samples):
                     if sample_labels is None and next_color:
                         sample_colors[j] = ax[i]._get_lines.get_next_color()
@@ -1012,7 +1002,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
             X, Y = np.meshgrid(x, y, indexing='ij')
 
-            for i in range(self.ndim_image):
+            for i in range(self.dim_codomain):
                 for j in range(self.n_samples):
                     if sample_labels is None and next_color:
                         sample_colors[j] = ax[i]._get_lines.get_next_color()

--- a/skfda/representation/basis.py
+++ b/skfda/representation/basis.py
@@ -1598,7 +1598,7 @@ class FDataBasis(FData):
 
         def __len__(self):
             """Return the number of coordinates."""
-            return self._fdatabasis.ndim_image
+            return self._fdatabasis.dim_codomain
 
     def __init__(self, basis, coefficients, *, dataset_label=None,
                  axes_labels=None, extrapolation=None, keepdims=False):
@@ -1718,14 +1718,14 @@ class FDataBasis(FData):
         return self.coefficients.shape[0]
 
     @property
-    def ndim_domain(self):
+    def dim_domain(self):
         """Return number of dimensions of the domain."""
 
         # Only domain dimension equal to 1 is supported
         return 1
 
     @property
-    def ndim_image(self):
+    def dim_codomain(self):
         """Return number of dimensions of the image."""
 
         # Only image dimension equal to 1 is supported
@@ -1849,7 +1849,7 @@ class FDataBasis(FData):
             :obj:`FDataBasis` with the shifted data.
         """
 
-        if self.ndim_image > 1 or self.ndim_domain > 1:
+        if self.dim_codomain > 1 or self.dim_domain > 1:
             raise ValueError
 
         domain_range = self.domain_range[0]
@@ -2041,7 +2041,7 @@ class FDataBasis(FData):
 
         """
 
-        if self.ndim_image > 1 or self.ndim_domain > 1:
+        if self.dim_codomain > 1 or self.dim_domain > 1:
             raise NotImplementedError
 
         if eval_points is None:
@@ -2326,7 +2326,7 @@ class FDataBasis(FData):
 
         grid = self.to_grid().compose(fd, eval_points=eval_points)
 
-        if fd.ndim_domain == 1:
+        if fd.dim_domain == 1:
             basis = self.basis.rescale(fd.domain_range[0])
             composition = grid.to_basis(basis, **kwargs)
         else:

--- a/skfda/representation/evaluator.py
+++ b/skfda/representation/evaluator.py
@@ -62,13 +62,13 @@ class Evaluator(ABC):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                ``(number_eval_points, ndim_domain)`` with the
+                ``(number_eval_points, dim_domain)`` with the
                 evaluation points.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape
-                ``(n_samples, number_eval_points, ndim_image)`` with the
+                ``(n_samples, number_eval_points, dim_codomain)`` with the
                 result of the evaluation. The entry ``(i,j,k)`` will contain
                 the value k-th image dimension of the i-th sample, at the
                 j-th evaluation point.
@@ -87,13 +87,13 @@ class Evaluator(ABC):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                ``(n_samples, number_eval_points, ndim_domain)`` with the
+                ``(n_samples, number_eval_points, dim_domain)`` with the
                 evaluation points for each sample.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape
-                ``(n_samples, number_eval_points, ndim_image)`` with the
+                ``(n_samples, number_eval_points, dim_codomain)`` with the
                 result of the evaluation. The entry ``(i,j,k)`` will contain
                 the value k-th image dimension of the i-th sample, at the
                 j-th evaluation point.
@@ -131,13 +131,13 @@ class GenericEvaluator(Evaluator):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                `(len(eval_points), ndim_domain)` with the evaluation points.
+                `(len(eval_points), dim_domain)` with the evaluation points.
                 Each entry represents the coordinate of a point.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3-d array with shape `(n_samples,
-                len(eval_points), ndim_image)` with the result of the
+                len(eval_points), dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th
                 image dimension of the i-th sample, at the j-th evaluation
                 point.
@@ -158,13 +158,13 @@ class GenericEvaluator(Evaluator):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, ndim_domain)` with the
+                `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, ndim_image)` with the result of the
+                number_eval_points, dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th image
                 dimension of the i-th sample, at the j-th evaluation point.
 

--- a/skfda/representation/extrapolation.py
+++ b/skfda/representation/extrapolation.py
@@ -51,13 +51,13 @@ def _periodic_evaluation(fdata, eval_points, *, derivative=0):
         fdata (:class:´FData´): Object where the evaluation is taken place.
         eval_points (:class: numpy.ndarray): Numpy array with the evalation
             points outside the domain range. The shape of the array may be
-            `n_eval_points` x `ndim_image` or `n_samples` x `n_eval_points`
-            x `ndim_image`.
+            `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
+            x `dim_codomain`.
         derivate (numeric, optional): Order of derivative to be evaluated.
 
     Returns:
         (numpy.ndarray): numpy array with the evaluation of the points in
-        a matrix with shape `n_samples` x `n_eval_points`x `ndim_image`.
+        a matrix with shape `n_samples` x `n_eval_points`x `dim_codomain`.
     """
 
     domain_range = np.asarray(fdata.domain_range)
@@ -117,18 +117,18 @@ def _boundary_evaluation(fdata, eval_points, *, derivative=0):
         fdata (:class:´FData´): Object where the evaluation is taken place.
         eval_points (:class: numpy.ndarray): Numpy array with the evalation
             points outside the domain range. The shape of the array may be
-            `n_eval_points` x `ndim_image` or `n_samples` x `n_eval_points`
-            x `ndim_image`.
+            `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
+            x `dim_codomain`.
         derivate (numeric, optional): Order of derivative to be evaluated.
 
     Returns:
         (numpy.ndarray): numpy array with the evaluation of the points in
-        a matrix with shape `n_samples` x `n_eval_points`x `ndim_image`.
+        a matrix with shape `n_samples` x `n_eval_points`x `dim_codomain`.
     """
 
     domain_range = fdata.domain_range
 
-    for i in range(fdata.ndim_domain):
+    for i in range(fdata.dim_domain):
         a, b = domain_range[i]
         eval_points[eval_points[..., i] < a, i] = a
         eval_points[eval_points[..., i] > b, i] = b
@@ -190,8 +190,8 @@ def _exception_evaluation(fdata, eval_points, *, derivative=0):
         fdata (:class:´FData´): Object where the evaluation is taken place.
         eval_points (:class: numpy.ndarray): Numpy array with the evalation
             points outside the domain range. The shape of the array may be
-            `n_eval_points` x `ndim_image` or `n_samples` x `n_eval_points`
-            x `ndim_image`.
+            `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
+            x `dim_codomain`.
         derivate (numeric, optional): Order of derivative to be evaluated.
 
     Raises:
@@ -264,7 +264,7 @@ class FillExtrapolationEvaluator(Evaluator):
 
     def _fill(self, eval_points):
         shape = (self.fdata.n_samples, eval_points.shape[-2],
-                 self.fdata.ndim_image)
+                 self.fdata.dim_codomain)
         return np.full(shape, self.fill_value)
 
     def evaluate(self, eval_points, *, derivative=0):
@@ -275,13 +275,13 @@ class FillExtrapolationEvaluator(Evaluator):
             fdata (:class:´FData´): Object where the evaluation is taken place.
             eval_points (:class: numpy.ndarray): Numpy array with the evalation
                 points outside the domain range. The shape of the array may be
-                `n_eval_points` x `ndim_image` or `n_samples` x `n_eval_points`
-                x `ndim_image`.
+                `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
+                x `dim_codomain`.
             derivate (numeric, optional): Order of derivative to be evaluated.
 
         Returns:
             (numpy.ndarray): numpy array with the evaluation of the points in
-            a matrix with shape `n_samples` x `n_eval_points`x `ndim_image`.
+            a matrix with shape `n_samples` x `n_eval_points`x `dim_codomain`.
 
         """
         return self._fill(eval_points)
@@ -298,13 +298,13 @@ class FillExtrapolationEvaluator(Evaluator):
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, ndim_domain)` with the
+                `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, ndim_image)` with the result of the
+                number_eval_points, dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th image
                 dimension of the i-th sample, at the j-th evaluation point.
 

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -83,7 +83,7 @@ class FDataGrid(FData):
         >>> data_matrix = [[[1, 0.3], [2, 0.4]], [[2, 0.5], [3, 0.6]]]
         >>> sample_points = [2, 4]
         >>> fd = FDataGrid(data_matrix, sample_points)
-        >>> fd.ndim_domain, fd.ndim_image
+        >>> fd.dim_domain, fd.dim_codomain
         (1, 2)
 
         Representation of a functional data object with 2 samples
@@ -92,7 +92,7 @@ class FDataGrid(FData):
         >>> data_matrix = [[[1, 0.3], [2, 0.4]], [[2, 0.5], [3, 0.6]]]
         >>> sample_points = [[2, 4], [3,6]]
         >>> fd = FDataGrid(data_matrix, sample_points)
-        >>> fd.ndim_domain, fd.ndim_image
+        >>> fd.dim_domain, fd.dim_codomain
         (2, 1)
 
     """
@@ -120,7 +120,7 @@ class FDataGrid(FData):
 
         def __len__(self):
             """Return the number of coordinates."""
-            return self._fdatagrid.ndim_image
+            return self._fdatagrid.dim_codomain
 
     def __init__(self, data_matrix, sample_points=None,
                  domain_range=None, dataset_label=None,
@@ -160,7 +160,7 @@ class FDataGrid(FData):
 
             self.sample_points = _list_of_arrays(sample_points)
 
-            data_shape = self.data_matrix.shape[1: 1 + self.ndim_domain]
+            data_shape = self.data_matrix.shape[1: 1 + self.dim_domain]
             sample_points_shape = [len(i) for i in self.sample_points]
 
             if not np.array_equal(data_shape, sample_points_shape):
@@ -171,7 +171,7 @@ class FDataGrid(FData):
 
         self._sample_range = np.array(
             [(self.sample_points[i][0], self.sample_points[i][-1])
-             for i in range(self.ndim_domain)])
+             for i in range(self.dim_domain)])
 
         if domain_range is None:
             self._domain_range = self.sample_range
@@ -183,9 +183,9 @@ class FDataGrid(FData):
             # dimensions in the domain and 2 columns
             if (self._domain_range.ndim != 2
                     or self._domain_range.shape[1] != 2
-                    or self._domain_range.shape[0] != self.ndim_domain):
+                    or self._domain_range.shape[0] != self.dim_domain):
                 raise ValueError("Incorrect shape of domain_range.")
-            for i in range(self.ndim_domain):
+            for i in range(self.dim_domain):
                 if (self._domain_range[i, 0] > self.sample_points[i][0]
                         or self._domain_range[i, -1] < self.sample_points[i]
                         [-1]):
@@ -193,7 +193,7 @@ class FDataGrid(FData):
                                      "range.")
 
         # Adjust the data matrix if the dimension of the image is one
-        if self.data_matrix.ndim == 1 + self.ndim_domain:
+        if self.data_matrix.ndim == 1 + self.dim_domain:
             self.data_matrix = self.data_matrix[..., np.newaxis]
 
         self.interpolator = interpolator
@@ -219,7 +219,7 @@ class FDataGrid(FData):
         return self.copy(data_matrix=self.data_matrix.round(decimals))
 
     @property
-    def ndim_domain(self):
+    def dim_domain(self):
         """Return number of dimensions of the domain.
 
         Returns:
@@ -229,7 +229,7 @@ class FDataGrid(FData):
         return len(self.sample_points)
 
     @property
-    def ndim_image(self):
+    def dim_codomain(self):
         """Return number of dimensions of the image.
 
         Returns:
@@ -240,7 +240,7 @@ class FDataGrid(FData):
             # The dimension of the image is the length of the array that can
             #  be extracted from the data_matrix using all the dimensions of
             #  the domain.
-            return self.data_matrix.shape[1 + self.ndim_domain]
+            return self.data_matrix.shape[1 + self.dim_domain]
         # If there is no array that means the dimension of the image is 1.
         except IndexError:
             return 1
@@ -259,8 +259,8 @@ class FDataGrid(FData):
             We will construct a dataset of curves in :math:`\mathbb{R}^3`
 
             >>> from skfda.datasets import make_multimodal_samples
-            >>> fd = make_multimodal_samples(ndim_image=3, random_state=0)
-            >>> fd.ndim_image
+            >>> fd = make_multimodal_samples(dim_codomain=3, random_state=0)
+            >>> fd.dim_codomain
             3
 
             The functions of this dataset are vectorial functions
@@ -273,20 +273,20 @@ class FDataGrid(FData):
 
             The object returned has image dimension equal to 1
 
-            >>> fd_0.ndim_image
+            >>> fd_0.dim_codomain
             1
 
             Or we can get multiple components, it can be accesed as a 1-d
             numpy array of coordinates, for example, :math:`(f_0(t), f_1(t))`.
 
             >>> fd_01 = fd.coordinates[0:2]
-            >>> fd_01.ndim_image
+            >>> fd_01.dim_codomain
             2
 
             We can use this method to iterate throught all the coordinates.
 
             >>> for fd_i in fd.coordinates:
-            ...     fd_i.ndim_image
+            ...     fd_i.dim_codomain
             1
             1
             1
@@ -470,7 +470,7 @@ class FDataGrid(FData):
                 ...)
 
         """
-        if self.ndim_domain != 1:
+        if self.dim_domain != 1:
             raise NotImplementedError(
                 "This method only works when the dimension "
                 "of the domain of the FDatagrid object is "
@@ -478,7 +478,7 @@ class FDataGrid(FData):
         if order < 1:
             raise ValueError("The order of a derivative has to be greater "
                              "or equal than 1.")
-        if self.ndim_domain > 1 or self.ndim_image > 1:
+        if self.dim_domain > 1 or self.dim_codomain > 1:
             raise NotImplementedError("Not implemented for 2 or more"
                                       " dimensional data.")
         if np.isnan(self.data_matrix).any():
@@ -822,8 +822,8 @@ class FDataGrid(FData):
         """
         fig, ax = self.generic_plotting_checks(fig, ax, nrows, ncols)
 
-        if self.ndim_domain == 1:
-            for i in range(self.ndim_image):
+        if self.dim_domain == 1:
+            for i in range(self.dim_codomain):
                 for j in range(self.n_samples):
                     ax[i].scatter(self.sample_points[0],
                                   self.data_matrix[j, :, i].T, **kwargs)
@@ -831,7 +831,7 @@ class FDataGrid(FData):
             X = self.sample_points[0]
             Y = self.sample_points[1]
             X, Y = np.meshgrid(X, Y)
-            for i in range(self.ndim_image):
+            for i in range(self.dim_codomain):
                 for j in range(self.n_samples):
                     ax[i].scatter(X, Y, self.data_matrix[j, :, :, i].T,
                                   **kwargs)
@@ -868,10 +868,10 @@ class FDataGrid(FData):
             array([[ 0.  , 0.71, 0.71]])
 
         """
-        if self.ndim_domain > 1:
+        if self.dim_domain > 1:
             raise NotImplementedError("Only support 1 dimension on the "
                                       "domain.")
-        elif self.ndim_image > 1:
+        elif self.dim_codomain > 1:
             raise NotImplementedError("Only support 1 dimension on the "
                                       "image.")
 
@@ -981,11 +981,11 @@ class FDataGrid(FData):
         shifts = np.array(shifts)
 
         # Case unidimensional treated as the multidimensional
-        if self.ndim_domain == 1 and shifts.ndim == 1 and shifts.shape[0] != 1:
+        if self.dim_domain == 1 and shifts.ndim == 1 and shifts.shape[0] != 1:
             shifts = shifts[:, np.newaxis]
 
         # Case same shift for all the curves
-        if shifts.shape[0] == self.ndim_domain and shifts.ndim == 1:
+        if shifts.shape[0] == self.dim_domain and shifts.ndim == 1:
 
             # Column vector with shapes
             shifts = np.atleast_2d(shifts).T
@@ -1013,7 +1013,7 @@ class FDataGrid(FData):
             eval_points = [eval_points[i][
                 np.logical_and(eval_points[i] >= domain[i, 0],
                                eval_points[i] <= domain[i, 1])]
-                           for i in range(self.ndim_domain)]
+                           for i in range(self.dim_domain)]
 
         else:
             domain = self.domain_range
@@ -1024,7 +1024,7 @@ class FDataGrid(FData):
                                        self.n_samples, axis=0)
 
         # Solve problem with cartesian and matrix indexing
-        if self.ndim_domain > 1:
+        if self.dim_domain > 1:
             shifts[:, :2] = np.flip(shifts[:, :2], axis=1)
 
         shifts = np.repeat(shifts[..., np.newaxis],
@@ -1051,17 +1051,17 @@ class FDataGrid(FData):
             eval_points (array_like): Points to perform the evaluation.
         """
 
-        if self.ndim_domain != fd.ndim_image:
+        if self.dim_domain != fd.dim_codomain:
             raise ValueError(f"Dimension of codomain of first function do not "
                              f"match with the domain of the second function "
-                             f"({self.ndim_domain})!=({fd.ndim_image}).")
+                             f"({self.dim_domain})!=({fd.dim_codomain}).")
 
         # All composed with same function
         if fd.n_samples == 1 and self.n_samples != 1:
             fd = fd.copy(data_matrix=np.repeat(fd.data_matrix, self.n_samples,
                                                axis=0))
 
-        if fd.ndim_domain == 1:
+        if fd.dim_domain == 1:
             if eval_points is None:
                 try:
                     eval_points = fd.sample_points[0]
@@ -1082,7 +1082,7 @@ class FDataGrid(FData):
 
             eval_points_transformation = np.empty((self.n_samples,
                                                    np.prod(lengths),
-                                                   self.ndim_domain))
+                                                   self.dim_domain))
 
             for i in range(self.n_samples):
                 eval_points_transformation[i] = np.array(
@@ -1093,7 +1093,7 @@ class FDataGrid(FData):
                                 aligned_evaluation=False)
 
             data_matrix = data_flatten.reshape((self.n_samples, *lengths,
-                                                self.ndim_image))
+                                                self.dim_codomain))
 
         return self.copy(data_matrix=data_matrix,
                          sample_points=eval_points,
@@ -1128,11 +1128,11 @@ class FDataGrid(FData):
         if isinstance(key, tuple):
             # If there are not values for every dimension, the remaining ones
             # are kept
-            key += (slice(None),) * (self.ndim_domain + 1 - len(key))
+            key += (slice(None),) * (self.dim_domain + 1 - len(key))
 
             sample_points = [self.sample_points[i][subkey]
                              for i, subkey in enumerate(
-                                 key[1:1 + self.ndim_domain])]
+                                 key[1:1 + self.dim_domain])]
 
             return self.copy(data_matrix=self.data_matrix[key],
                              sample_points=sample_points)

--- a/skfda/representation/interpolation.py
+++ b/skfda/representation/interpolation.py
@@ -166,13 +166,13 @@ class SplineInterpolatorEvaluator(Evaluator):
         data_matrix = fdatagrid.data_matrix
 
         self._fdatagrid = fdatagrid
-        self._ndim_image = fdatagrid.ndim_image
-        self._ndim_domain = fdatagrid.ndim_domain
+        self._dim_codomain = fdatagrid.dim_codomain
+        self._dim_domain = fdatagrid.dim_domain
         self._n_samples = fdatagrid.n_samples
         self._keepdims = fdatagrid.keepdims
         self._domain_range = fdatagrid.domain_range
 
-        if self._ndim_domain == 1:
+        if self._dim_domain == 1:
             self._splines = self._construct_spline_1_m(sample_points,
                                                        data_matrix,
                                                        k, s, monotone)
@@ -180,7 +180,7 @@ class SplineInterpolatorEvaluator(Evaluator):
             raise ValueError("Monotone interpolation is only supported with "
                              "domain dimension equal to 1.")
 
-        elif self._ndim_domain == 2:
+        elif self._dim_domain == 2:
             self._splines = self._construct_spline_2_m(sample_points,
                                                        data_matrix, k, s)
 
@@ -213,7 +213,7 @@ class SplineInterpolatorEvaluator(Evaluator):
             k (integer): Order of the spline interpolators.
 
         Returns:
-            (np.ndarray): Array of size n_samples x ndim_image with the
+            (np.ndarray): Array of size n_samples x dim_codomain with the
             corresponding interpolator of the sample i, and image dimension j
             in the entry (i,j) of the array.
 
@@ -282,7 +282,7 @@ class SplineInterpolatorEvaluator(Evaluator):
             k (integer): Order of the spline interpolators.
 
         Returns:
-            (np.ndarray): Array of size n_samples x ndim_image with the
+            (np.ndarray): Array of size n_samples x dim_codomain with the
             corresponding interpolator of the sample i, and image dimension j
             in the entry (i,j) of the array.
 
@@ -321,10 +321,10 @@ class SplineInterpolatorEvaluator(Evaluator):
         self._process_derivative = _process_derivative_2_m
 
         # Matrix of splines
-        spline = np.empty((self._n_samples, self._ndim_image), dtype=object)
+        spline = np.empty((self._n_samples, self._dim_codomain), dtype=object)
 
         for i in range(self._n_samples):
-            for j in range(self._ndim_image):
+            for j in range(self._dim_codomain):
                 spline[i, j] = RectBivariateSpline(sample_points[0],
                                                    sample_points[1],
                                                    data_matrix[i, :, :, j],
@@ -349,7 +349,7 @@ class SplineInterpolatorEvaluator(Evaluator):
             k (integer): Order of the spline interpolators.
 
         Returns:
-            (np.ndarray): Array of size n_samples x ndim_image with the
+            (np.ndarray): Array of size n_samples x dim_codomain with the
             corresponding interpolator of the sample i, and image dimension j
             in the entry (i,j) of the array.
 
@@ -383,10 +383,10 @@ class SplineInterpolatorEvaluator(Evaluator):
         # Evaluator of splines called in evaluate
         self._spline_evaluator = _spline_evaluator_n_m
 
-        spline = np.empty((self._n_samples, self._ndim_image), dtype=object)
+        spline = np.empty((self._n_samples, self._dim_codomain), dtype=object)
 
         for i in range(self._n_samples):
-            for j in range(self._ndim_image):
+            for j in range(self._dim_codomain):
                 spline[i, j] = RegularGridInterpolator(
                     sample_points, data_matrix[i, ..., j], method, False)
 
@@ -404,13 +404,13 @@ class SplineInterpolatorEvaluator(Evaluator):
 
         Args:
             eval_points (np.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, ndim_domain)` with the
+                `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (np.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, ndim_image)` with the result of the
+                number_eval_points, dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th image
                 dimension of the i-th sample, at the j-th evaluation point.
 
@@ -422,7 +422,7 @@ class SplineInterpolatorEvaluator(Evaluator):
         derivative = self._process_derivative(derivative)
 
         # Constructs the evaluator for t_eval
-        if self._ndim_image == 1:
+        if self._dim_codomain == 1:
             def evaluator(spl):
                 """Evaluator of object with image dimension equal to 1."""
                 return self._spline_evaluator(spl[0], eval_points, derivative)
@@ -436,7 +436,7 @@ class SplineInterpolatorEvaluator(Evaluator):
         # Points evaluated inside the domain
         res = np.apply_along_axis(evaluator, 1, self._splines)
         res = res.reshape(self._n_samples, eval_points.shape[0],
-                          self._ndim_image)
+                          self._dim_codomain)
 
         return res
 
@@ -452,13 +452,13 @@ class SplineInterpolatorEvaluator(Evaluator):
 
         Args:
             eval_points (np.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, ndim_domain)` with the
+                `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
             derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (np.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, ndim_image)` with the result of the
+                number_eval_points, dim_codomain)` with the result of the
                 evaluation. The entry (i,j,k) will contain the value k-th image
                 dimension of the i-th sample, at the j-th evaluation point.
 
@@ -467,19 +467,19 @@ class SplineInterpolatorEvaluator(Evaluator):
                 argument.
 
         """
-        shape = (self._n_samples, eval_points.shape[1], self._ndim_image)
+        shape = (self._n_samples, eval_points.shape[1], self._dim_codomain)
         res = np.empty(shape)
 
         derivative = self._process_derivative(derivative)
 
-        if self._ndim_image == 1:
+        if self._dim_codomain == 1:
             def evaluator(t, spl):
                 """Evaluator of sample with image dimension equal to 1"""
                 return self._spline_evaluator(spl[0], t, derivative)
 
             for i in range(self._n_samples):
                 res[i] = evaluator(eval_points[i], self._splines[i]).reshape(
-                    (eval_points.shape[1], self._ndim_image))
+                    (eval_points.shape[1], self._dim_codomain))
 
         else:
             def evaluator(t, spl_m):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -66,8 +66,8 @@ class TestFDataGrid(unittest.TestCase):
         fd = fd1.concatenate(fd2)
 
         np.testing.assert_equal(fd.n_samples, 4)
-        np.testing.assert_equal(fd.ndim_image, 1)
-        np.testing.assert_equal(fd.ndim_domain, 1)
+        np.testing.assert_equal(fd.dim_codomain, 1)
+        np.testing.assert_equal(fd.dim_domain, 1)
         np.testing.assert_array_equal(fd.data_matrix[..., 0],
                                       [[1, 2, 3, 4, 5], [2, 3, 4, 5, 6],
                                        [3, 4, 5, 6, 7], [4, 5, 6, 7, 8]])
@@ -82,8 +82,8 @@ class TestFDataGrid(unittest.TestCase):
         fd = fd1.concatenate(fd2, as_coordinates=True)
 
         np.testing.assert_equal(fd.n_samples, 2)
-        np.testing.assert_equal(fd.ndim_image, 2)
-        np.testing.assert_equal(fd.ndim_domain, 1)
+        np.testing.assert_equal(fd.dim_codomain, 2)
+        np.testing.assert_equal(fd.dim_domain, 1)
 
         np.testing.assert_array_equal(fd.data_matrix,
                                       [[[1, 3], [2, 4], [3, 5], [4, 6]],
@@ -118,7 +118,7 @@ class TestFDataGrid(unittest.TestCase):
         fd3 = fd1.concatenate(fd2, fd1, fd, as_coordinates=True)
 
         # Multiple indexation
-        np.testing.assert_equal(fd3.ndim_image, 5)
+        np.testing.assert_equal(fd3.dim_codomain, 5)
         np.testing.assert_array_equal(fd3.coordinates[:2].data_matrix,
                                       fd.data_matrix)
         np.testing.assert_array_equal(fd3.coordinates[-2:].data_matrix,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,10 +4,10 @@ import scipy.stats.mstats
 
 import numpy as np
 from skfda import FDataGrid, FDataBasis
-from skfda.representation.basis import Monomial
-from skfda.exploratory import stats
 from skfda.datasets import make_multimodal_samples
+from skfda.exploratory import stats
 from skfda.misc.metrics import lp_distance, norm_lp, vectorial_norm
+from skfda.representation.basis import Monomial
 
 
 class TestLpMetrics(unittest.TestCase):
@@ -19,14 +19,14 @@ class TestLpMetrics(unittest.TestCase):
         basis = Monomial(nbasis=3, domain_range=(1, 5))
         self.fd_basis = FDataBasis(basis, [[1, 1, 0], [0, 0, 1]])
         self.fd_curve = self.fd.concatenate(self.fd, as_coordinates=True)
-        self.fd_surface = make_multimodal_samples(n_samples=3, ndim_domain=2,
+        self.fd_surface = make_multimodal_samples(n_samples=3, dim_domain=2,
                                                   random_state=0)
 
     def test_vectorial_norm(self):
 
         vec = vectorial_norm(self.fd_curve, p=2)
         np.testing.assert_array_almost_equal(vec.data_matrix,
-                                             np.sqrt(2)* self.fd.data_matrix)
+                                             np.sqrt(2) * self.fd.data_matrix)
 
         vec = vectorial_norm(self.fd_curve, p='inf')
         np.testing.assert_array_almost_equal(vec.data_matrix,
@@ -58,7 +58,7 @@ class TestLpMetrics(unittest.TestCase):
 
     def test_norm_lp_surface_inf(self):
         np.testing.assert_allclose(norm_lp(self.fd_surface, p='inf').round(5),
-                                   [0.99994, 0.99793 , 0.99868])
+                                   [0.99994, 0.99793, 0.99868])
 
     def test_norm_lp_surface(self):
         # Integration of surfaces not implemented, add test case after
@@ -79,7 +79,7 @@ class TestLpMetrics(unittest.TestCase):
     def test_lp_error_domain_ranges(self):
         sample_points = [2, 3, 4, 5, 6]
         fd2 = FDataGrid([[2, 3, 4, 5, 6], [1, 4, 9, 16, 25]],
-                            sample_points=sample_points)
+                        sample_points=sample_points)
 
         with np.testing.assert_raises(ValueError):
             lp_distance(self.fd, fd2)
@@ -87,7 +87,7 @@ class TestLpMetrics(unittest.TestCase):
     def test_lp_error_sample_points(self):
         sample_points = [1, 2, 4, 4.3, 5]
         fd2 = FDataGrid([[2, 3, 4, 5, 6], [1, 4, 9, 16, 25]],
-                            sample_points=sample_points)
+                        sample_points=sample_points)
 
         with np.testing.assert_raises(ValueError):
             lp_distance(self.fd, fd2)
@@ -101,7 +101,6 @@ class TestLpMetrics(unittest.TestCase):
                         self.fd_basis, eval_points=[1, 2, 3, 4, 5]), 0)
         np.testing.assert_allclose(lp_distance(self.fd_basis, self.fd_basis),
                                    0)
-
 
 
 if __name__ == '__main__':

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -4,21 +4,17 @@ import unittest
 
 import numpy as np
 from skfda.datasets import make_multimodal_samples
-
+from skfda.exploratory.stats import mean as l2_mean
+from skfda.misc.metrics import lp_distance, pairwise_distance
 from skfda.ml.classification import (KNeighborsClassifier,
                                      RadiusNeighborsClassifier,
                                      NearestCentroids)
-
+from skfda.ml.clustering import NearestNeighbors
 from skfda.ml.regression import (KNeighborsScalarRegressor,
                                  RadiusNeighborsScalarRegressor,
                                  KNeighborsFunctionalRegressor,
                                  RadiusNeighborsFunctionalRegressor)
-
-from skfda.ml.clustering import NearestNeighbors
-
-from skfda.misc.metrics import lp_distance, pairwise_distance
 from skfda.representation.basis import Fourier
-from skfda.exploratory.stats import mean as l2_mean
 
 
 class TestNeighbors(unittest.TestCase):
@@ -294,13 +290,14 @@ class TestNeighbors(unittest.TestCase):
         y = 5 * self.X + 1
         neigh.fit(self.X, y)
         r = neigh.score(self.X, y)
-        np.testing.assert_almost_equal(r,0.962651178452408)
+        np.testing.assert_almost_equal(r, 0.962651178452408)
 
-        #Weighted case and basis form
+        # Weighted case and basis form
         y = y.to_basis(Fourier(domain_range=y.domain_range[0], nbasis=5))
         neigh.fit(self.X, y)
 
-        r = neigh.score(self.X[:7], y[:7], sample_weight=4*[1./5]+ 3 *[1./15])
+        r = neigh.score(self.X[:7], y[:7],
+                        sample_weight=4 * [1. / 5] + 3 * [1. / 15])
         np.testing.assert_almost_equal(r, 0.9982527586114364)
 
     def test_score_functional_response_exceptions(self):
@@ -308,17 +305,18 @@ class TestNeighbors(unittest.TestCase):
         neigh.fit(self.X, self.X)
 
         with np.testing.assert_raises(ValueError):
-            neigh.score(self.X, self.X, sample_weight=[1,2,3])
+            neigh.score(self.X, self.X, sample_weight=[1, 2, 3])
 
     def test_multivariate_response_score(self):
 
         neigh = RadiusNeighborsFunctionalRegressor()
-        y = make_multimodal_samples(n_samples=5, ndim_domain=2, random_state=0)
+        y = make_multimodal_samples(n_samples=5, dim_domain=2, random_state=0)
         neigh.fit(self.X[:5], y)
 
         # It is not supported the multivariate score by the moment
         with np.testing.assert_raises(ValueError):
             neigh.score(self.X[:5], y)
+
 
 if __name__ == '__main__':
     print()


### PR DESCRIPTION
* `ndim_domain` is now `dim_domain`
* `ndim_codomain` is now `dim_codomain`
* `ndim_image` is removed, as it was redundant with `ndim_codomain` and
the dimension is a property of the codomain and not the image.

The old names where based in numpy nomenclature, which is
matrix-centric. The new names try to reflect the usual conventions for
functions.