### PR TITLE
Rework differentiation

### DIFF
--- a/examples/plot_explore.py
+++ b/examples/plot_explore.py
@@ -9,8 +9,9 @@ means and derivatives.
 # Author: Miguel Carbajo Berrocal
 # License: MIT
 
-import numpy as np
 import skfda
+
+import numpy as np
 
 
 ##############################################################################
@@ -60,12 +61,12 @@ means.plot(group=['high fat', 'low fat'], group_colors=colors,
 #
 # The first derivative is shown below:
 
-fdd = fd.derivative(1)
+fdd = fd.derivative()
 fig = fdd.plot(group=labels, group_colors=colors,
                linewidth=0.5, alpha=0.7, legend=True)
 
 ##############################################################################
 # We now show the second derivative:
-fdd = fd.derivative(2)
+fdd = fd.derivative(order=2)
 fig = fdd.plot(group=labels, group_colors=colors,
                linewidth=0.5, alpha=0.7, legend=True)

--- a/examples/plot_interpolation.py
+++ b/examples/plot_interpolation.py
@@ -81,42 +81,6 @@ fd_smooth.plot(fig=fig, label="Cubic smoothed")
 fd_smooth.scatter(fig=fig)
 fig.legend()
 
-
-##############################################################################
-# It is possible to evaluate derivatives of the FDatagrid,
-# but due to the fact that interpolation is performed first, the interpolation
-# loses one degree for each order of derivation. In the next example, it is
-# shown the first derivative of a sample using interpolation with different
-# degrees.
-#
-
-fd = fd[1]
-
-fig = plt.figure()
-fig.add_subplot(1, 1, 1)
-
-for i in range(1, 4):
-    fd.interpolation = SplineInterpolation(interpolation_order=i)
-    fd.plot(fig=fig, derivative=1, label=f"Degree {i}")
-
-fig.legend()
-
-##############################################################################
-# FDataGrids can be differentiate using lagged differences with the
-# method :func:`~skfda.representation.grid.FDataGrid.derivative`, creating
-# another FDataGrid which could be interpolated in order to avoid
-# interpolating before differentiating.
-#
-
-fd_derivative = fd.derivative()
-
-fig = fd_derivative.plot(label="Differentiation first")
-fd_derivative.scatter(fig=fig)
-
-fd.plot(fig=fig, derivative=1, label="Interpolation first")
-
-fig.legend()
-
 ##############################################################################
 # Sometimes our samples are required to be monotone, in these cases it is
 # possible to use monotone cubic interpolation with the attribute
@@ -124,6 +88,7 @@ fig.legend()
 # will be used.
 #
 
+fd = fd[1]
 
 fd_monotone = fd.copy(data_matrix=np.sort(fd.data_matrix, axis=1))
 
@@ -167,32 +132,22 @@ fd.scatter(fig=fig)
 # the values (3,2).
 #
 
-
 fd.interpolation = SplineInterpolation(interpolation_order=3)
 
 fig = fd.plot()
 fd.scatter(fig=fig)
 
 ##############################################################################
-# In case of surface derivatives could be taked in two directions, for this
-# reason a tuple with the order of derivates in each direction could be passed.
-# Let :math:`x(t,s)` be the surface, in the following example it is shown the
-# derivative with respect to the second coordinate, :math:`\frac{\partial}
-# {\partial s}x(t,s)`.
-
-fd.plot(derivative=(0, 1))
-
-##############################################################################
 # The following table shows the interpolation methods available by the class
 # :class:`SplineInterpolation` depending on the domain dimension.
 #
-# +------------------+--------+----------------+----------+-------------+-------------+
-# | Domain dimension | Linear | Up to degree 5 | Monotone | Derivatives |  Smoothing  |
-# +==================+========+================+==========+=============+=============+
-# |         1        |   ✔    |       ✔        |    ✔     |      ✔      |      ✔      |
-# +------------------+--------+----------------+----------+-------------+-------------+
-# |         2        |   ✔    |       ✔        |    ✖     |      ✔      |      ✔      |
-# +------------------+--------+----------------+----------+-------------+-------------+
-# |     3 or more    |   ✔    |       ✖        |    ✖     |      ✖      |      ✖      |
-# +------------------+--------+----------------+----------+-------------+-------------+
+# +------------------+--------+----------------+----------+-------------+
+# | Domain dimension | Linear | Up to degree 5 | Monotone |  Smoothing  |
+# +==================+========+================+==========+=============+
+# |         1        |   ✔    |       ✔        |    ✔     |      ✔      |
+# +------------------+--------+----------------+----------+-------------+
+# |         2        |   ✔    |       ✔        |    ✖     |      ✔      |
+# +------------------+--------+----------------+----------+-------------+
+# |     3 or more    |   ✔    |       ✖        |    ✖     |      ✖      |
+# +------------------+--------+----------------+----------+-------------+
 #

--- a/skfda/exploratory/visualization/representation.py
+++ b/skfda/exploratory/visualization/representation.py
@@ -77,7 +77,7 @@ def _get_color_info(fdata, group, group_names, group_colors, legend, kwargs):
     return sample_colors, patches
 
 
-def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
+def plot_graph(fdata, chart=None, *, fig=None, axes=None,
                n_rows=None, n_cols=None, n_points=None,
                domain_range=None,
                group=None, group_colors=None, group_names=None,
@@ -93,10 +93,6 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
             with the graphs are plotted or axis over where the graphs are
             plotted. If None and ax is also None, the figure is
             initialized.
-        derivative (int or tuple, optional): Order of derivative to be
-            plotted. In case of surfaces a tuple with the order of
-            derivation in each direction can be passed. See
-            :func:`evaluate` to obtain more information. Defaults 0.
         fig (figure object, optional): figure over with the graphs are
             plotted in case ax is not specified. If None and ax is also
             None, the figure is initialized.
@@ -164,7 +160,7 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
 
         # Evaluates the object in a linspace
         eval_points = np.linspace(*domain_range[0], n_points)
-        mat = fdata(eval_points, derivative=derivative, keepdims=True)
+        mat = fdata(eval_points, keepdims=True)
 
         color_dict = {}
 
@@ -193,7 +189,7 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
         y = np.linspace(*domain_range[1], npoints[1])
 
         # Evaluation of the functional object
-        Z = fdata((x, y), derivative=derivative, grid=True, keepdims=True)
+        Z = fdata((x, y), grid=True, keepdims=True)
 
         X, Y = np.meshgrid(x, y, indexing='ij')
 
@@ -213,7 +209,7 @@ def plot_graph(fdata, chart=None, *, derivative=0, fig=None, axes=None,
     return fig
 
 
-def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
+def plot_scatter(fdata, chart=None, *, sample_points=None,
                  fig=None, axes=None,
                  n_rows=None, n_cols=None, domain_range=None,
                  group=None, group_colors=None, group_names=None,
@@ -227,10 +223,6 @@ def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
             plotted. If None and ax is also None, the figure is
             initialized.
         sample_points (ndarray): points to plot.
-        derivative (int or tuple, optional): Order of derivative to be
-            plotted. In case of surfaces a tuple with the order of
-            derivation in each direction can be passed. See
-            :func:`evaluate` to obtain more information. Defaults 0.
         fig (figure object, optional): figure over with the graphs are
             plotted in case ax is not specified. If None and ax is also
             None, the figure is initialized.
@@ -278,12 +270,11 @@ def plot_scatter(fdata, chart=None, *, sample_points=None, derivative=0,
     if sample_points is None:
         # This can only be done for FDataGrid
         sample_points = fdata.sample_points
-        if derivative == 0:
-            evaluated_points = fdata.data_matrix
+        evaluated_points = fdata.data_matrix
 
     if evaluated_points is None:
         evaluated_points = fdata(
-            sample_points, grid=True, derivative=derivative)
+            sample_points, grid=True)
 
     fig, axes = _get_figure_and_axes(chart, fig, axes)
     fig, axes = _set_figure_layout_for_fdata(fdata, fig, axes, n_rows, n_cols)

--- a/skfda/misc/metrics.py
+++ b/skfda/misc/metrics.py
@@ -5,7 +5,6 @@ import numpy as np
 from ..preprocessing.registration import normalize_warping, ElasticRegistration
 from ..preprocessing.registration._warping import _normalize_scale
 from ..preprocessing.registration.elastic import SRSF
-from ..representation import FData
 from ..representation import FDataGrid, FDataBasis
 
 
@@ -306,7 +305,8 @@ def norm_lp(fdata, p=2, p2=2):
 
         elif fdata.dim_domain == 1:
 
-            # Computes the norm, approximating the integral with Simpson's rule.
+            # Computes the norm, approximating the integral with Simpson's
+            # rule.
             res = scipy.integrate.simps(data_matrix[..., 0] ** p,
                                         x=fdata.sample_points) ** (1 / p)
 
@@ -493,10 +493,11 @@ def amplitude_distance(fdata1, fdata2, *, lam=0., eval_points=None,
     fdata2 = fdata2.copy(sample_points=eval_points_normalized,
                          domain_range=(0, 1))
 
-    elastic_registration = ElasticRegistration(template=fdata2,
-                                               penalty=lam,
-                                               output_points=eval_points_normalized,
-                                               **kwargs)
+    elastic_registration = ElasticRegistration(
+        template=fdata2,
+        penalty=lam,
+        output_points=eval_points_normalized,
+        **kwargs)
 
     fdata1_reg = elastic_registration.fit_transform(fdata1)
 
@@ -507,9 +508,9 @@ def amplitude_distance(fdata1, fdata2, *, lam=0., eval_points=None,
 
     if lam != 0.0:
         # L2 norm || sqrt(Dh) - 1 ||^2
-        warping = elastic_registration.warping_
-        penalty = warping(eval_points_normalized, derivative=1,
-                          keepdims=False)[0]
+        warping_deriv = elastic_registration.warping_.derivative()
+        penalty = warping_deriv(eval_points_normalized,
+                                keepdims=False)[0]
         penalty = np.sqrt(penalty, out=penalty)
         penalty -= 1
         penalty = np.square(penalty, out=penalty)
@@ -573,14 +574,15 @@ def phase_distance(fdata1, fdata2, *, lam=0., eval_points=None, _check=True,
     fdata2 = fdata2.copy(sample_points=eval_points_normalized,
                          domain_range=(0, 1))
 
-    elastic_registration = ElasticRegistration(penalty=lam, template=fdata2,
-                                               output_points=eval_points_normalized)
+    elastic_registration = ElasticRegistration(
+        penalty=lam, template=fdata2,
+        output_points=eval_points_normalized)
 
     elastic_registration.fit_transform(fdata1)
 
-    derivative_warping = elastic_registration.warping_(eval_points_normalized,
-                                                       keepdims=False,
-                                                       derivative=1)[0]
+    warping_deriv = elastic_registration.warping_.derivative()
+    derivative_warping = warping_deriv(eval_points_normalized,
+                                       keepdims=False)[0]
 
     derivative_warping = np.sqrt(derivative_warping, out=derivative_warping)
 

--- a/skfda/misc/operators/_linear_differential_operator.py
+++ b/skfda/misc/operators/_linear_differential_operator.py
@@ -104,8 +104,7 @@ class LinearDifferentialOperator(Operator):
 
     def __init__(
             self, order_or_weights=None, *, order=None, weights=None,
-            domain_range=None,
-            derivative_function=None):
+            domain_range=None):
         """Constructor. You have to provide either order or weights.
            If both are provided, it will raise an error.
            If a positional argument is supplied it will be considered the
@@ -123,9 +122,6 @@ class LinearDifferentialOperator(Operator):
                          defined. If the functional weights are specified
                          and this is not, takes the domain range from them.
                          Otherwise, defaults to (0,1).
-
-            derivative_function (callable): function used to evaluate the
-                                derivatives.
 
         """
 
@@ -189,9 +185,6 @@ class LinearDifferentialOperator(Operator):
                                  "integers or FDataBasis objects")
 
         self.domain_range = real_domain_range
-        self.derivative_function = (
-            LinearDifferentialOperator.evaluate_derivative
-            if derivative_function is None else derivative_function)
 
     def __repr__(self):
         """Representation of linear differential operator object."""
@@ -236,13 +229,6 @@ class LinearDifferentialOperator(Operator):
                        for i, w in enumerate(self.weights))
 
         return applied_linear_diff_op
-
-    @staticmethod
-    def evaluate_derivative(function, points, derivative):
-        """
-        Default function for evaluating derivatives.
-        """
-        return function(points, derivative=derivative)
 
 
 #############################################################
@@ -479,8 +465,8 @@ def bspline_penalty_matrix_optimized(
         # defined between knots
         knots = np.array(basis.knots)
         mid_inter = (knots[1:] + knots[:-1]) / 2
-        constants = basis.evaluate(mid_inter,
-                                   derivative=derivative_degree).T
+        basis_deriv = basis.derivative(order=derivative_degree)
+        constants = basis_deriv(mid_inter).T
         knots_intervals = np.diff(basis.knots)
         # Integration of product of constants
         return constants.T @ np.diag(knots_intervals) @ constants
@@ -576,8 +562,8 @@ def fdatagrid_penalty_matrix_optimized(
         basis: FDataGrid):
 
     evaluated_basis = sum(
-        w(basis.sample_points[0]) * linear_operator.derivative_function(
-            function=basis, points=basis.sample_points[0], derivative=i)
+        w(basis.sample_points[0]) *
+        basis.derivative(order=i)(basis.sample_points[0])
         for i, w in enumerate(linear_operator.weights))
 
     indices = np.triu_indices(basis.n_samples)

--- a/skfda/misc/operators/_linear_differential_operator.py
+++ b/skfda/misc/operators/_linear_differential_operator.py
@@ -227,10 +227,13 @@ class LinearDifferentialOperator(Operator):
 
     def __call__(self, f):
         """Return the function that results of applying the operator."""
+
+        function_derivatives = [
+            f.derivative(order=i) for i, _ in enumerate(self.weights)]
+
         def applied_linear_diff_op(t):
-            return sum(w(t) * self.derivative_function(
-                function=f, points=t, derivative=i)
-                for i, w in enumerate(self.weights))
+            return sum(w(t) * function_derivatives[i](t)
+                       for i, w in enumerate(self.weights))
 
         return applied_linear_diff_op
 

--- a/skfda/preprocessing/registration/_shift_registration.py
+++ b/skfda/preprocessing/registration/_shift_registration.py
@@ -8,9 +8,9 @@ from sklearn.utils.validation import check_is_fitted
 
 import numpy as np
 
+from ... import FData, FDataGrid
 from ..._utils import constants, check_is_univariate
 from .base import RegistrationTransformer
-from ... import FData, FDataGrid
 
 
 class ShiftRegistration(RegistrationTransformer):
@@ -101,7 +101,7 @@ class ShiftRegistration(RegistrationTransformer):
         Shifts applied during the transformation
 
         >>> reg.deltas_.round(3)
-        array([-0.126,  0.19 ,  0.029,  0.036, -0.104,  0.116,  ..., -0.058])
+        array([-0.128,  0.187,  0.027,  0.034, -0.106,  0.114, ..., -0.06 ])
 
 
         Registration and creation of a dataset in basis form using the
@@ -184,7 +184,8 @@ class ShiftRegistration(RegistrationTransformer):
         delta_aux = np.empty(fd.n_samples)
 
         # Computes the derivate of originals curves in the mesh points
-        D1x = fd.evaluate(output_points, derivative=1, keepdims=False)
+        fd_deriv = fd.derivative(order=1)
+        D1x = fd_deriv(output_points, keepdims=False)
 
         # Second term of the second derivate estimation of REGSSE. The
         # first term has been dropped to improve convergence (see references)

--- a/skfda/preprocessing/registration/validation.py
+++ b/skfda/preprocessing/registration/validation.py
@@ -311,8 +311,9 @@ class AmplitudePhaseDecomposition(RegistrationScorer):
         # If the warping functions are not provided, are suppose independent
         if warping is not None:
             # Derivates warping functions
-            dh_fine = warping.evaluate(eval_points, derivative=1,
-                                       keepdims=False)
+            warping_deriv = warping.derivative()
+            dh_fine = warping_deriv(eval_points,
+                                    keepdims=False)
             dh_fine_mean = dh_fine.mean(axis=0)
             dh_fine_center = dh_fine - dh_fine_mean
 

--- a/skfda/preprocessing/registration/validation.py
+++ b/skfda/preprocessing/registration/validation.py
@@ -1,7 +1,8 @@
 """Methods and classes for validation of the registration procedures"""
 
-import numpy as np
 from typing import NamedTuple
+
+import numpy as np
 
 from ..._utils import check_is_univariate, _to_grid
 
@@ -38,6 +39,7 @@ class RegistrationScorer():
         :class:`~PairwiseCorrelation`
 
     """
+
     def __init__(self, eval_points=None):
         """Initialize the transformer"""
         self.eval_points = eval_points
@@ -224,10 +226,11 @@ class AmplitudePhaseDecomposition(RegistrationScorer):
         :class:`~PairwiseCorrelation`
 
     """
+
     def __init__(self, return_stats=False, eval_points=None):
         """Initialize the transformer"""
         super().__init__(eval_points)
-        self.return_stats=return_stats
+        self.return_stats = return_stats
 
     def __call__(self, estimator, X, y=None):
         """Compute the score of the transformation.
@@ -420,6 +423,7 @@ class LeastSquares(AmplitudePhaseDecomposition):
         :class:`~PairwiseCorrelation`
 
     """
+
     def score_function(self, X, y):
         """Compute the score of the transformation performed.
 
@@ -526,7 +530,7 @@ class SobolevLeastSquares(RegistrationScorer):
         >>> scorer = SobolevLeastSquares()
         >>> score = scorer(shift_registration, X)
         >>> round(score, 3)
-        0.762
+        0.761
 
     See also:
         :class:`~AmplitudePhaseDecomposition`
@@ -534,6 +538,7 @@ class SobolevLeastSquares(RegistrationScorer):
         :class:`~PairwiseCorrelation`
 
     """
+
     def score_function(self, X, y):
         """Compute the score of the transformation performed.
 

--- a/skfda/representation/_evaluation_trasformer.py
+++ b/skfda/representation/_evaluation_trasformer.py
@@ -12,7 +12,6 @@ class EvaluationTransformer(BaseEstimator, TransformerMixin):
         eval_points (array_like): List of points where the functions are
             evaluated. If `None`, the functions must be `FDatagrid` objects
             and all points will be returned.
-        derivative (int, optional): Order of the derivative. Defaults to 0.
         extrapolation (str or Extrapolation, optional): Controls the
             extrapolation mode for elements outside the domain range. By
             default it is used the mode defined during the instance of the
@@ -81,35 +80,11 @@ class EvaluationTransformer(BaseEstimator, TransformerMixin):
         array([[ 0.5   ,  0.784 ,  1.5625,  2.3515,  4.    ],
                [ 1.5   ,  1.864 ,  3.0625,  4.3315,  7.    ]])
 
-        Evaluating derivative of a FDataGrid at all points.
-
-        >>> data_matrix = [[1, 2, 3], [2, 3, 4]]
-        >>> sample_points = [2, 4, 6]
-        >>> fd = FDataGrid(data_matrix, sample_points)
-        >>>
-        >>> transformer = EvaluationTransformer(derivative=1)
-        >>> transformer.fit_transform(fd)
-        array([[ 0.5,  0.5,  0.5],
-               [ 0.5,  0.5,  0.5]])
-
-        Evaluation of the derivative of a functional data object at several
-        points.
-
-        >>> basis = Monomial(n_basis=4)
-        >>> coefficients = [[0.5, 1, 2, .5], [1.5, 1, 4, .5]]
-        >>> fd = FDataBasis(basis, coefficients)
-        >>>
-        >>> transformer = EvaluationTransformer([0, 0.2, 0.5, 0.7, 1],
-        ...                                     derivative=1)
-        >>> transformer.fit_transform(fd)
-        array([[  1.   ,   1.86 ,   3.375,   4.535,   6.5  ],
-               [  1.   ,   2.66 ,   5.375,   7.335,  10.5  ]])
     """
 
-    def __init__(self, eval_points=None, *, derivative=0,
+    def __init__(self, eval_points=None, *,
                  extrapolation=None, grid=False):
         self.eval_points = eval_points
-        self.derivative = derivative
         self.extrapolation = extrapolation
         self.grid = grid
 
@@ -128,11 +103,9 @@ class EvaluationTransformer(BaseEstimator, TransformerMixin):
         check_is_fitted(self, '_is_fitted')
 
         if self.eval_points is None:
-            if self.derivative != 0:
-                X = X.derivative(self.derivative)
             evaluation = X.data_matrix.copy()
         else:
-            evaluation = X(self.eval_points, derivative=self.derivative,
+            evaluation = X(self.eval_points,
                            extrapolation=self.extrapolation, grid=self.grid)
 
         evaluation = evaluation.reshape((X.n_samples, -1))

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -199,7 +199,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         return index
 
-    def _evaluate_grid(self, axes, *, derivative=0, extrapolation=None,
+    def _evaluate_grid(self, axes, *, extrapolation=None,
                        aligned_evaluation=True, keepdims=None):
         """Evaluate the functional object in the cartesian grid.
 
@@ -226,7 +226,6 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
         Args:
             axes (array_like): List of axes to generated the grid where the
                 object will be evaluated.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
             extrapolation (str or Extrapolation, optional): Controls the
                 extrapolation mode for elements outside the domain range. By
                 default it is used the mode defined during the instance of the
@@ -260,7 +259,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
             eval_points = _coordinate_list(axes)
 
-            res = self.evaluate(eval_points, derivative=derivative,
+            res = self.evaluate(eval_points,
                                 extrapolation=extrapolation, keepdims=True)
 
         elif self.dim_domain == 1:
@@ -268,7 +267,6 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             eval_points = [ax.squeeze(0) for ax in axes]
 
             return self.evaluate(eval_points,
-                                 derivative=derivative,
                                  extrapolation=extrapolation,
                                  keepdims=keepdims,
                                  aligned_evaluation=False)
@@ -289,7 +287,7 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             for i in range(self.n_samples):
                 eval_points[i] = _coordinate_list(axes[i])
 
-            res = self.evaluate(eval_points, derivative=derivative,
+            res = self.evaluate(eval_points,
                                 extrapolation=extrapolation,
                                 keepdims=True, aligned_evaluation=False)
 
@@ -396,7 +394,6 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 evaluated. If a matrix of shape nsample x eval_points is given
                 each sample is evaluated at the values in the corresponding row
                 in eval_points.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
             extrapolation (str or Extrapolation, optional): Controls the
                 extrapolation mode for elements outside the domain range. By
                 default it is used the mode defined during the instance of the
@@ -419,12 +416,15 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
             function at the values specified in eval_points.
 
         """
-        if derivative < 0:
-            raise ValueError("derivative only takes non-negative values.")
-        elif derivative != 0:
+        if derivative != 0:
             warnings.warn("Parameter derivative is deprecated. Use the "
                           "derivative function instead.", DeprecationWarning)
-            return self.derivative(order=derivative)(eval_points)
+            return self.derivative(order=derivative)(
+                eval_points,
+                extrapolation=extrapolation,
+                grid=grid,
+                aligned_evaluation=aligned_evaluation,
+                keepdims=keepdims)
 
         if extrapolation is None:
             extrapolation = self.extrapolation

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -101,7 +101,7 @@ class Basis(ABC):
         elif derivative != 0:
             warnings.warn("Parameter derivative is deprecated. Use the "
                           "derivative function instead.", DeprecationWarning)
-            return self.derivative(eval_points, order=derivative)
+            return self.derivative(order=derivative)(eval_points)
 
         eval_points = np.atleast_1d(eval_points)
         if np.any(np.isnan(eval_points)):
@@ -113,40 +113,18 @@ class Basis(ABC):
     def __call__(self, *args, **kwargs):
         return self.evaluate(*args, **kwargs)
 
-    def _derivative(self, eval_points, order=1):
-        """
-        Subclasses must override this to provide evaluation of derivatives.
-
-        Order 0 derivatives (original function) are automatically
-        implemented. Subclasses can assume that the order passed is
-        nonzero.
-
-        A basis can provide derivative evaluation at given points
-        without providing a basis representation for its derivatives,
-        although is recommended to provide both if possible.
-
-        """
-        return NotImplementedError(f"{type(self)} basis is not "
-                                   "differentiable.")
-
-    def derivative(self, eval_points, order=1):
-        """Evaluate the basis derivative at given points.
+    def derivative(self, *, order=1):
+        """Construct a FDataBasis object containing the derivative.
 
         Args:
-            eval_points (array_like): List of points where the derivative of
-                the basis is evaluated.
             order (int, optional): Order of the derivative. Defaults to 1.
 
         Returns:
-            (numpy.darray): Matrix whose rows are the values of the derivatives
-            of each basis function or its derivatives at the values specified
-            in eval_points.
+            (FDataBasis): Derivative object.
 
         """
-        if order == 0:
-            return self(eval_points)
-        else:
-            return self._derivative(eval_points, order=order)
+
+        return self.to_basis().derivative(order=order)
 
     def _derivative_basis_and_coefs(self, coefs, order=1):
         """
@@ -157,9 +135,9 @@ class Basis(ABC):
         although is recommended to provide both if possible.
 
         """
-        return NotImplementedError(f"{type(self)} basis does not support "
-                                   "the construction of a basis of the "
-                                   "derivatives.")
+        raise NotImplementedError(f"{type(self)} basis does not support "
+                                  "the construction of a basis of the "
+                                  "derivatives.")
 
     def plot(self, chart=None, *, derivative=0, **kwargs):
         """Plot the basis object or its derivatives.

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -88,7 +88,6 @@ class Basis(ABC):
         Args:
             eval_points (array_like): List of points where the basis is
                 evaluated.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Matrix whose rows are the values of the each

--- a/skfda/representation/basis/_constant.py
+++ b/skfda/representation/basis/_constant.py
@@ -33,12 +33,9 @@ class Constant(Basis):
     def _evaluate(self, eval_points):
         return np.ones((1, len(eval_points)))
 
-    def _derivative(self, eval_points, order=1):
-        return np.zeros((1, len(eval_points)))
-
     def _derivative_basis_and_coefs(self, coefs, order=1):
-        return (self.copy(), coefs.copy() if order == 0
-                else self.copy(), np.zeros(coefs.shape))
+        return ((self.copy(), coefs.copy()) if order == 0
+                else (self.copy(), np.zeros(coefs.shape)))
 
     def _gram_matrix(self):
         return np.array([[self.domain_range[0][1] -

--- a/skfda/representation/basis/_constant.py
+++ b/skfda/representation/basis/_constant.py
@@ -30,11 +30,13 @@ class Constant(Basis):
         """
         super().__init__(domain_range, 1)
 
-    def _evaluate(self, eval_points, derivative=0):
-        return (np.ones((1, len(eval_points))) if derivative == 0
-                else np.zeros((1, len(eval_points))))
+    def _evaluate(self, eval_points):
+        return np.ones((1, len(eval_points)))
 
-    def _derivative(self, coefs, order=1):
+    def _derivative(self, eval_points, order=1):
+        return np.zeros((1, len(eval_points)))
+
+    def _derivative_basis_and_coefs(self, coefs, order=1):
         return (self.copy(), coefs.copy() if order == 0
                 else self.copy(), np.zeros(coefs.shape))
 

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -233,7 +233,7 @@ class FDataBasis(FData):
         """Definition range."""
         return self.basis.domain_range
 
-    def _evaluate(self, eval_points, *, derivative=0):
+    def _evaluate(self, eval_points):
         """"Evaluate the object or its derivatives at a list of values.
 
         Args:
@@ -241,7 +241,6 @@ class FDataBasis(FData):
                 evaluated. If a matrix of shape `n_samples` x eval_points is
                 given each sample is evaluated at the values in the
                 corresponding row.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
 
         Returns:
@@ -253,13 +252,13 @@ class FDataBasis(FData):
         eval_points = eval_points[:, 0]
 
         # each row contains the values of one element of the basis
-        basis_values = self.basis.evaluate(eval_points, derivative)
+        basis_values = self.basis.evaluate(eval_points)
 
         res = np.tensordot(self.coefficients, basis_values, axes=(1, 0))
 
         return res.reshape((self.n_samples, len(eval_points), 1))
 
-    def _evaluate_composed(self, eval_points, *, derivative=0):
+    def _evaluate_composed(self, eval_points):
         r"""Evaluate the object or its derivatives at a list of values with a
         different time for each sample.
 
@@ -272,7 +271,6 @@ class FDataBasis(FData):
 
         Args:
             eval_points (numpy.ndarray): Matrix of size `n_samples`x n_points
-            derivative (int, optional): Order of the derivative. Defaults to 0.
             extrapolation (str or Extrapolation, optional): Controls the
                 extrapolation mode for elements outside the domain range.
                 By default uses the method defined in fd. See extrapolation to
@@ -290,7 +288,7 @@ class FDataBasis(FData):
         _matrix = np.empty((eval_points.shape[1], self.n_basis))
 
         for i in range(self.n_samples):
-            basis_values = self.basis.evaluate(eval_points[i], derivative).T
+            basis_values = self.basis.evaluate(eval_points[i]).T
 
             np.multiply(basis_values, self.coefficients[i], out=_matrix)
             np.sum(_matrix, axis=1, out=res_matrix[i])

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -376,7 +376,7 @@ class FDataBasis(FData):
         return FDataBasis.from_data(_data_matrix, eval_points,
                                     _basis, **kwargs)
 
-    def derivative(self, eval_points=None, *, order=1):
+    def derivative(self, *, order=1):
         r"""Differentiate a FDataBasis object.
 
 
@@ -387,18 +387,13 @@ class FDataBasis(FData):
         if order < 0:
             raise ValueError("order only takes non-negative integer values.")
 
-        if eval_points is not None:
-            return np.sum(
-                self.basis.derivative(eval_points, order=order), axis=0)
+        if order == 0:
+            return self.copy()
 
-        else:
-            if order == 0:
-                return self.copy()
+        basis, coefficients = self.basis._derivative_basis_and_coefs(
+            self.coefficients, order)
 
-            basis, coefficients = self.basis._derivative_basis_and_coefs(
-                self.coefficients, order)
-
-            return FDataBasis(basis, coefficients)
+        return FDataBasis(basis, coefficients)
 
     def mean(self, weights=None):
         """Compute the mean of all the samples in a FDataBasis object.

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -376,7 +376,7 @@ class FDataBasis(FData):
         return FDataBasis.from_data(_data_matrix, eval_points,
                                     _basis, **kwargs)
 
-    def derivative(self, order=1):
+    def derivative(self, eval_points=None, *, order=1):
         r"""Differentiate a FDataBasis object.
 
 
@@ -387,12 +387,18 @@ class FDataBasis(FData):
         if order < 0:
             raise ValueError("order only takes non-negative integer values.")
 
-        if order == 0:
-            return self.copy()
+        if eval_points is not None:
+            return np.sum(
+                self.basis.derivative(eval_points, order=order), axis=0)
 
-        basis, coefficients = self.basis._derivative(self.coefficients, order)
+        else:
+            if order == 0:
+                return self.copy()
 
-        return FDataBasis(basis, coefficients)
+            basis, coefficients = self.basis._derivative_basis_and_coefs(
+                self.coefficients, order)
+
+            return FDataBasis(basis, coefficients)
 
     def mean(self, weights=None):
         """Compute the mean of all the samples in a FDataBasis object.

--- a/skfda/representation/basis/_fourier.py
+++ b/skfda/representation/basis/_fourier.py
@@ -113,23 +113,14 @@ class Fourier(Basis):
 
         return deriv_functions, amplitude_coefs_pairs, phase_coef_pairs
 
-    def _evaluate(self, eval_points, derivative=0):
-        """Compute the basis or its derivatives given a list of values.
+    def _evaluate(self, eval_points):
+        # The derivative method already works for 0 order.
+        return self._derivative(eval_points, 0)
 
-        Args:
-            eval_points (array_like): List of points where the basis is
-                evaluated.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
-
-        Returns:
-            (:obj:`numpy.darray`): Matrix whose rows are the values of the each
-            basis function or its derivatives at the values specified in
-            eval_points.
-
-        """
+    def _derivative(self, eval_points, order=1):
         (functions,
          amplitude_coefs,
-         phase_coefs) = self._functions_pairs_coefs_derivatives(derivative)
+         phase_coefs) = self._functions_pairs_coefs_derivatives(order)
 
         normalization_denominator = np.sqrt(self.period / 2)
 
@@ -146,7 +137,7 @@ class Fourier(Basis):
         res /= normalization_denominator
 
         # Add constant basis
-        if derivative == 0:
+        if order == 0:
             constant_basis = np.full(
                 shape=(1, len(eval_points)),
                 fill_value=1 / (np.sqrt(2) * normalization_denominator))
@@ -157,7 +148,7 @@ class Fourier(Basis):
 
         return res
 
-    def _derivative(self, coefs, order=1):
+    def _derivative_basis_and_coefs(self, coefs, order=1):
 
         omega = 2 * np.pi / self.period
         deriv_factor = (np.arange(1, (self.n_basis + 1) / 2) * omega) ** order

--- a/skfda/representation/basis/_monomial.py
+++ b/skfda/representation/basis/_monomial.py
@@ -46,7 +46,7 @@ class Monomial(Basis):
 
     """
 
-    def _coefs_exps_derivatives(self, derivative):
+    def _coefs_exps_derivatives(self, order):
         """
         Return coefficients and exponents of the derivatives.
 
@@ -56,23 +56,24 @@ class Monomial(Basis):
         is zero) returns 0 as the exponent (to prevent division by zero).
         """
         seq = np.arange(self.n_basis)
-        coef_mat = np.linspace(seq, seq - derivative + 1,
-                               derivative, dtype=int)
+        coef_mat = np.linspace(seq, seq - order + 1,
+                               order, dtype=int)
         coefs = np.prod(coef_mat, axis=0)
 
-        exps = np.maximum(seq - derivative, 0)
+        exps = np.maximum(seq - order, 0)
 
         return coefs, exps
 
-    def _evaluate(self, eval_points, derivative=0):
+    def _evaluate(self, eval_points):
+        # The derivative method already works for 0 order.
+        return self._derivative(eval_points, 0)
 
-        coefs, exps = self._coefs_exps_derivatives(derivative)
-
+    def _derivative(self, eval_points, order=1):
+        coefs, exps = self._coefs_exps_derivatives(order)
         raised = np.power.outer(eval_points, exps)
-
         return (coefs * raised).T
 
-    def _derivative(self, coefs, order=1):
+    def _derivative_basis_and_coefs(self, coefs, order=1):
         return (Monomial(self.domain_range, self.n_basis - order),
                 np.array([np.polyder(x[::-1], order)[::-1]
                           for x in coefs]))

--- a/skfda/representation/basis/_monomial.py
+++ b/skfda/representation/basis/_monomial.py
@@ -28,55 +28,40 @@ class Monomial(Basis):
         And evaluates all the functions in the basis in a list of descrete
         values.
 
-        >>> bs_mon.evaluate([0, 1, 2])
-        array([[1, 1, 1],
-               [0, 1, 2],
-               [0, 1, 4]])
+        >>> bs_mon([0., 1., 2.])
+        array([[ 1., 1., 1.],
+               [ 0., 1., 2.],
+               [ 0., 1., 4.]])
 
         And also evaluates its derivatives
 
-        >>> bs_mon.evaluate([0, 1, 2], derivative=1)
-        array([[0, 0, 0],
-               [1, 1, 1],
-               [0, 2, 4]])
-        >>> bs_mon.evaluate([0, 1, 2], derivative=2)
-        array([[0, 0, 0],
-               [0, 0, 0],
-               [2, 2, 2]])
+        >>> deriv = bs_mon.derivative()
+        >>> deriv([0, 1, 2])
+        array([[ 0., 0., 0.],
+               [ 1., 1., 1.],
+               [ 0., 2., 4.]])
+        >>> deriv2 = bs_mon.derivative(order=2)
+        >>> deriv2([0, 1, 2])
+        array([[ 0., 0., 0.],
+               [ 0., 0., 0.],
+               [ 2., 2., 2.]])
 
     """
 
-    def _coefs_exps_derivatives(self, order):
-        """
-        Return coefficients and exponents of the derivatives.
-
-        This function is used for computing the basis functions and evaluate.
-
-        When the exponent would be negative (the coefficient in that case
-        is zero) returns 0 as the exponent (to prevent division by zero).
-        """
-        seq = np.arange(self.n_basis)
-        coef_mat = np.linspace(seq, seq - order + 1,
-                               order, dtype=int)
-        coefs = np.prod(coef_mat, axis=0)
-
-        exps = np.maximum(seq - order, 0)
-
-        return coefs, exps
-
     def _evaluate(self, eval_points):
-        # The derivative method already works for 0 order.
-        return self._derivative(eval_points, 0)
-
-    def _derivative(self, eval_points, order=1):
-        coefs, exps = self._coefs_exps_derivatives(order)
+        exps = np.arange(self.n_basis)
         raised = np.power.outer(eval_points, exps)
-        return (coefs * raised).T
+
+        return raised.T
 
     def _derivative_basis_and_coefs(self, coefs, order=1):
-        return (Monomial(self.domain_range, self.n_basis - order),
-                np.array([np.polyder(x[::-1], order)[::-1]
-                          for x in coefs]))
+        if order >= self.n_basis:
+            return (Monomial(self.domain_range, 1),
+                    np.zeros((len(coefs), 1)))
+        else:
+            return (Monomial(self.domain_range, self.n_basis - order),
+                    np.array([np.polyder(x[::-1], order)[::-1]
+                              for x in coefs]))
 
     def _gram_matrix(self):
         integral_coefs = np.polyint(np.ones(2 * self.n_basis - 1))

--- a/skfda/representation/evaluator.py
+++ b/skfda/representation/evaluator.py
@@ -20,7 +20,7 @@ class Evaluator(ABC):
 
     """
     @abstractmethod
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         """Evaluation method.
 
         Evaluates the samples at the same evaluation points. The evaluation
@@ -32,7 +32,6 @@ class Evaluator(ABC):
             eval_points (numpy.ndarray): Numpy array with shape
                 ``(number_eval_points, dim_domain)`` with the
                 evaluation points.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape
@@ -45,7 +44,7 @@ class Evaluator(ABC):
         pass
 
     @abstractmethod
-    def evaluate_composed(self, fdata, eval_points, *, derivative=0):
+    def evaluate_composed(self, fdata, eval_points):
         """Evaluation method.
 
         Evaluates the samples at different evaluation points. The evaluation
@@ -57,7 +56,6 @@ class Evaluator(ABC):
             eval_points (numpy.ndarray): Numpy array with shape
                 ``(n_samples, number_eval_points, dim_domain)`` with the
                 evaluation points for each sample.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape
@@ -94,7 +92,7 @@ class GenericEvaluator(Evaluator):
         else:
             self.evaluate_composed_func = evaluate_composed_func
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         """Evaluation method.
 
         Evaluates the samples at the same evaluation points. The evaluation
@@ -107,7 +105,6 @@ class GenericEvaluator(Evaluator):
             eval_points (numpy.ndarray): Numpy array with shape
                 `(len(eval_points), dim_domain)` with the evaluation points.
                 Each entry represents the coordinate of a point.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3-d array with shape `(n_samples,
@@ -117,10 +114,9 @@ class GenericEvaluator(Evaluator):
                 point.
 
         """
-        return self.evaluate_func(fdata, eval_points,
-                                  derivative=derivative)
+        return self.evaluate_func(fdata, eval_points)
 
-    def evaluate_composed(self, fdata, eval_points, *, derivative=0):
+    def evaluate_composed(self, fdata, eval_points):
         """Evaluation method.
 
         Evaluates the samples at different evaluation points. The evaluation
@@ -134,7 +130,6 @@ class GenericEvaluator(Evaluator):
             eval_points (numpy.ndarray): Numpy array with shape
                 `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape `(n_samples,
@@ -143,5 +138,4 @@ class GenericEvaluator(Evaluator):
                 dimension of the i-th sample, at the j-th evaluation point.
 
         """
-        return self.evaluate_composed_func(fdata, eval_points,
-                                           derivative=derivative)
+        return self.evaluate_composed_func(fdata, eval_points)

--- a/skfda/representation/extrapolation.py
+++ b/skfda/representation/extrapolation.py
@@ -34,7 +34,7 @@ class PeriodicExtrapolation(Evaluator):
                [-1.086,  0.759, -1.086]])
     """
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         """Evaluate points outside the domain range.
 
         Args:
@@ -43,7 +43,6 @@ class PeriodicExtrapolation(Evaluator):
                 points outside the domain range. The shape of the array may be
                 `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
                 x `dim_codomain`.
-            derivate (numeric, optional): Order of derivative to be evaluated.
 
         Returns:
             (numpy.ndarray): numpy array with the evaluation of the points in
@@ -58,9 +57,9 @@ class PeriodicExtrapolation(Evaluator):
         eval_points += domain_range[:, 0]
 
         if eval_points.ndim == 3:
-            res = fdata._evaluate_composed(eval_points, derivative=derivative)
+            res = fdata._evaluate_composed(eval_points)
         else:
-            res = fdata._evaluate(eval_points, derivative=derivative)
+            res = fdata._evaluate(eval_points)
 
         return res
 
@@ -93,7 +92,7 @@ class BoundaryExtrapolation(Evaluator):
                [ 0.759,  0.759,  1.125]])
     """
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         """Evaluate points outside the domain range.
 
         Args:
@@ -102,7 +101,6 @@ class BoundaryExtrapolation(Evaluator):
                 points outside the domain range. The shape of the array may be
                 `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
                 x `dim_codomain`.
-            derivate (numeric, optional): Order of derivative to be evaluated.
 
         Returns:
             (numpy.ndarray): numpy array with the evaluation of the points in
@@ -118,10 +116,10 @@ class BoundaryExtrapolation(Evaluator):
 
         if eval_points.ndim == 3:
 
-            res = fdata._evaluate_composed(eval_points, derivative=derivative)
+            res = fdata._evaluate_composed(eval_points)
         else:
 
-            res = fdata._evaluate(eval_points, derivative=derivative)
+            res = fdata._evaluate(eval_points)
 
         return res
 
@@ -159,7 +157,7 @@ class ExceptionExtrapolation(Evaluator):
 
     """
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         """Evaluate points outside the domain range.
 
         Args:
@@ -168,7 +166,6 @@ class ExceptionExtrapolation(Evaluator):
                 points outside the domain range. The shape of the array may be
                 `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
                 x `dim_codomain`.
-            derivate (numeric, optional): Order of derivative to be evaluated.
 
         Raises:
             ValueError: when the extrapolation method is called.
@@ -216,7 +213,7 @@ class FillExtrapolation(Evaluator):
                  fdata.dim_codomain)
         return np.full(shape, self.fill_value)
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         """
         Evaluate points outside the domain range.
 
@@ -226,7 +223,6 @@ class FillExtrapolation(Evaluator):
                 points outside the domain range. The shape of the array may be
                 `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
                 x `dim_codomain`.
-            derivate (numeric, optional): Order of derivative to be evaluated.
 
         Returns:
             (numpy.ndarray): numpy array with the evaluation of the points in
@@ -235,7 +231,7 @@ class FillExtrapolation(Evaluator):
         """
         return self._fill(fdata, eval_points)
 
-    def evaluate_composed(self, fdata, eval_points, *, derivative=0):
+    def evaluate_composed(self, fdata, eval_points):
         """Evaluation method.
 
         Evaluates the samples at different evaluation points. The evaluation
@@ -249,7 +245,6 @@ class FillExtrapolation(Evaluator):
             eval_points (numpy.ndarray): Numpy array with shape
                 `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape `(n_samples,

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -434,20 +434,13 @@ class FDataGrid(FData):
                 ...)
 
         """
-        if self.dim_domain != 1:
-            raise NotImplementedError(
-                "This method only works when the dimension "
-                "of the domain of the FDatagrid object is "
-                "one.")
-        if order < 0:
-            raise ValueError("The order of a derivative has to be greater "
-                             "or equal than 0.")
+        order_list = np.atleast_1d(order)
+        if order_list.ndim != 1 or len(order_list) != self.dim_domain:
+            raise ValueError("The order for each partial should be specified.")
 
-        if np.isnan(self.data_matrix).any():
-            raise ValueError("The FDataGrid object cannot contain nan "
-                             "elements.")
-
-        operator = findiff.FinDiff(1, self.sample_points[0], order)
+        operator = findiff.FinDiff(*[(1 + i, p, o)
+                                     for i, (p, o) in enumerate(
+                                         zip(self.sample_points, order_list))])
         data_matrix = operator(self.data_matrix.astype(float))
 
         if self.dataset_label:

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -360,7 +360,7 @@ class FDataGrid(FData):
 
         self._interpolation = new_interpolation
 
-    def _evaluate(self, eval_points, *, derivative=0):
+    def _evaluate(self, eval_points):
         """"Evaluate the object or its derivatives at a list of values.
 
         Args:
@@ -368,7 +368,6 @@ class FDataGrid(FData):
                 evaluated. If a matrix of shape nsample x eval_points is given
                 each sample is evaluated at the values in the corresponding row
                 in eval_points.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Matrix whose rows are the values of the each
@@ -376,9 +375,9 @@ class FDataGrid(FData):
 
         """
 
-        return self.interpolation.evaluate(self, eval_points, derivative=derivative)
+        return self.interpolation.evaluate(self, eval_points)
 
-    def _evaluate_composed(self, eval_points, *, derivative=0):
+    def _evaluate_composed(self, eval_points):
         """"Evaluate the object or its derivatives at a list of values.
 
         Args:
@@ -386,7 +385,6 @@ class FDataGrid(FData):
                 evaluated. If a matrix of shape nsample x eval_points is given
                 each sample is evaluated at the values in the corresponding row
                 in eval_points.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (numpy.darray): Matrix whose rows are the values of the each
@@ -394,8 +392,7 @@ class FDataGrid(FData):
 
         """
 
-        return self.interpolation.evaluate_composed(self, eval_points,
-                                                    derivative=derivative)
+        return self.interpolation.evaluate_composed(self, eval_points)
 
     def derivative(self, *, order=1):
         r"""Differentiate a FDataGrid object.
@@ -445,9 +442,7 @@ class FDataGrid(FData):
         if order < 0:
             raise ValueError("The order of a derivative has to be greater "
                              "or equal than 0.")
-        if self.dim_domain > 1 or self.dim_codomain > 1:
-            raise NotImplementedError("Not implemented for 2 or more"
-                                      " dimensional data.")
+
         if np.isnan(self.data_matrix).any():
             raise ValueError("The FDataGrid object cannot contain nan "
                              "elements.")

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -407,7 +407,7 @@ class FDataGrid(FData):
         return self._evaluator.evaluate_composed(eval_points,
                                                  derivative=derivative)
 
-    def derivative(self, eval_points=None, *, order=1):
+    def derivative(self, *, order=1):
         r"""Differentiate a FDataGrid object.
 
         It is calculated using central finite differences when possible. In
@@ -474,10 +474,7 @@ class FDataGrid(FData):
         fdatagrid = self.copy(data_matrix=data_matrix,
                               dataset_label=dataset_label)
 
-        if eval_points is None:
-            return fdatagrid
-        else:
-            return fdatagrid(eval_points)
+        return fdatagrid
 
     def __check_same_dimensions(self, other):
         if self.data_matrix.shape[1:-1] != other.data_matrix.shape[1:-1]:

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -407,7 +407,7 @@ class FDataGrid(FData):
         return self._evaluator.evaluate_composed(eval_points,
                                                  derivative=derivative)
 
-    def derivative(self, order=1):
+    def derivative(self, eval_points=None, *, order=1):
         r"""Differentiate a FDataGrid object.
 
         It is calculated using central finite differences when possible. In
@@ -435,7 +435,7 @@ class FDataGrid(FData):
             Second order derivative
 
             >>> fdata = FDataGrid([1,2,4,5,8], range(5))
-            >>> fdata.derivative(2)
+            >>> fdata.derivative(order=2)
             FDataGrid(
                 array([[[ 3.],
                         [ 1.],
@@ -471,8 +471,13 @@ class FDataGrid(FData):
         else:
             dataset_label = None
 
-        return self.copy(data_matrix=data_matrix,
-                         dataset_label=dataset_label)
+        fdatagrid = self.copy(data_matrix=data_matrix,
+                              dataset_label=dataset_label)
+
+        if eval_points is None:
+            return fdatagrid
+        else:
+            return fdatagrid(eval_points)
 
     def __check_same_dimensions(self, other):
         if self.data_matrix.shape[1:-1] != other.data_matrix.shape[1:-1]:

--- a/skfda/representation/interpolation.py
+++ b/skfda/representation/interpolation.py
@@ -396,7 +396,7 @@ class SplineInterpolation(Evaluator):
                 interpolation_order=self.interpolation_order,
                 smoothness_parameter=self.smoothness_parameter)
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points):
         r"""Evaluation method.
 
         Evaluates the samples at different evaluation points. The evaluation
@@ -410,7 +410,6 @@ class SplineInterpolation(Evaluator):
             eval_points (np.ndarray): Numpy array with shape
                 `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (np.darray): Numpy 3d array with shape `(n_samples,
@@ -426,9 +425,9 @@ class SplineInterpolation(Evaluator):
 
         spline_list = self._build_interpolator(fdata)
 
-        return spline_list.evaluate(fdata, eval_points, derivative=derivative)
+        return spline_list.evaluate(fdata, eval_points)
 
-    def evaluate_composed(self, fdata, eval_points, *, derivative=0):
+    def evaluate_composed(self, fdata, eval_points):
         """Evaluation method.
 
         Evaluates the samples at different evaluation points. The evaluation
@@ -442,7 +441,6 @@ class SplineInterpolation(Evaluator):
             eval_points (np.ndarray): Numpy array with shape
                 `(n_samples, number_eval_points, dim_domain)` with the
                  evaluation points for each sample.
-            derivative (int, optional): Order of the derivative. Defaults to 0.
 
         Returns:
             (np.darray): Numpy 3d array with shape `(n_samples,
@@ -457,8 +455,7 @@ class SplineInterpolation(Evaluator):
         """
         spline_list = self._build_interpolator(fdata)
 
-        return spline_list.evaluate_composed(fdata, eval_points,
-                                             derivative=derivative)
+        return spline_list.evaluate_composed(fdata, eval_points)
 
     def __repr__(self):
         """repr method of the interpolation"""

--- a/tests/test_basis_evaluation.py
+++ b/tests/test_basis_evaluation.py
@@ -64,8 +64,9 @@ class TestBasisEvaluationFourier(unittest.TestCase):
                         -4.81336320468984, -1.7123673353027, 6.52573053999253]
                        ).reshape((2, 4)).round(3)
 
+        f_deriv = f.derivative()
         np.testing.assert_array_almost_equal(
-            f(t, derivative=1).round(3), res
+            f_deriv(t).round(3), res
         )
 
     def test_evaluation_grid_fourier(self):
@@ -317,8 +318,9 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
+        f_deriv = f.derivative()
         np.testing.assert_array_almost_equal(
-            f(t, derivative=1).round(3),
+            f_deriv(t).round(3),
             np.array([[2.927,  0.453, -1.229,  0.6],
                       [4.3, -1.599,  1.016, -2.52]])
         )
@@ -570,8 +572,9 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
+        f_deriv = f.derivative()
         np.testing.assert_array_almost_equal(
-            f(t, derivative=1).round(3),
+            f_deriv(t).round(3),
             np.array([[2., 4., 6., 8.],
                       [1.4, 2.267, 3.133, 4.]])
         )

--- a/tests/test_fpca.py
+++ b/tests/test_fpca.py
@@ -61,12 +61,13 @@ class FPCATestCase(unittest.TestCase):
 
         fpca = FPCA(n_components=n_components,
                     regularization=TikhonovRegularization(
-                         LinearDifferentialOperator(2),
-                         regularization_parameter=1e5))
+                        LinearDifferentialOperator(2),
+                        regularization_parameter=1e5))
         fpca.fit(fd_basis)
 
         # results obtained using Ramsay's R package
-        results = [[0.92407552, 0.13544888, 0.35399023, 0.00805966, -0.02148108,
+        results = [[0.92407552, 0.13544888, 0.35399023, 0.00805966,
+                    -0.02148108,
                     -0.01709549, -0.00208469, -0.00297439, -0.00308224],
                    [-0.33314436, -0.05116842, 0.89443418, 0.14673902,
                     0.21559073,
@@ -100,8 +101,8 @@ class FPCATestCase(unittest.TestCase):
 
         fpca = FPCA(n_components=n_components,
                     regularization=TikhonovRegularization(
-                         LinearDifferentialOperator(2),
-                         regularization_parameter=1e5))
+                        LinearDifferentialOperator(2),
+                        regularization_parameter=1e5))
         fpca.fit(fd_basis)
         scores = fpca.transform(fd_basis)
 
@@ -156,7 +157,7 @@ class FPCATestCase(unittest.TestCase):
                             np.arange(0.5, 365, 1))
 
         # initialize basis data
-        basis = Fourier(n_basis=9, domain_range=(0, 365))
+        basis = Fourier(n_basis=n_basis, domain_range=(0, 365))
         fd_basis = fd_data.to_basis(basis)
 
         fpca = FPCA(n_components=n_components)
@@ -318,11 +319,7 @@ class FPCATestCase(unittest.TestCase):
         fpca = FPCA(
             n_components=n_components, weights=[1] * 365,
             regularization=TikhonovRegularization(
-                LinearDifferentialOperator(
-                    2,
-                    derivative_function=(
-                        lambda function, points, derivative:
-                        function.derivative(order=derivative)(points)))))
+                LinearDifferentialOperator(2)))
         fpca.fit(fd_data)
 
         # results obtained using fda.usc for the first component

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -45,16 +45,6 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         np.testing.assert_array_almost_equal(f([3]), np.array([[9.], [36.]]))
         np.testing.assert_array_almost_equal(f((2,)), np.array([[4.], [49.]]))
 
-    def test_evaluation_linear_derivative(self):
-        """Test derivative"""
-        f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10))
-
-        # Derivate = [2*x, 2*(9-x)]
-        np.testing.assert_array_almost_equal(
-            f([0.5, 1.5, 2.5], derivative=1).round(3),
-            np.array([[1.,   3.,   5.],
-                      [-17., -15., -13.]]))
-
     def test_evaluation_linear_grid(self):
         """Test grid evaluation. With domain dimension = 1"""
 
@@ -229,17 +219,6 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             f((2,)).round(3), np.array([[4.], [49.]]))
 
-    def test_evaluation_cubic_derivative(self):
-        """Test derivative"""
-        f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10),
-                      interpolation=SplineInterpolation(3))
-
-        # Derivate = [2*x, 2*(9-x)]
-        np.testing.assert_array_almost_equal(
-            f([0.5, 1.5, 2.5], derivative=1).round(3),
-            np.array([[1.,   3.,   5.],
-                      [-17., -15., -13.]]))
-
     def test_evaluation_cubic_grid(self):
         """Test grid evaluation. With domain dimension = 1"""
 
@@ -363,20 +342,6 @@ class TestEvaluationSpline1_n(unittest.TestCase):
                                                        [[13.69,  0.50697]]]
                                                       )
                                              )
-
-    def test_evaluation_derivative(self):
-        """Test derivative"""
-        f = FDataGrid(self.data_matrix_1_n, sample_points=self.t,
-                      interpolation=self.interpolation)
-
-        # [(2*x, d/dx sin(pi/81*x**2)), (2*(9-x), d/dx sin(pi/81*(9-x)**2))]
-        np.testing.assert_array_almost_equal(f([1.5, 2.5, 3.5], derivative=1),
-                                             np.array([[[3., 0.1162381],
-                                                        [5., 0.1897434],
-                                                        [7., 0.2453124]],
-                                                       [[-15., 0.3385772],
-                                                        [-13., 0.0243172],
-                                                        [-11., -0.1752035]]]))
 
     def test_evaluation_grid(self):
         """Test grid evaluation. With domain dimension = 1"""

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -213,7 +213,7 @@ class TestShiftRegistration(unittest.TestCase):
 
         fd_registered = reg.transform(fd)
         deltas = reg.deltas_.round(3)
-        np.testing.assert_array_almost_equal(deltas, [0.071, -0.071])
+        np.testing.assert_allclose(deltas, [0.071, -0.072])
 
     def test_inverse_transform(self):
 
@@ -331,39 +331,39 @@ class TestRegistrationValidation(unittest.TestCase):
     def test_amplitude_phase_score(self):
         scorer = AmplitudePhaseDecomposition()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.972000160)
+        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
 
     def test_amplitude_phase_score_with_output_points(self):
         eval_points = self.X.sample_points[0]
         scorer = AmplitudePhaseDecomposition(eval_points=eval_points)
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.972000160)
+        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
 
     def test_amplitude_phase_score_with_basis(self):
         scorer = AmplitudePhaseDecomposition()
         X = self.X.to_basis(Fourier())
         score = scorer(self.shift_registration, X)
-        np.testing.assert_almost_equal(score, 0.9950259588)
+        np.testing.assert_allclose(score, 0.995087, rtol=1e-6)
 
     def test_default_score(self):
 
         score = self.shift_registration.score(self.X)
-        np.testing.assert_almost_equal(score, 0.972000160)
+        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
 
     def test_least_squares_score(self):
         scorer = LeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.795742349)
+        np.testing.assert_allclose(score, 0.795933, rtol=1e-6)
 
     def test_sobolev_least_squares_score(self):
         scorer = SobolevLeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 0.7621990)
+        np.testing.assert_allclose(score, 0.76124, rtol=1e-6)
 
     def test_pairwise_correlation(self):
         scorer = PairwiseCorrelation()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_almost_equal(score, 1.816298653)
+        np.testing.assert_allclose(score, 1.816228, rtol=1e-6)
 
     def test_mse_decomposition(self):
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -374,10 +374,10 @@ class TestRegistrationValidation(unittest.TestCase):
         fd_registered = fd.compose(warping)
         scorer = AmplitudePhaseDecomposition(return_stats=True)
         ret = scorer.score_function(fd, fd_registered, warping=warping)
-        np.testing.assert_almost_equal(ret.mse_amp, 0.0009866997121476962)
-        np.testing.assert_almost_equal(ret.mse_pha, 0.11576861468435257)
-        np.testing.assert_almost_equal(ret.r_squared, 0.9915489952877273)
-        np.testing.assert_almost_equal(ret.c_r, 0.9999963424653829)
+        np.testing.assert_allclose(ret.mse_amp, 0.0009866997121476962)
+        np.testing.assert_allclose(ret.mse_pha, 0.11576935495450151)
+        np.testing.assert_allclose(ret.r_squared, 0.9915489952877273)
+        np.testing.assert_allclose(ret.c_r, 0.999999, rtol=1e-6)
 
     def test_raises_amplitude_phase(self):
         scorer = AmplitudePhaseDecomposition()


### PR DESCRIPTION
Derivatives are now separated from evaluation and plotting.

- Now a full object representing the derivative must be constructed and evaluated using `derivative()`.
- Fixed construction of `derivative` for some basis.
- `derivative` now works for higher dimensional `FDataGrid` objects. Order must be a tuple with the order of each partial derivative involved.