### PR TITLE
Remove the custom definition of shape for FDataGrid.

### DIFF
--- a/skfda/exploratory/outliers/_directional_outlyingness.py
+++ b/skfda/exploratory/outliers/_directional_outlyingness.py
@@ -170,7 +170,7 @@ def directional_outlyingness_stats(
     median_index = np.argmax(depth_pointwise, axis=0)
     pointwise_median = fdatagrid.data_matrix[
         median_index, range(fdatagrid.data_matrix.shape[1])]
-    assert pointwise_median.shape == fdatagrid.shape[1:]
+    assert pointwise_median.shape == fdatagrid.data_matrix.shape[1:]
     v = fdatagrid.data_matrix - pointwise_median
     assert v.shape == fdatagrid.data_matrix.shape
     v_norm = la.norm(v, axis=-1, keepdims=True)

--- a/skfda/ml/clustering/base_kmeans.py
+++ b/skfda/ml/clustering/base_kmeans.py
@@ -93,7 +93,7 @@ class BaseKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             warnings.warn("Warning: The number of iterations is ignored "
                           "because the init parameter is set.")
 
-        if self.init is not None and self.init.shape != (
+        if self.init is not None and self.init.data_matrix.shape != (
                 self.n_clusters, fdatagrid.ncol, fdatagrid.dim_codomain):
             raise ValueError("The init FDataGrid data_matrix should be of "
                              "shape (n_clusters, n_features, dim_codomain) and "
@@ -164,7 +164,8 @@ class BaseKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         """Checks that the FDataGrid object and the calculated centroids have
         compatible shapes.
         """
-        if fdatagrid.shape[1:3] != self.cluster_centers_.shape[1:3]:
+        if (fdatagrid.data_matrix.shape[1:3]
+                != self.cluster_centers_.data_matrix.shape[1:3]):
             raise ValueError("The fdatagrid shape is not the one expected for "
                              "the calculated cluster_centers_.")
 

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -344,18 +344,6 @@ class FDataGrid(FData):
         return self._domain_range
 
     @property
-    def shape(self):
-        """Dimensions (aka shape) of the data_matrix.
-
-        Returns:
-            list of int: List containing the length of the matrix on each of
-            its axis. If the matrix is 2 dimensional shape returns [number of
-            rows, number of columns].
-
-        """
-        return self.data_matrix.shape
-
-    @property
     def interpolator(self):
         """Defines the type of interpolation applied in `evaluate`."""
         return self._interpolator


### PR DESCRIPTION
An FDatagrid shape is now `(n_samples,)` (inherited from Panda's
`ExtensionArray`) as a FDataGrid is an array of functions with the same
evaluation points.

Closes #141.