### PR TITLE
Change default interpolation

### DIFF
--- a/skfda/preprocessing/registration/_shift_registration.py
+++ b/skfda/preprocessing/registration/_shift_registration.py
@@ -8,9 +8,9 @@ from sklearn.utils.validation import check_is_fitted
 
 import numpy as np
 
+from ... import FData, FDataGrid
 from ..._utils import constants, check_is_univariate
 from .base import RegistrationTransformer
-from ... import FData, FDataGrid
 
 
 class ShiftRegistration(RegistrationTransformer):
@@ -101,7 +101,7 @@ class ShiftRegistration(RegistrationTransformer):
         Shifts applied during the transformation
 
         >>> reg.deltas_.round(3)
-        array([-0.126,  0.19 ,  0.029,  0.036, -0.104,  0.116,  ..., -0.058])
+        array([-0.128,  0.187,  0.027,  0.034, -0.106,  0.114, ..., -0.06 ])
 
 
         Registration and creation of a dataset in basis form using the

--- a/skfda/preprocessing/registration/validation.py
+++ b/skfda/preprocessing/registration/validation.py
@@ -1,7 +1,8 @@
 """Methods and classes for validation of the registration procedures"""
 
-import numpy as np
 from typing import NamedTuple
+
+import numpy as np
 
 from ..._utils import check_is_univariate, _to_grid
 
@@ -38,6 +39,7 @@ class RegistrationScorer():
         :class:`~PairwiseCorrelation`
 
     """
+
     def __init__(self, eval_points=None):
         """Initialize the transformer"""
         self.eval_points = eval_points
@@ -224,10 +226,11 @@ class AmplitudePhaseDecomposition(RegistrationScorer):
         :class:`~PairwiseCorrelation`
 
     """
+
     def __init__(self, return_stats=False, eval_points=None):
         """Initialize the transformer"""
         super().__init__(eval_points)
-        self.return_stats=return_stats
+        self.return_stats = return_stats
 
     def __call__(self, estimator, X, y=None):
         """Compute the score of the transformation.
@@ -420,6 +423,7 @@ class LeastSquares(AmplitudePhaseDecomposition):
         :class:`~PairwiseCorrelation`
 
     """
+
     def score_function(self, X, y):
         """Compute the score of the transformation performed.
 
@@ -526,7 +530,7 @@ class SobolevLeastSquares(RegistrationScorer):
         >>> scorer = SobolevLeastSquares()
         >>> score = scorer(shift_registration, X)
         >>> round(score, 3)
-        0.762
+        0.761
 
     See also:
         :class:`~AmplitudePhaseDecomposition`
@@ -534,6 +538,7 @@ class SobolevLeastSquares(RegistrationScorer):
         :class:`~PairwiseCorrelation`
 
     """
+
     def score_function(self, X, y):
         """Compute the score of the transformation performed.
 

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -18,7 +18,7 @@ import numpy as np
 from . import basis as fdbasis
 from .._utils import _list_of_arrays, constants
 from ._functional_data import FData
-from .interpolation import SplineInterpolation
+from .interpolation import LinearInterpolation
 
 
 __author__ = "Miguel Carbajo Berrocal"
@@ -356,7 +356,7 @@ class FDataGrid(FData):
     def interpolation(self, new_interpolation):
         """Sets the interpolation of the FDataGrid."""
         if new_interpolation is None:
-            new_interpolation = SplineInterpolation()
+            new_interpolation = LinearInterpolation()
 
         self._interpolation = new_interpolation
         self._interpolation_evaluator = None

--- a/tests/test_fpca.py
+++ b/tests/test_fpca.py
@@ -61,8 +61,8 @@ class FPCATestCase(unittest.TestCase):
 
         fpca = FPCA(n_components=n_components,
                     regularization=TikhonovRegularization(
-                         LinearDifferentialOperator(2),
-                         regularization_parameter=1e5))
+                        LinearDifferentialOperator(2),
+                        regularization_parameter=1e5))
         fpca.fit(fd_basis)
 
         # results obtained using Ramsay's R package
@@ -100,8 +100,8 @@ class FPCATestCase(unittest.TestCase):
 
         fpca = FPCA(n_components=n_components,
                     regularization=TikhonovRegularization(
-                         LinearDifferentialOperator(2),
-                         regularization_parameter=1e5))
+                        LinearDifferentialOperator(2),
+                        regularization_parameter=1e5))
         fpca.fit(fd_basis)
         scores = fpca.transform(fd_basis)
 
@@ -318,11 +318,7 @@ class FPCATestCase(unittest.TestCase):
         fpca = FPCA(
             n_components=n_components, weights=[1] * 365,
             regularization=TikhonovRegularization(
-                LinearDifferentialOperator(
-                    2,
-                    derivative_function=(
-                        lambda function, points, derivative:
-                        function.derivative(order=derivative)(points)))))
+                LinearDifferentialOperator(2)))
         fpca.fit(fd_data)
 
         # results obtained using fda.usc for the first component

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -213,7 +213,7 @@ class TestShiftRegistration(unittest.TestCase):
 
         fd_registered = reg.transform(fd)
         deltas = reg.deltas_.round(3)
-        np.testing.assert_array_almost_equal(deltas, [0.071, -0.071])
+        np.testing.assert_allclose(deltas, [0.071, -0.072])
 
     def test_inverse_transform(self):
 
@@ -331,39 +331,39 @@ class TestRegistrationValidation(unittest.TestCase):
     def test_amplitude_phase_score(self):
         scorer = AmplitudePhaseDecomposition()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.972000160)
+        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
 
     def test_amplitude_phase_score_with_output_points(self):
         eval_points = self.X.sample_points[0]
         scorer = AmplitudePhaseDecomposition(eval_points=eval_points)
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.972000160)
+        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
 
     def test_amplitude_phase_score_with_basis(self):
         scorer = AmplitudePhaseDecomposition()
         X = self.X.to_basis(Fourier())
         score = scorer(self.shift_registration, X)
-        np.testing.assert_almost_equal(score, 0.9950259588)
+        np.testing.assert_allclose(score, 0.995087, rtol=1e-6)
 
     def test_default_score(self):
 
         score = self.shift_registration.score(self.X)
-        np.testing.assert_almost_equal(score, 0.972000160)
+        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
 
     def test_least_squares_score(self):
         scorer = LeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.795742349)
+        np.testing.assert_allclose(score, 0.795933, rtol=1e-6)
 
     def test_sobolev_least_squares_score(self):
         scorer = SobolevLeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.7621990)
+        np.testing.assert_allclose(score, 0.76124, rtol=1e-6)
 
     def test_pairwise_correlation(self):
         scorer = PairwiseCorrelation()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 1.816298653)
+        np.testing.assert_allclose(score, 1.816228, rtol=1e-6)
 
     def test_mse_decomposition(self):
 


### PR DESCRIPTION
Adds linear interpolation. For derivatives, this interpolator interpolates (again, linearly) the finite differences.

The default interpolation is changed to this.

The `ShiftRegistration` tests had been changed because the derivatives were used.