### PR TITLE
Change phonemes dataset domain range to 0-8kHz

### DIFF
--- a/skfda/datasets/_real_datasets.py
+++ b/skfda/datasets/_real_datasets.py
@@ -218,7 +218,8 @@ def fetch_phoneme(return_X_y: bool = False):
     speaker = data["speaker"].values
 
     curves = FDataGrid(data_matrix=curve_data.values,
-                       sample_points=np.array(range(0, 256)) * 8 / 255,
+                       sample_points=np.linspace(0, 8, 256),
+                       domain_range=[0, 8],
                        dataset_label="Phoneme",
                        axes_labels=["frequency (kHz)", "log-periodogram"])
 

--- a/skfda/datasets/_real_datasets.py
+++ b/skfda/datasets/_real_datasets.py
@@ -218,9 +218,9 @@ def fetch_phoneme(return_X_y: bool = False):
     speaker = data["speaker"].values
 
     curves = FDataGrid(data_matrix=curve_data.values,
-                       sample_points=range(0, 256),
+                       sample_points=np.array(range(0, 256)) * 8 / 255,
                        dataset_label="Phoneme",
-                       axes_labels=["frequency", "log-periodogram"])
+                       axes_labels=["frequency (kHz)", "log-periodogram"])
 
     if return_X_y:
         return curves, sound


### PR DESCRIPTION
The phonemes dataset contains 256 points equally spaced from 0-8 kHz. Before this, we are considering that the domain range is 0-255 which is incorrect and does not have a scale.
