### PR TITLE
Feature/optimize gram matrix

### DIFF
--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -226,6 +226,24 @@ class Basis(ABC):
 
         return inner
 
+    def _gram_matrix(self):
+        """
+        Compute the Gram matrix.
+
+        Subclasses may override this method for improving computation
+        of the Gram matrix.
+        """
+        fbasis = self.to_basis()
+
+        gram = np.zeros((self.n_basis, self.n_basis))
+
+        for i in range(fbasis.n_basis):
+            for j in range(i, fbasis.n_basis):
+                gram[i, j] = fbasis[i].inner_product(fbasis[j], None, None)
+                gram[j, i] = gram[i, j]
+
+        return gram
+
     def gram_matrix(self):
         r"""Return the Gram Matrix of a basis
 
@@ -241,14 +259,12 @@ class Basis(ABC):
             numpy.array: Gram Matrix of the basis.
 
         """
-        fbasis = self.to_basis()
 
-        gram = np.zeros((self.n_basis, self.n_basis))
+        cached = getattr(self, "_gram_matrix_cached", None)
 
-        for i in range(fbasis.n_basis):
-            for j in range(i, fbasis.n_basis):
-                gram[i, j] = fbasis[i].inner_product(fbasis[j], None, None)
-                gram[j, i] = gram[i, j]
+        if cached is None:
+            gram = self._gram_matrix()
+            self._gram_matrix_cached = gram
 
         return gram
 

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -260,9 +260,9 @@ class Basis(ABC):
 
         """
 
-        cached = getattr(self, "_gram_matrix_cached", None)
+        gram = getattr(self, "_gram_matrix_cached", None)
 
-        if cached is None:
+        if gram is None:
             gram = self._gram_matrix()
             self._gram_matrix_cached = gram
 

--- a/skfda/representation/basis/_constant.py
+++ b/skfda/representation/basis/_constant.py
@@ -38,6 +38,10 @@ class Constant(Basis):
         return (self.copy(), coefs.copy() if order == 0
                 else self.copy(), np.zeros(coefs.shape))
 
+    def _gram_matrix(self):
+        return np.array([[self.domain_range[0][1] -
+                          self.domain_range[0][0]]])
+
     def basis_of_product(self, other):
         """Multiplication of a Constant Basis with other Basis"""
         if not _same_domain(self, other):

--- a/skfda/representation/basis/_fourier.py
+++ b/skfda/representation/basis/_fourier.py
@@ -177,6 +177,14 @@ class Fourier(Basis):
         # normalise
         return self.copy(), deriv_coefs
 
+    def _gram_matrix(self):
+
+        # Orthogonal in this case
+        if self.period == (self.domain_range[0][1] - self.domain_range[0][0]):
+            return np.identity(self.n_basis)
+        else:
+            return super()._gram_matrix()
+
     def basis_of_product(self, other):
         """Multiplication of two Fourier Basis"""
         if not _same_domain(self, other):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -87,21 +87,23 @@ class TestBasis(unittest.TestCase):
         # TODO testing with other basis
 
     def test_basis_gram_matrix(self):
-        np.testing.assert_array_almost_equal(Monomial(n_basis=3).gram_matrix(),
-                                             [[1, 1 / 2, 1 / 3], [1 / 2, 1 / 3, 1 / 4], [1 / 3, 1 / 4, 1 / 5]])
-        np.testing.assert_almost_equal(Fourier(n_basis=3).gram_matrix(),
-                                       np.identity(3))
-        np.testing.assert_almost_equal(BSpline(n_basis=6).gram_matrix().round(4),
-                                       np.array([[4.760e-02, 2.920e-02, 6.200e-03, 4.000e-04, 0.000e+00, 0.000e+00],
-                                                 [2.920e-02, 7.380e-02, 5.210e-02,
-                                                  1.150e-02, 1.000e-04, 0.000e+00],
-                                                 [6.200e-03, 5.210e-02, 1.090e-01,
-                                                  7.100e-02, 1.150e-02, 4.000e-04],
-                                                 [4.000e-04, 1.150e-02, 7.100e-02,
-                                                  1.090e-01, 5.210e-02, 6.200e-03],
-                                                 [0.000e+00, 1.000e-04, 1.150e-02,
-                                                  5.210e-02, 7.380e-02, 2.920e-02],
-                                                 [0.000e+00, 0.000e+00, 4.000e-04, 6.200e-03, 2.920e-02, 4.760e-02]]))
+        np.testing.assert_allclose(Monomial(n_basis=3).gram_matrix(),
+                                   [[1, 1 / 2, 1 / 3], [1 / 2, 1 / 3, 1 / 4], [1 / 3, 1 / 4, 1 / 5]])
+        np.testing.assert_allclose(Fourier(n_basis=3).gram_matrix(),
+                                   np.identity(3))
+        np.testing.assert_allclose(BSpline(n_basis=6).gram_matrix().round(4),
+                                   np.array([[4.760e-02, 2.920e-02, 6.200e-03,
+                                              4.000e-04, 0.000e+00, 0.000e+00],
+                                             [2.920e-02, 7.380e-02, 5.210e-02,
+                                              1.150e-02, 1.000e-04, 0.000e+00],
+                                             [6.200e-03, 5.210e-02, 1.089e-01,
+                                              7.100e-02, 1.150e-02, 4.000e-04],
+                                             [4.000e-04, 1.150e-02, 7.100e-02,
+                                              1.089e-01, 5.210e-02, 6.200e-03],
+                                             [0.000e+00, 1.000e-04, 1.150e-02,
+                                              5.210e-02, 7.380e-02, 2.920e-02],
+                                             [0.000e+00, 0.000e+00, 4.000e-04,
+                                              6.200e-03, 2.920e-02, 4.760e-02]]))
 
     def test_basis_basis_inprod(self):
         monomial = Monomial(n_basis=4)


### PR DESCRIPTION
Optimize the computation of the Gram matrix for all existing basis.

As a result, the identity operator used in regularization, and thus the L2 regularization, should be more efficient.