### PR TITLE
Simplify evaluation

### DIFF
--- a/skfda/_utils/__init__.py
+++ b/skfda/_utils/__init__.py
@@ -1,6 +1,6 @@
 from . import constants
 
-from ._utils import (_list_of_arrays, _coordinate_list,
+from ._utils import (_list_of_arrays, _cartesian_product,
                      _check_estimator, parameter_aliases,
                      _to_grid, check_is_univariate,
                      _same_domain)

--- a/skfda/_utils/__init__.py
+++ b/skfda/_utils/__init__.py
@@ -3,4 +3,4 @@ from . import constants
 from ._utils import (_list_of_arrays, _cartesian_product,
                      _check_estimator, parameter_aliases,
                      _to_grid, check_is_univariate,
-                     _same_domain)
+                     _same_domain, _to_array_maybe_ragged)

--- a/skfda/_utils/_utils.py
+++ b/skfda/_utils/_utils.py
@@ -81,6 +81,36 @@ def _list_of_arrays(original_array):
         return [np.asarray(i) for i in original_array]
 
 
+def _to_array_maybe_ragged(array, *, row_shape=None):
+    """
+    Convert to an array where each element may or may not be of equal length.
+
+    If each element is of equal length the array is multidimensional.
+    Otherwise it is a ragged array.
+
+    """
+    def convert_row(row):
+        r = np.array(row)
+
+        if row_shape is not None:
+            r = r.reshape(row_shape)
+
+        return r
+
+    array_list = [convert_row(a) for a in array]
+    shapes = [a.shape for a in array_list]
+
+    if all(s == shapes[0] for s in shapes):
+        return np.array(array_list)
+    else:
+        res = np.empty(len(array_list), dtype=np.object_)
+
+        for i, a in enumerate(array_list):
+            res[i] = a
+
+        return res
+
+
 def _cartesian_product(axes, flatten=True, return_shape=False):
     """Computes the cartesian product of the axes.
 

--- a/skfda/_utils/_utils.py
+++ b/skfda/_utils/_utils.py
@@ -81,8 +81,8 @@ def _list_of_arrays(original_array):
         return [np.asarray(i) for i in original_array]
 
 
-def _coordinate_list(axes):
-    """Convert a list with axes in a list with coordinates.
+def _cartesian_product(axes, flatten=True, return_shape=False):
+    """Computes the cartesian product of the axes.
 
     Computes the cartesian product of the axes and returns a numpy array of
     1 dimension with all the possible combinations, for an arbitrary number of
@@ -97,28 +97,38 @@ def _coordinate_list(axes):
 
     Examples:
 
-        >>> from skfda.representation._functional_data import _coordinate_list
+        >>> from skfda.representation._functional_data import _cartesian_product
         >>> axes = [[0,1],[2,3]]
-        >>> _coordinate_list(axes)
+        >>> _cartesian_product(axes)
         array([[0, 2],
                [0, 3],
                [1, 2],
                [1, 3]])
 
         >>> axes = [[0,1],[2,3],[4]]
-        >>> _coordinate_list(axes)
+        >>> _cartesian_product(axes)
         array([[0, 2, 4],
                [0, 3, 4],
                [1, 2, 4],
                [1, 3, 4]])
 
         >>> axes = [[0,1]]
-        >>> _coordinate_list(axes)
+        >>> _cartesian_product(axes)
         array([[0],
                [1]])
 
     """
-    return np.vstack(list(map(np.ravel, np.meshgrid(*axes, indexing='ij')))).T
+    cartesian = np.stack(np.meshgrid(*axes, indexing='ij'), -1)
+
+    shape = cartesian.shape
+
+    if flatten:
+        cartesian = cartesian.reshape(-1, len(axes))
+
+    if return_shape:
+        return cartesian, shape
+    else:
+        return cartesian
 
 
 def _same_domain(fd, fd2):

--- a/skfda/preprocessing/registration/_shift_registration.py
+++ b/skfda/preprocessing/registration/_shift_registration.py
@@ -240,7 +240,7 @@ class ShiftRegistration(RegistrationTransformer):
 
             # Computes the new values shifted
             x = fd(output_points_rep + np.atleast_2d(delta).T,
-                   aligned_evaluation=False,
+                   aligned=False,
                    extrapolation=self.extrapolation)[..., 0]
 
             if template == "mean":

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -372,9 +372,9 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
 
         Args:
             eval_points (array_like): List of points where the functions are
-                evaluated. If `grid` is `True`, a list of axes, one per domain
-                dimension, must be passed instead. If `aligned_evaluation` is
-                `True`, then a list of lists (of points or axes, as explained)
+                evaluated. If ``grid`` is ``True``, a list of axes, one per domain
+                dimension, must be passed instead. If ``aligned_evaluation`` is
+                ``True``, then a list of lists (of points or axes, as explained)
                 must be passed, with one list per sample.
             extrapolation (str or Extrapolation, optional): Controls the
                 extrapolation mode for elements outside the domain range. By
@@ -443,15 +443,6 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 eval_points_extrapolation = eval_points[index_ext]
                 eval_points_evaluation = eval_points[index_ev]
 
-                # Direct evaluation
-                res_evaluation = self._evaluate(
-                    eval_points_evaluation,
-                    aligned_evaluation=aligned_evaluation)
-
-                res_extrapolation = extrapolation.evaluate(
-                    self,
-                    eval_points_extrapolation)
-
             else:
                 index_ext = np.logical_or.reduce(index_matrix, axis=0)
                 eval_points_extrapolation = eval_points[:, index_ext]
@@ -459,14 +450,15 @@ class FData(ABC, pandas.api.extensions.ExtensionArray):
                 index_ev = np.logical_or.reduce(~index_matrix, axis=0)
                 eval_points_evaluation = eval_points[:, index_ev]
 
-                # Direct evaluation
-                res_evaluation = self._evaluate(
-                    eval_points_evaluation,
-                    aligned_evaluation=aligned_evaluation)
+            # Direct evaluation
+            res_evaluation = self._evaluate(
+                eval_points_evaluation,
+                aligned_evaluation=aligned_evaluation)
 
-                res_extrapolation = extrapolation.evaluate_composed(
-                    self,
-                    eval_points_extrapolation)
+            res_extrapolation = extrapolation.evaluate(
+                self,
+                eval_points_extrapolation,
+                aligned=aligned_evaluation)
 
             res = self._join_evaluation(index_matrix, index_ext, index_ev,
                                         res_extrapolation, res_evaluation)

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -470,13 +470,12 @@ class FDataBasis(FData):
             ...                 basis=Monomial((0,5), n_basis=3))
             >>> fd.to_grid([0, 1, 2])
             FDataGrid(
-                array([[[ 1.],
-                        [ 3.],
-                        [ 7.]],
-            <BLANKLINE>
-                       [[ 1.],
-                        [ 2.],
-                        [ 5.]]]),
+                array([[[1],
+                        [3],
+                        [7]],
+                       [[1],
+                        [2],
+                        [5]]]),
                 sample_points=[array([0, 1, 2])],
                 domain_range=array([[0, 5]]),
                 ...)

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -233,12 +233,12 @@ class FDataBasis(FData):
         """Definition range."""
         return self.basis.domain_range
 
-    def _evaluate(self, eval_points,  *, aligned_evaluation=True):
+    def _evaluate(self, eval_points,  *, aligned=True):
 
         #  Only suported 1D objects
         eval_points = eval_points[..., 0]
 
-        if aligned_evaluation:
+        if aligned:
 
             # Each row contains the values of one element of the basis
             basis_values = self.basis.evaluate(eval_points)
@@ -330,7 +330,7 @@ class FDataBasis(FData):
 
         # Matrix of shifted values
         _data_matrix = self(points_shifted,
-                            aligned_evaluation=False,
+                            aligned=False,
                             extrapolation=extrapolation)[..., 0]
 
         _basis = self.basis.rescale(domain)

--- a/skfda/representation/evaluator.py
+++ b/skfda/representation/evaluator.py
@@ -20,42 +20,18 @@ class Evaluator(ABC):
 
     """
     @abstractmethod
-    def evaluate(self, fdata, eval_points):
+    def evaluate(self, fdata, eval_points, *, aligned=True):
         """Evaluation method.
 
-        Evaluates the samples at the same evaluation points. The evaluation
-        call will receive a 2-d array with the evaluation points.
-        This method is called internally by :meth:`evaluate` when the
-        argument ``aligned_evaluation`` is True.
+        Evaluates the samples at evaluation points. The evaluation
+        call will receive a 2-d array with the evaluation points, or
+        a 3-d array with the evaluation points per sample if ``aligned``
+        is ``False``.
 
         Args:
             eval_points (numpy.ndarray): Numpy array with shape
                 ``(number_eval_points, dim_domain)`` with the
                 evaluation points.
-
-        Returns:
-            (numpy.darray): Numpy 3d array with shape
-                ``(n_samples, number_eval_points, dim_codomain)`` with the
-                result of the evaluation. The entry ``(i,j,k)`` will contain
-                the value k-th image dimension of the i-th sample, at the
-                j-th evaluation point.
-
-        """
-        pass
-
-    @abstractmethod
-    def evaluate_composed(self, fdata, eval_points):
-        """Evaluation method.
-
-        Evaluates the samples at different evaluation points. The evaluation
-        call will receive a 3-d array with the evaluation points for each
-        sample. This method is called internally by :func:`evaluate` when
-        the argument ``aligned_evaluation`` is False.
-
-        Args:
-            eval_points (numpy.ndarray): Numpy array with shape
-                ``(n_samples, number_eval_points, dim_domain)`` with the
-                evaluation points for each sample.
 
         Returns:
             (numpy.darray): Numpy 3d array with shape
@@ -78,64 +54,14 @@ class Evaluator(ABC):
 class GenericEvaluator(Evaluator):
     """Generic Evaluator.
 
-    Generic evaluator that recibes two functions to construct the evaluator.
-    The functions will recieve an :class:`FData` as first argument, a numpy
-    array with the eval_points and a named argument derivative.
+    Generic evaluator that recibes a functions to construct the evaluator.
+    The function will recieve an :class:`FData` as first argument, a numpy
+    array with the eval_points and the ``aligned`` parameter.
 
     """
 
-    def __init__(self, evaluate_func, evaluate_composed_func=None):
-        self.evaluate_func = evaluate_func
+    def __init__(self, evaluate_function):
+        self.evaluate_function = evaluate_function
 
-        if evaluate_composed_func is None:
-            self.evaluate_composed_func = evaluate_func
-        else:
-            self.evaluate_composed_func = evaluate_composed_func
-
-    def evaluate(self, fdata, eval_points):
-        """Evaluation method.
-
-        Evaluates the samples at the same evaluation points. The evaluation
-        call will receive a 2-d array with the evaluation points.
-
-        This method is called internally by :meth:`evaluate` when the argument
-        `aligned_evaluation` is True.
-
-        Args:
-            eval_points (numpy.ndarray): Numpy array with shape
-                `(len(eval_points), dim_domain)` with the evaluation points.
-                Each entry represents the coordinate of a point.
-
-        Returns:
-            (numpy.darray): Numpy 3-d array with shape `(n_samples,
-                len(eval_points), dim_codomain)` with the result of the
-                evaluation. The entry (i,j,k) will contain the value k-th
-                image dimension of the i-th sample, at the j-th evaluation
-                point.
-
-        """
-        return self.evaluate_func(fdata, eval_points)
-
-    def evaluate_composed(self, fdata, eval_points):
-        """Evaluation method.
-
-        Evaluates the samples at different evaluation points. The evaluation
-        call will receive a 3-d array with the evaluation points for each
-        sample.
-
-        This method is called internally by :meth:`evaluate` when the argument
-        `aligned_evaluation` is False.
-
-        Args:
-            eval_points (numpy.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, dim_domain)` with the
-                 evaluation points for each sample.
-
-        Returns:
-            (numpy.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, dim_codomain)` with the result of the
-                evaluation. The entry (i,j,k) will contain the value k-th image
-                dimension of the i-th sample, at the j-th evaluation point.
-
-        """
-        return self.evaluate_composed_func(fdata, eval_points)
+    def evaluate(self, fdata, eval_points, *, aligned=True):
+        return self.evaluate_function(fdata, eval_points, aligned=aligned)

--- a/skfda/representation/extrapolation.py
+++ b/skfda/representation/extrapolation.py
@@ -65,9 +65,9 @@ class PeriodicExtrapolation(Evaluator):
         eval_points += domain_range[:, 0]
 
         if eval_points.ndim == 3:
-            res = fdata._evaluate_composed(eval_points)
+            res = fdata(eval_points, aligned_evaluation=False)
         else:
-            res = fdata._evaluate(eval_points)
+            res = fdata(eval_points)
 
         return res
 
@@ -132,10 +132,10 @@ class BoundaryExtrapolation(Evaluator):
 
         if eval_points.ndim == 3:
 
-            res = fdata._evaluate_composed(eval_points)
+            res = fdata(eval_points, aligned_evaluation=False)
         else:
 
-            res = fdata._evaluate(eval_points)
+            res = fdata(eval_points)
 
         return res
 

--- a/skfda/representation/extrapolation.py
+++ b/skfda/representation/extrapolation.py
@@ -51,7 +51,7 @@ class PeriodicExtrapolation(Evaluator):
         eval_points %= domain_range[:, 1] - domain_range[:, 0]
         eval_points += domain_range[:, 0]
 
-        res = fdata(eval_points, aligned_evaluation=aligned)
+        res = fdata(eval_points, aligned=aligned)
 
         return res
 
@@ -98,7 +98,7 @@ class BoundaryExtrapolation(Evaluator):
             eval_points[eval_points[..., i] < a, i] = a
             eval_points[eval_points[..., i] > b, i] = b
 
-        res = fdata(eval_points, aligned_evaluation=aligned)
+        res = fdata(eval_points, aligned=aligned)
 
         return res
 

--- a/skfda/representation/extrapolation.py
+++ b/skfda/representation/extrapolation.py
@@ -42,20 +42,7 @@ class PeriodicExtrapolation(Evaluator):
                 [-1.086]]])
     """
 
-    def evaluate(self, fdata, eval_points):
-        """Evaluate points outside the domain range.
-
-        Args:
-            fdata (:class:´FData´): Object where the evaluation is taken place.
-            eval_points (:class: numpy.ndarray): Numpy array with the evalation
-                points outside the domain range. The shape of the array may be
-                `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
-                x `dim_codomain`.
-
-        Returns:
-            (numpy.ndarray): numpy array with the evaluation of the points in
-            a matrix with shape `n_samples` x `n_eval_points`x `dim_codomain`.
-        """
+    def evaluate(self, fdata, eval_points, *, aligned=True):
 
         domain_range = np.asarray(fdata.domain_range)
 
@@ -64,15 +51,9 @@ class PeriodicExtrapolation(Evaluator):
         eval_points %= domain_range[:, 1] - domain_range[:, 0]
         eval_points += domain_range[:, 0]
 
-        if eval_points.ndim == 3:
-            res = fdata(eval_points, aligned_evaluation=False)
-        else:
-            res = fdata(eval_points)
+        res = fdata(eval_points, aligned_evaluation=aligned)
 
         return res
-
-    def evaluate_composed(self, *args, **kwargs):
-        return self.evaluate(*args, **kwargs)
 
 
 class BoundaryExtrapolation(Evaluator):
@@ -108,20 +89,7 @@ class BoundaryExtrapolation(Evaluator):
                 [ 1.125]]])
     """
 
-    def evaluate(self, fdata, eval_points):
-        """Evaluate points outside the domain range.
-
-        Args:
-            fdata (:class:´FData´): Object where the evaluation is taken place.
-            eval_points (:class: numpy.ndarray): Numpy array with the evalation
-                points outside the domain range. The shape of the array may be
-                `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
-                x `dim_codomain`.
-
-        Returns:
-            (numpy.ndarray): numpy array with the evaluation of the points in
-            a matrix with shape `n_samples` x `n_eval_points`x `dim_codomain`.
-        """
+    def evaluate(self, fdata, eval_points, *, aligned=True):
 
         domain_range = fdata.domain_range
 
@@ -130,17 +98,9 @@ class BoundaryExtrapolation(Evaluator):
             eval_points[eval_points[..., i] < a, i] = a
             eval_points[eval_points[..., i] > b, i] = b
 
-        if eval_points.ndim == 3:
-
-            res = fdata(eval_points, aligned_evaluation=False)
-        else:
-
-            res = fdata(eval_points)
+        res = fdata(eval_points, aligned_evaluation=aligned)
 
         return res
-
-    def evaluate_composed(self, *args, **kwargs):
-        return self.evaluate(*args, **kwargs)
 
 
 class ExceptionExtrapolation(Evaluator):
@@ -173,27 +133,12 @@ class ExceptionExtrapolation(Evaluator):
 
     """
 
-    def evaluate(self, fdata, eval_points):
-        """Evaluate points outside the domain range.
-
-        Args:
-            fdata (:class:´FData´): Object where the evaluation is taken place.
-            eval_points (:class: numpy.ndarray): Numpy array with the evalation
-                points outside the domain range. The shape of the array may be
-                `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
-                x `dim_codomain`.
-
-        Raises:
-            ValueError: when the extrapolation method is called.
-        """
+    def evaluate(self, fdata, eval_points, *, aligned=True):
 
         n_points = eval_points.shape[-2]
 
         raise ValueError(f"Attempt to evaluate {n_points} points outside the "
                          f"domain range.")
-
-    def evaluate_composed(self, *args, **kwargs):
-        return self.evaluate(*args, **kwargs)
 
 
 class FillExtrapolation(Evaluator):
@@ -237,46 +182,8 @@ class FillExtrapolation(Evaluator):
                  fdata.dim_codomain)
         return np.full(shape, self.fill_value)
 
-    def evaluate(self, fdata, eval_points):
-        """
-        Evaluate points outside the domain range.
+    def evaluate(self, fdata, eval_points, *, aligned=True):
 
-        Args:
-            fdata (:class:´FData´): Object where the evaluation is taken place.
-            eval_points (:class: numpy.ndarray): Numpy array with the evalation
-                points outside the domain range. The shape of the array may be
-                `n_eval_points` x `dim_codomain` or `n_samples` x `n_eval_points`
-                x `dim_codomain`.
-
-        Returns:
-            (numpy.ndarray): numpy array with the evaluation of the points in
-            a matrix with shape `n_samples` x `n_eval_points`x `dim_codomain`.
-
-        """
-        return self._fill(fdata, eval_points)
-
-    def evaluate_composed(self, fdata, eval_points):
-        """Evaluation method.
-
-        Evaluates the samples at different evaluation points. The evaluation
-        call will receive a 3-d array with the evaluation points for
-        each sample.
-
-        This method is called internally by :meth:`evaluate` when the argument
-        `aligned_evaluation` is False.
-
-        Args:
-            eval_points (numpy.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, dim_domain)` with the
-                 evaluation points for each sample.
-
-        Returns:
-            (numpy.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, dim_codomain)` with the result of the
-                evaluation. The entry (i,j,k) will contain the value k-th image
-                dimension of the i-th sample, at the j-th evaluation point.
-
-        """
         return self._fill(fdata, eval_points)
 
     def __repr__(self):

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -359,39 +359,12 @@ class FDataGrid(FData):
 
         self._interpolation = new_interpolation
 
-    def _evaluate(self, eval_points):
-        """"Evaluate the object or its derivatives at a list of values.
+    def _evaluate(self, eval_points, *, aligned_evaluation=True):
 
-        Args:
-            eval_points (array_like): List of points where the functions are
-                evaluated. If a matrix of shape nsample x eval_points is given
-                each sample is evaluated at the values in the corresponding row
-                in eval_points.
-
-        Returns:
-            (numpy.darray): Matrix whose rows are the values of the each
-            function at the values specified in eval_points.
-
-        """
-
-        return self.interpolation.evaluate(self, eval_points)
-
-    def _evaluate_composed(self, eval_points):
-        """"Evaluate the object or its derivatives at a list of values.
-
-        Args:
-            eval_points (array_like): List of points where the functions are
-                evaluated. If a matrix of shape nsample x eval_points is given
-                each sample is evaluated at the values in the corresponding row
-                in eval_points.
-
-        Returns:
-            (numpy.darray): Matrix whose rows are the values of the each
-            function at the values specified in eval_points.
-
-        """
-
-        return self.interpolation.evaluate_composed(self, eval_points)
+        if aligned_evaluation:
+            return self.interpolation.evaluate(self, eval_points)
+        else:
+            return self.interpolation.evaluate_composed(self, eval_points)
 
     def derivative(self, *, order=1):
         r"""Differentiate a FDataGrid object.

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -359,10 +359,10 @@ class FDataGrid(FData):
 
         self._interpolation = new_interpolation
 
-    def _evaluate(self, eval_points, *, aligned_evaluation=True):
+    def _evaluate(self, eval_points, *, aligned=True):
 
         return self.interpolation.evaluate(self, eval_points,
-                                           aligned=aligned_evaluation)
+                                           aligned=aligned)
 
     def derivative(self, *, order=1):
         r"""Differentiate a FDataGrid object.
@@ -935,7 +935,7 @@ class FDataGrid(FData):
 
         data_matrix = self.evaluate(eval_points_shifted,
                                     extrapolation=extrapolation,
-                                    aligned_evaluation=False,
+                                    aligned=False,
                                     grid=True)
 
         return self.copy(data_matrix=data_matrix, sample_points=eval_points,
@@ -972,7 +972,7 @@ class FDataGrid(FData):
 
             eval_points_transformation = fd(eval_points)
             data_matrix = self(eval_points_transformation,
-                               aligned_evaluation=False)
+                               aligned=False)
         else:
             if eval_points is None:
                 eval_points = fd.sample_points
@@ -991,7 +991,7 @@ class FDataGrid(FData):
                 ).T
 
             data_matrix = self(eval_points_transformation,
-                               aligned_evaluation=False)
+                               aligned=False)
 
         return self.copy(data_matrix=data_matrix,
                          sample_points=eval_points,

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -361,10 +361,8 @@ class FDataGrid(FData):
 
     def _evaluate(self, eval_points, *, aligned_evaluation=True):
 
-        if aligned_evaluation:
-            return self.interpolation.evaluate(self, eval_points)
-        else:
-            return self.interpolation.evaluate_composed(self, eval_points)
+        return self.interpolation.evaluate(self, eval_points,
+                                           aligned=aligned_evaluation)
 
     def derivative(self, *, order=1):
         r"""Differentiate a FDataGrid object.

--- a/skfda/representation/interpolation.py
+++ b/skfda/representation/interpolation.py
@@ -36,25 +36,23 @@ class _SplineList(abc.ABC):
         return np.array([self._evaluate_one(spl, t, derivative)
                          for spl in spl_m]).T
 
-    def evaluate(self, fdata, eval_points, *, derivative=0):
+    def evaluate(self, fdata, eval_points, *, derivative=0, aligned=True):
 
-        # Points evaluated inside the domain
-        res = np.apply_along_axis(
-            self._evaluate_codomain, 1,
-            self.splines, eval_points, derivative)
-        res = res.reshape(fdata.n_samples, eval_points.shape[0],
-                          fdata.dim_codomain)
+        if aligned:
+            # Points evaluated inside the domain
+            res = np.apply_along_axis(
+                self._evaluate_codomain, 1,
+                self.splines, eval_points, derivative)
+            res = res.reshape(fdata.n_samples, eval_points.shape[0],
+                              fdata.dim_codomain)
 
-        return res
+        else:
+            shape = (fdata.n_samples, eval_points.shape[1], fdata.dim_codomain)
+            res = np.empty(shape)
 
-    def evaluate_composed(self, fdata, eval_points, *, derivative=0):
-
-        shape = (fdata.n_samples, eval_points.shape[1], fdata.dim_codomain)
-        res = np.empty(shape)
-
-        for i in range(fdata.n_samples):
-            res[i] = self._evaluate_codomain(
-                self.splines[i], eval_points[i], derivative=derivative)
+            for i in range(fdata.n_samples):
+                res[i] = self._evaluate_codomain(
+                    self.splines[i], eval_points[i], derivative=derivative)
 
         return res
 
@@ -396,66 +394,11 @@ class SplineInterpolation(Evaluator):
                 interpolation_order=self.interpolation_order,
                 smoothness_parameter=self.smoothness_parameter)
 
-    def evaluate(self, fdata, eval_points):
-        r"""Evaluation method.
-
-        Evaluates the samples at different evaluation points. The evaluation
-        call will receive a 3-d array with the evaluation points for
-        each sample.
-
-        This method is called internally by :meth:`evaluate` when the argument
-        `aligned_evaluation` is False.
-
-        Args:
-            eval_points (np.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, dim_domain)` with the
-                 evaluation points for each sample.
-
-        Returns:
-            (np.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, dim_codomain)` with the result of the
-                evaluation. The entry (i,j,k) will contain the value k-th image
-                dimension of the i-th sample, at the j-th evaluation point.
-
-        Raises:
-            ValueError: In case of an incorrect value of the derivative
-                argument.
-
-        """
+    def evaluate(self, fdata, eval_points, *, aligned=True):
 
         spline_list = self._build_interpolator(fdata)
 
-        return spline_list.evaluate(fdata, eval_points)
-
-    def evaluate_composed(self, fdata, eval_points):
-        """Evaluation method.
-
-        Evaluates the samples at different evaluation points. The evaluation
-        call will receive a 3-d array with the evaluation points for
-        each sample.
-
-        This method is called internally by :meth:`evaluate` when the argument
-        `aligned_evaluation` is False.
-
-        Args:
-            eval_points (np.ndarray): Numpy array with shape
-                `(n_samples, number_eval_points, dim_domain)` with the
-                 evaluation points for each sample.
-
-        Returns:
-            (np.darray): Numpy 3d array with shape `(n_samples,
-                number_eval_points, dim_codomain)` with the result of the
-                evaluation. The entry (i,j,k) will contain the value k-th image
-                dimension of the i-th sample, at the j-th evaluation point.
-
-        Raises:
-            ValueError: In case of an incorrect value of the derivative
-                argument.
-
-        """
-        spline_list = self._build_interpolator(fdata)
-
-        return spline_list.evaluate_composed(fdata, eval_points)
+        return spline_list.evaluate(fdata, eval_points, aligned=aligned)
 
     def __repr__(self):
         """repr method of the interpolation"""

--- a/skfda/representation/interpolation.py
+++ b/skfda/representation/interpolation.py
@@ -47,12 +47,9 @@ class _SplineList(abc.ABC):
                               fdata.dim_codomain)
 
         else:
-            shape = (fdata.n_samples, eval_points.shape[1], fdata.dim_codomain)
-            res = np.empty(shape)
-
-            for i in range(fdata.n_samples):
-                res[i] = self._evaluate_codomain(
-                    self.splines[i], eval_points[i], derivative=derivative)
+            res = np.array([self._evaluate_codomain(
+                s, e, derivative=derivative)
+                for s, e in zip(self.splines, eval_points)])
 
         return res
 
@@ -148,7 +145,7 @@ class _SplineList1D(_SplineList):
 
     def _evaluate_one(self, spl, t, derivative=0):
         try:
-            return spl(t, derivative)
+            return spl(t, derivative)[:, 0]
         except ValueError:
             return np.zeros_like(t)
 

--- a/tests/test_basis_evaluation.py
+++ b/tests/test_basis_evaluation.py
@@ -108,18 +108,18 @@ class TestBasisEvaluationFourier(unittest.TestCase):
         # Test same result than evaluation standart
         np.testing.assert_array_almost_equal(f([1]),
                                              f([[1], [1]],
-                                               aligned_evaluation=False))
+                                               aligned=False))
         np.testing.assert_array_almost_equal(f(t), f(np.vstack((t, t)),
-                                                     aligned_evaluation=False))
+                                                     aligned=False))
 
         # Different evaluation times
         t_multiple = [[0, 0.5], [0.2, 0.7]]
         np.testing.assert_array_almost_equal(f(t_multiple[0])[0],
                                              f(t_multiple,
-                                               aligned_evaluation=False)[0])
+                                               aligned=False)[0])
         np.testing.assert_array_almost_equal(f(t_multiple[1])[1],
                                              f(t_multiple,
-                                               aligned_evaluation=False)[1])
+                                               aligned=False)[1])
 
     def test_domain_in_list_fourier(self):
         """Test the evaluation of FDataBasis"""
@@ -241,18 +241,18 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         # Test same result than evaluation standart
         np.testing.assert_array_almost_equal(f([1]),
                                              f([[1], [1]],
-                                               aligned_evaluation=False))
+                                               aligned=False))
         np.testing.assert_array_almost_equal(f(t), f(np.vstack((t, t)),
-                                                     aligned_evaluation=False))
+                                                     aligned=False))
 
         # Different evaluation times
         t_multiple = [[0, 0.5], [0.2, 0.7]]
         np.testing.assert_array_almost_equal(f(t_multiple[0])[0],
                                              f(t_multiple,
-                                               aligned_evaluation=False)[0])
+                                               aligned=False)[0])
         np.testing.assert_array_almost_equal(f(t_multiple[1])[1],
                                              f(t_multiple,
-                                               aligned_evaluation=False)[1])
+                                               aligned=False)[1])
 
     def test_domain_in_list_bspline(self):
         """Test the evaluation of FDataBasis"""
@@ -380,18 +380,18 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         # Test same result than evaluation standart
         np.testing.assert_array_almost_equal(f([1]),
                                              f([[1], [1]],
-                                               aligned_evaluation=False))
+                                               aligned=False))
         np.testing.assert_array_almost_equal(f(t), f(np.vstack((t, t)),
-                                                     aligned_evaluation=False))
+                                                     aligned=False))
 
         # Different evaluation times
         t_multiple = [[0, 0.5], [0.2, 0.7]]
         np.testing.assert_array_almost_equal(f(t_multiple[0])[0],
                                              f(t_multiple,
-                                               aligned_evaluation=False)[0])
+                                               aligned=False)[0])
         np.testing.assert_array_almost_equal(f(t_multiple[1])[1],
                                              f(t_multiple,
-                                               aligned_evaluation=False)[1])
+                                               aligned=False)[1])
 
     def test_domain_in_list_monomial(self):
         """Test the evaluation of FDataBasis"""

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -239,6 +239,19 @@ class TestEvaluateFDataGrid(unittest.TestCase):
 
         np.testing.assert_allclose(res, expected)
 
+    def test_evaluate_unaligned_ragged(self):
+
+        res = self.fd([[(0, 0), (1, 1), (2, 2), (3, 3)],
+                       [(1, 7), (5, 2), (3, 4)]],
+                      aligned=False)
+        expected = ([[[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]],
+                     [[3, 4, 5], [3, 4, 5], [3, 4, 5]]])
+
+        self.assertEqual(len(res), self.fd.n_samples)
+
+        for r, e in zip(res, expected):
+            np.testing.assert_allclose(r, e)
+
     def test_evaluate_grid_aligned(self):
 
         res = self.fd([[0, 1], [1, 2]], grid=True)
@@ -255,6 +268,16 @@ class TestEvaluateFDataGrid(unittest.TestCase):
                              [[[3, 4, 5], [3, 4, 5]], [[3, 4, 5], [3, 4, 5]]]])
 
         np.testing.assert_allclose(res, expected)
+
+    def test_evaluate_grid_unaligned_ragged(self):
+
+        res = self.fd([[[0, 1], [1, 2]], [[3, 4], [5]]],
+                      grid=True, aligned=False)
+        expected = ([[[[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]]],
+                     [[[3, 4, 5]], [[3, 4, 5]]]])
+
+        for r, e in zip(res, expected):
+            np.testing.assert_allclose(r, e)
 
 
 if __name__ == '__main__':

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -197,6 +197,66 @@ class TestFDataGrid(unittest.TestCase):
         self.assertEqual(gof.dim_codomain, 1)
 
 
+class TestEvaluateFDataGrid(unittest.TestCase):
+
+    def setUp(self):
+        data_matrix = np.array(
+            [
+                [
+                    [[0, 1, 2], [0, 1, 2]],
+                    [[0, 1, 2], [0, 1, 2]]
+                ],
+                [
+                    [[3, 4, 5], [3, 4, 5]],
+                    [[3, 4, 5], [3, 4, 5]]
+                ]
+            ])
+
+        sample_points = [[0, 1], [0, 1]]
+
+        fd = FDataGrid(data_matrix, sample_points=sample_points)
+        self.assertEqual(fd.n_samples, 2)
+        self.assertEqual(fd.dim_domain, 2)
+        self.assertEqual(fd.dim_codomain, 3)
+
+        self.fd = fd
+
+    def test_evaluate_aligned(self):
+
+        res = self.fd([(0, 0), (1, 1), (2, 2), (3, 3)])
+        expected = np.array([[[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]],
+                             [[3, 4, 5], [3, 4, 5], [3, 4, 5], [3, 4, 5]]])
+
+        np.testing.assert_allclose(res, expected)
+
+    def test_evaluate_unaligned(self):
+
+        res = self.fd([[(0, 0), (1, 1), (2, 2), (3, 3)],
+                       [(1, 7), (5, 2), (3, 4), (6, 1)]],
+                      aligned_evaluation=False)
+        expected = np.array([[[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]],
+                             [[3, 4, 5], [3, 4, 5], [3, 4, 5], [3, 4, 5]]])
+
+        np.testing.assert_allclose(res, expected)
+
+    def test_evaluate_grid_aligned(self):
+
+        res = self.fd([[0, 1], [1, 2]], grid=True)
+        expected = np.array([[[[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]]],
+                             [[[3, 4, 5], [3, 4, 5]], [[3, 4, 5], [3, 4, 5]]]])
+
+        np.testing.assert_allclose(res, expected)
+
+    def test_evaluate_grid_unaligned(self):
+
+        res = self.fd([[[0, 1], [1, 2]], [[3, 4], [5, 6]]],
+                      grid=True, aligned_evaluation=False)
+        expected = np.array([[[[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]]],
+                             [[[3, 4, 5], [3, 4, 5]], [[3, 4, 5], [3, 4, 5]]]])
+
+        np.testing.assert_allclose(res, expected)
+
+
 if __name__ == '__main__':
     print()
     unittest.main()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -233,7 +233,7 @@ class TestEvaluateFDataGrid(unittest.TestCase):
 
         res = self.fd([[(0, 0), (1, 1), (2, 2), (3, 3)],
                        [(1, 7), (5, 2), (3, 4), (6, 1)]],
-                      aligned_evaluation=False)
+                      aligned=False)
         expected = np.array([[[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]],
                              [[3, 4, 5], [3, 4, 5], [3, 4, 5], [3, 4, 5]]])
 
@@ -250,7 +250,7 @@ class TestEvaluateFDataGrid(unittest.TestCase):
     def test_evaluate_grid_unaligned(self):
 
         res = self.fd([[[0, 1], [1, 2]], [[3, 4], [5, 6]]],
-                      grid=True, aligned_evaluation=False)
+                      grid=True, aligned=False)
         expected = np.array([[[[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]]],
                              [[[3, 4, 5], [3, 4, 5]], [[3, 4, 5], [3, 4, 5]]]])
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -78,19 +78,19 @@ class TestEvaluationSpline1_1(unittest.TestCase):
 
         # Evaluate (x**2, (9-x)**2) in (1,8)
         np.testing.assert_array_almost_equal(f([[1], [8]],
-                                               aligned_evaluation=False),
+                                               aligned=False),
                                              np.array([[[1.]], [[1.]]]))
 
         t = np.linspace(4, 6, 4)
         np.testing.assert_array_almost_equal(
-            f([t, 9 - t], aligned_evaluation=False).round(2),
+            f([t, 9 - t], aligned=False).round(2),
             np.array([[[16.], [22.], [28.67], [36.]],
                       [[16.], [22.], [28.67], [36.]]]))
 
         # Same length than nsample
         t = np.linspace(4, 6, 2)
         np.testing.assert_array_almost_equal(
-            f([t, 9 - t], aligned_evaluation=False).round(2),
+            f([t, 9 - t], aligned=False).round(2),
             np.array([[[16.], [36.]], [[16.], [36.]]]))
 
     def test_evaluation_cubic_simple(self):
@@ -153,19 +153,19 @@ class TestEvaluationSpline1_1(unittest.TestCase):
 
         # Evaluate (x**2, (9-x)**2) in (1,8)
         np.testing.assert_array_almost_equal(
-            f([[1], [8]], aligned_evaluation=False).round(3),
+            f([[1], [8]], aligned=False).round(3),
             np.array([[[1.]], [[1.]]]))
 
         t = np.linspace(4, 6, 4)
         np.testing.assert_array_almost_equal(
-            f([t, 9 - t], aligned_evaluation=False).round(2),
+            f([t, 9 - t], aligned=False).round(2),
             np.array([[[16.], [21.78], [28.44], [36.]],
                       [[16.], [21.78], [28.44], [36.]]]))
 
         # Same length than nsample
         t = np.linspace(4, 6, 2)
         np.testing.assert_array_almost_equal(
-            f([t, 9 - t], aligned_evaluation=False).round(3),
+            f([t, 9 - t], aligned=False).round(3),
             np.array([[[16.], [36.]], [[16.], [36.]]]))
 
     def test_evaluation_nodes(self):
@@ -280,10 +280,10 @@ class TestEvaluationSpline1_n(unittest.TestCase):
 
         # Evaluate (x**2, (9-x)**2) in (1,8)
         np.testing.assert_array_almost_equal(f([[1], [4]],
-                                               aligned_evaluation=False)[0],
+                                               aligned=False)[0],
                                              f(1)[0])
         np.testing.assert_array_almost_equal(f([[1], [4]],
-                                               aligned_evaluation=False)[1],
+                                               aligned=False)[1],
                                              f(4)[1])
 
     def test_evaluation_nodes(self):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -107,7 +107,7 @@ class TestWarping(unittest.TestCase):
         landmarks = landmarks.squeeze()
 
         original_modes = fd(landmarks.reshape((3, 1, 1)),
-                            aligned_evaluation=False)
+                            aligned=False)
         # Test default location
         fd_registered = landmark_shift(fd, landmarks)
         center = (landmarks.max() + landmarks.min()) / 2
@@ -131,7 +131,7 @@ class TestWarping(unittest.TestCase):
 
         # Test array location
         fd_registered = landmark_shift(fd, landmarks, location=[0, 0.1, 0.2])
-        reg_modes = fd_registered([[0], [.1], [.2]], aligned_evaluation=False)
+        reg_modes = fd_registered([[0], [.1], [.2]], aligned=False)
 
         np.testing.assert_almost_equal(reg_modes, original_modes, decimal=2)
 
@@ -159,7 +159,7 @@ class TestWarping(unittest.TestCase):
                                               random_state=9)
         landmarks = landmarks.squeeze()
 
-        original_values = fd(landmarks.reshape(3, 2), aligned_evaluation=False)
+        original_values = fd(landmarks.reshape(3, 2), aligned=False)
 
         # Default location
         fd_reg = landmark_registration(fd, landmarks)


### PR DESCRIPTION
- Simplify internal code
- Only one entry point for evaluation in evaluators and `FData` objects
- Rename `aligned_evaluation` to `aligned`
- Allow ragged input for unaligned evaluation