### PR TITLE
Changes to plotting groups

### DIFF
--- a/examples/plot_boxplot.py
+++ b/examples/plot_boxplot.py
@@ -38,9 +38,9 @@ label_names = dataset["target_names"]
 nlabels = len(label_names)
 label_colors = colormap(np.arange(nlabels) / (nlabels - 1))
 
-fd_temperatures.plot(sample_labels=dataset["target"],
-                     label_colors=label_colors,
-                     label_names=label_names)
+fd_temperatures.plot(group=dataset["target"],
+                     group_colors=label_colors,
+                     group_names=label_names)
 
 
 ##############################################################################
@@ -70,9 +70,9 @@ fdBoxplot.plot()
 color = 0.3
 outliercol = 0.7
 
-fd_temperatures.plot(sample_labels=fdBoxplot.outliers.astype(int),
-                     label_colors=colormap([color, outliercol]),
-                     label_names=["nonoutliers", "outliers"])
+fd_temperatures.plot(group=fdBoxplot.outliers.astype(int),
+                     group_colors=colormap([color, outliercol]),
+                     group_names=["nonoutliers", "outliers"])
 
 ##############################################################################
 # The curves pointed as outliers are are those curves with significantly lower

--- a/examples/plot_clustering.py
+++ b/examples/plot_clustering.py
@@ -58,8 +58,8 @@ colormap = plt.cm.get_cmap('tab20b')
 n_climates = len(climates)
 climate_colors = colormap(np.arange(n_climates) / (n_climates - 1))
 
-fd.plot(sample_labels=indexer, label_colors=climate_colors,
-        label_names=climates)
+fd.plot(group=indexer, group_colors=climate_colors,
+        group_names=climates)
 
 ##############################################################################
 # The number of clusters is set with the number of climates, in order to see

--- a/examples/plot_explore.py
+++ b/examples/plot_explore.py
@@ -32,12 +32,13 @@ fat = y[:, np.asarray(target_feature_names) == 'Fat'].ravel()
 # the rest.
 
 low_fat = fat < 20
-labels = np.zeros(fd.n_samples, dtype=int)
-labels[low_fat] = 1
-colors = ['red', 'blue']
+labels = np.full(fd.n_samples, 'high fat')
+labels[low_fat] = 'low fat'
+colors = {'high fat': 'red',
+          'low fat': 'blue'}
 
 fig = fd.plot(group=labels, group_colors=colors,
-              linewidth=0.5, alpha=0.7)
+              linewidth=0.5, alpha=0.7, legend=True)
 
 ##############################################################################
 # The means of each group are the following ones.
@@ -48,8 +49,8 @@ mean_high = skfda.exploratory.stats.mean(fd[~low_fat])
 means = mean_high.concatenate(mean_low)
 
 means.dataset_label = fd.dataset_label + ' - means'
-means.plot(group=[0, 1], group_colors=colors,
-           linewidth=0.5)
+means.plot(group=['high fat', 'low fat'], group_colors=colors,
+           linewidth=0.5, legend=True)
 
 ##############################################################################
 # In this dataset, the vertical shift in the original trajectories is not
@@ -61,10 +62,10 @@ means.plot(group=[0, 1], group_colors=colors,
 
 fdd = fd.derivative(1)
 fig = fdd.plot(group=labels, group_colors=colors,
-               linewidth=0.5, alpha=0.7)
+               linewidth=0.5, alpha=0.7, legend=True)
 
 ##############################################################################
 # We now show the second derivative:
 fdd = fd.derivative(2)
 fig = fdd.plot(group=labels, group_colors=colors,
-               linewidth=0.5, alpha=0.7)
+               linewidth=0.5, alpha=0.7, legend=True)

--- a/examples/plot_explore.py
+++ b/examples/plot_explore.py
@@ -36,7 +36,7 @@ labels = np.zeros(fd.n_samples, dtype=int)
 labels[low_fat] = 1
 colors = ['red', 'blue']
 
-fig = fd.plot(sample_labels=labels, label_colors=colors,
+fig = fd.plot(group=labels, group_colors=colors,
               linewidth=0.5, alpha=0.7)
 
 ##############################################################################
@@ -48,7 +48,7 @@ mean_high = skfda.exploratory.stats.mean(fd[~low_fat])
 means = mean_high.concatenate(mean_low)
 
 means.dataset_label = fd.dataset_label + ' - means'
-means.plot(sample_labels=[0, 1], label_colors=colors,
+means.plot(group=[0, 1], group_colors=colors,
            linewidth=0.5)
 
 ##############################################################################
@@ -60,11 +60,11 @@ means.plot(sample_labels=[0, 1], label_colors=colors,
 # The first derivative is shown below:
 
 fdd = fd.derivative(1)
-fig = fdd.plot(sample_labels=labels, label_colors=colors,
+fig = fdd.plot(group=labels, group_colors=colors,
                linewidth=0.5, alpha=0.7)
 
 ##############################################################################
 # We now show the second derivative:
 fdd = fd.derivative(2)
-fig = fdd.plot(sample_labels=labels, label_colors=colors,
+fig = fdd.plot(group=labels, group_colors=colors,
                linewidth=0.5, alpha=0.7)

--- a/examples/plot_k_neighbors_classification.py
+++ b/examples/plot_k_neighbors_classification.py
@@ -37,7 +37,7 @@ y = data['target']
 class_names = data['target_names']
 
 # Plot samples grouped by sex
-X.plot(sample_labels=y, label_names=class_names, label_colors=['C0', 'C1'])
+X.plot(group=y, group_names=class_names, group_colors=['C0', 'C1'])
 
 
 ##############################################################################

--- a/examples/plot_k_neighbors_classification.py
+++ b/examples/plot_k_neighbors_classification.py
@@ -37,7 +37,7 @@ y = data['target']
 class_names = data['target_names']
 
 # Plot samples grouped by sex
-X.plot(group=y, group_names=class_names, group_colors=['C0', 'C1'])
+X.plot(group=y, group_names=class_names)
 
 
 ##############################################################################

--- a/examples/plot_magnitude_shape.py
+++ b/examples/plot_magnitude_shape.py
@@ -37,9 +37,9 @@ label_names = dataset["target_names"]
 nlabels = len(label_names)
 label_colors = colormap(np.arange(nlabels) / (nlabels - 1))
 
-fd_temperatures.plot(sample_labels=dataset["target"],
-                     label_colors=label_colors,
-                     label_names=label_names)
+fd_temperatures.plot(group=dataset["target"],
+                     group_colors=label_colors,
+                     group_names=label_names)
 
 ##############################################################################
 # The MS-Plot is generated. In order to show the results, the
@@ -62,9 +62,9 @@ msplot.plot()
 # To show the utility of the plot, the curves are plotted according to the
 # distinction made by the MS-Plot (outliers or not) with the same colors.
 
-fd_temperatures.plot(sample_labels=msplot.outliers.astype(int),
-                     label_colors=msplot.colormap([color, outliercol]),
-                     label_names=['nonoutliers', 'outliers'])
+fd_temperatures.plot(group=msplot.outliers.astype(int),
+                     group_colors=msplot.colormap([color, outliercol]),
+                     group_names=['nonoutliers', 'outliers'])
 
 ##############################################################################
 # We can observe that most of the curves  pointed as outliers belong either to
@@ -118,5 +118,5 @@ labels[group2] = 2
 ##############################################################################
 # We now plot the curves with their corresponding color:
 
-fd_temperatures.plot(sample_labels=labels,
-                     label_colors=colormap([color, outliercol, 0.9]))
+fd_temperatures.plot(group=labels,
+                     group_colors=colormap([color, outliercol, 0.9]))

--- a/examples/plot_magnitude_shape_synthetic.py
+++ b/examples/plot_magnitude_shape_synthetic.py
@@ -76,8 +76,8 @@ fd = fd.concatenate(magnitude_outlier, shape_outlier_shift,
 # The data is plotted to show the curves we are working with.
 labels = [0] * n_samples + [1] * 6
 
-fd.plot(sample_labels=labels,
-        label_colors=['lightgrey', 'black'])
+fd.plot(group=labels,
+        group_colors=['lightgrey', 'black'])
 
 ##############################################################################
 # The MS-Plot is generated. In order to show the results, the
@@ -96,8 +96,8 @@ labels = [0] * n_samples + [1, 2, 3, 4, 5, 6]
 colors = ['lightgrey', 'orange', 'blue', 'black',
           'green', 'brown', 'lightblue']
 
-fd.plot(sample_labels=labels,
-        label_colors=colors)
+fd.plot(group=labels,
+        group_colors=colors)
 
 ##############################################################################
 # We now show the points in the MS-plot using the same colors

--- a/examples/plot_radius_neighbors_classification.py
+++ b/examples/plot_radius_neighbors_classification.py
@@ -40,7 +40,7 @@ X = fd1.concatenate(fd2)
 y = np.array(15 * [0] + 15 * [1])
 
 # Plot toy dataset
-X.plot(sample_labels=y, label_colors=['C0', 'C1'])
+X.plot(group=y, group_colors=['C0', 'C1'])
 
 ##############################################################################
 #
@@ -69,7 +69,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25,
 radius = 0.3
 sample = X_test[0]  # Center of the ball
 
-fig = X_train.plot(sample_labels=y_train, label_colors=['C0', 'C1'])
+fig = X_train.plot(group=y_train, group_colors=['C0', 'C1'])
 
 # Plot ball
 sample.plot(fig=fig, color='red', linewidth=3)

--- a/examples/plot_representation.py
+++ b/examples/plot_representation.py
@@ -28,7 +28,7 @@ y = dataset['target']
 
 print(repr(fd))
 
-fd.plot(sample_labels=y, label_colors=['red', 'blue'])
+fd.plot(group=y, group_colors=['red', 'blue'])
 
 ##############################################################################
 # This kind of representation is a discretized representation, in which the

--- a/skfda/exploratory/visualization/representation.py
+++ b/skfda/exploratory/visualization/representation.py
@@ -9,50 +9,50 @@ from ._utils import (_get_figure_and_axes, _set_figure_layout_for_fdata,
                      _set_labels)
 
 
-def _get_label_colors(n_labels, label_colors=None):
+def _get_label_colors(n_labels, group_colors=None):
     """Get the colors of each label"""
 
-    if label_colors is not None:
-        if len(label_colors) != n_labels:
-            raise ValueError("There must be a color in label_colors "
+    if group_colors is not None:
+        if len(group_colors) != n_labels:
+            raise ValueError("There must be a color in group_colors "
                              "for each of the labels that appear in "
-                             "sample_labels.")
+                             "group.")
     else:
         colormap = matplotlib.cm.get_cmap()
-        label_colors = colormap(np.arange(n_labels) / (n_labels - 1))
+        group_colors = colormap(np.arange(n_labels) / (n_labels - 1))
 
-    return label_colors
+    return group_colors
 
 
-def _get_color_info(fdata, sample_labels, label_names, label_colors, kwargs):
+def _get_color_info(fdata, group, group_names, group_colors, kwargs):
 
     patches = None
 
-    if sample_labels is not None:
+    if group is not None:
         # In this case, each curve has a label, and all curves with the same
         # label should have the same color
 
-        sample_labels = np.asarray(sample_labels)
+        group = np.asarray(group)
 
-        n_labels = np.max(sample_labels) + 1
+        n_labels = np.max(group) + 1
 
-        if np.any((sample_labels < 0) | (sample_labels >= n_labels)) or \
-                not np.all(np.isin(range(n_labels), sample_labels)):
-            raise ValueError("Sample_labels must contain at least an "
+        if np.any((group < 0) | (group >= n_labels)) or \
+                not np.all(np.isin(range(n_labels), group)):
+            raise ValueError("group must contain at least an "
                              "occurence of numbers between 0 and number "
                              "of distint sample labels.")
 
-        label_colors = _get_label_colors(n_labels, label_colors)
-        sample_colors = np.asarray(label_colors)[sample_labels]
+        group_colors = _get_label_colors(n_labels, group_colors)
+        sample_colors = np.asarray(group_colors)[group]
 
-        if label_names is not None:
-            if len(label_names) != n_labels:
-                raise ValueError("There must be a name in  label_names "
+        if group_names is not None:
+            if len(group_names) != n_labels:
+                raise ValueError("There must be a name in  group_names "
                                  "for each of the labels that appear in "
-                                 "sample_labels.")
+                                 "group.")
 
             patches = [matplotlib.patches.Patch(color=c, label=l)
-                       for c, l in zip(label_colors, label_names)]
+                       for c, l in zip(group_colors, group_names)]
 
     else:
         # In this case, each curve has a different color unless specified
@@ -75,7 +75,7 @@ def _get_color_info(fdata, sample_labels, label_names, label_colors, kwargs):
 def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
                n_rows=None, n_cols=None, n_points=None,
                domain_range=None,
-               sample_labels=None, label_colors=None, label_names=None,
+               group=None, group_colors=None, group_names=None,
                **kwargs):
     """Plot the FDatGrid object graph as hypersurfaces.
 
@@ -115,15 +115,15 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
             interval; in the case of surfaces a list with 2 tuples with
             the ranges for each dimension. Default uses the domain range
             of the functional object.
-        sample_labels (list of int): contains integers from [0 to number of
+        group (list of int): contains integers from [0 to number of
             labels) indicating to which group each sample belongs to. Then,
             the samples with the same label are plotted in the same color.
             If None, the default value, each sample is plotted in the color
             assigned by matplotlib.pyplot.rcParams['axes.prop_cycle'].
-        label_colors (list of colors): colors in which groups are
+        group_colors (list of colors): colors in which groups are
             represented, there must be one for each group. If None, each
             group is shown with distict colors in the "Greys" colormap.
-        label_names (list of str): name of each of the groups which appear
+        group_names (list of str): name of each of the groups which appear
             in a legend, there must be one for each one. Defaults to None
             and the legend is not shown.
         **kwargs: if dim_domain is 1, keyword arguments to be passed to
@@ -145,7 +145,7 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
         domain_range = _list_of_arrays(domain_range)
 
     sample_colors, patches = _get_color_info(
-        fdata, sample_labels, label_names, label_colors, kwargs)
+        fdata, group, group_names, group_colors, kwargs)
 
     if fdata.dim_domain == 1:
 
@@ -205,8 +205,8 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
 
 def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
                  fig=None, axes=None,
-                 n_rows=None, n_cols=None, n_points=None, domain_range=None,
-                 sample_labels=None, label_colors=None, label_names=None,
+                 n_rows=None, n_cols=None, domain_range=None,
+                 group=None, group_colors=None, group_names=None,
                  **kwargs):
     """Plot the FDatGrid object.
 
@@ -231,28 +231,21 @@ def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
         n_cols(int, optional): designates the number of columns of the
             figure to plot the different dimensions of the image. Only
             specified if fig and ax are None.
-        n_points (int or tuple, optional): Number of points to evaluate in
-            the plot. In case of surfaces a tuple of length 2 can be pased
-            with the number of points to plot in each axis, otherwise the
-            same number of points will be used in the two axes. By default
-            in unidimensional plots will be used 501 points; in surfaces
-            will be used 30 points per axis, wich makes a grid with 900
-            points.
         domain_range (tuple or list of tuples, optional): Range where the
             function will be plotted. In objects with unidimensional domain
             the domain range should be a tuple with the bounds of the
             interval; in the case of surfaces a list with 2 tuples with
             the ranges for each dimension. Default uses the domain range
             of the functional object.
-        sample_labels (list of int): contains integers from [0 to number of
+        group (list of int): contains integers from [0 to number of
             labels) indicating to which group each sample belongs to. Then,
             the samples with the same label are plotted in the same color.
             If None, the default value, each sample is plotted in the color
             assigned by matplotlib.pyplot.rcParams['axes.prop_cycle'].
-        label_colors (list of colors): colors in which groups are
+        group_colors (list of colors): colors in which groups are
             represented, there must be one for each group. If None, each
             group is shown with distict colors in the "Greys" colormap.
-        label_names (list of str): name of each of the groups which appear
+        group_names (list of str): name of each of the groups which appear
             in a legend, there must be one for each one. Defaults to None
             and the legend is not shown.
         **kwargs: if dim_domain is 1, keyword arguments to be passed to
@@ -265,12 +258,17 @@ def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
 
     """
 
+    evaluated_points = None
+
     if sample_points is None:
         # This can only be done for FDataGrid
         sample_points = fdata.sample_points
-        evaluated_points = fdata.data_matrix
-    else:
-        evaluated_points = fdata(sample_points, grid=True)
+        if derivative == 0:
+            evaluated_points = fdata.data_matrix
+
+    if evaluated_points is None:
+        evaluated_points = fdata(
+            sample_points, grid=True, derivative=derivative)
 
     fig, axes = _get_figure_and_axes(chart, fig, axes)
     fig, axes = _set_figure_layout_for_fdata(fdata, fig, axes, n_rows, n_cols)
@@ -281,7 +279,7 @@ def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
         domain_range = _list_of_arrays(domain_range)
 
     sample_colors, patches = _get_color_info(
-        fdata, sample_labels, label_names, label_colors, kwargs)
+        fdata, group, group_names, group_colors, kwargs)
 
     if fdata.dim_domain == 1:
 

--- a/skfda/exploratory/visualization/representation.py
+++ b/skfda/exploratory/visualization/representation.py
@@ -39,9 +39,11 @@ def _get_color_info(fdata, group, group_names, group_colors, legend, kwargs):
             group_colors_array = np.array(
                 [group_colors[g] for g in group_unique])
         else:
-            colormap = matplotlib.cm.get_cmap()
-            group_colors_array = np.asarray(
-                colormap(np.arange(n_labels) / (n_labels - 1)))
+            prop_cycle = matplotlib.rcParams['axes.prop_cycle']
+            cycle_colors = prop_cycle.by_key()['color']
+
+            group_colors_array = np.take(
+                cycle_colors, np.arange(n_labels), mode='wrap')
 
         sample_colors = group_colors_array[group_indexes]
 

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -685,15 +685,15 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 interval; in the case of surfaces a list with 2 tuples with
                 the ranges for each dimension. Default uses the domain range
                 of the functional object.
-            sample_labels (list of int): contains integers from [0 to number of
+            group (list of int): contains integers from [0 to number of
                 labels) indicating to which group each sample belongs to. Then,
                 the samples with the same label are plotted in the same color.
                 If None, the default value, each sample is plotted in the color
                 assigned by matplotlib.pyplot.rcParams['axes.prop_cycle'].
-            label_colors (list of colors): colors in which groups are
+            group_colors (list of colors): colors in which groups are
                 represented, there must be one for each group. If None, each
                 group is shown with distict colors in the "Greys" colormap.
-            label_names (list of str): name of each of the groups which appear
+            group_names (list of str): name of each of the groups which appear
                 in a legend, there must be one for each one. Defaults to None
                 and the legend is not shown.
             **kwargs: if dim_domain is 1, keyword arguments to be passed to


### PR DESCRIPTION
* Rename sample_labels to group.
* Rename label_colors to group_colors.
* Rename label_names to group_names.
* `group` is now not required to be an array of integers, closes #165.
* `group_colors` and `group_names` are now objects that index the
color/name per group (so if `group` is an array of integers, they can
still be arrays, but they can be dict-like objects for other types).
* A new parameter `legend` allows to plot a legend even if no
`group_names` is passed (it will use the objects passed to `group`).
* The *explore* example is changed to make use of some of these features
in order to test them.

