### PR TITLE
Add basis for functions with codomain dimension above 1

### DIFF
--- a/docs/modules/representation.rst
+++ b/docs/modules/representation.rst
@@ -45,7 +45,8 @@ of elements of a basis function system.
    skfda.representation.basis.FDataBasis
 
 
-The following classes are used to define different basis systems.
+The following classes are used to define different basis for
+:math:`\mathbb{R} \to \mathbb{R}` functions.
 
 .. autosummary::
    :toctree: autosummary
@@ -54,6 +55,15 @@ The following classes are used to define different basis systems.
    skfda.representation.basis.Fourier
    skfda.representation.basis.Monomial
    skfda.representation.basis.Constant
+
+The following class, allows the construction of a basis for
+:math:`\mathbb{R}^n \to \mathbb{R}^m` functions from
+several :math:`\mathbb{R}^n \to \mathbb{R}` bases.
+
+.. autosummary::
+   :toctree: autosummary
+
+   skfda.representation.basis.VectorValued
 
 Generic representation
 ----------------------

--- a/skfda/_utils/__init__.py
+++ b/skfda/_utils/__init__.py
@@ -3,4 +3,5 @@ from . import constants
 from ._utils import (_list_of_arrays, _cartesian_product,
                      _check_estimator, parameter_aliases,
                      _to_grid, check_is_univariate,
-                     _same_domain, _to_array_maybe_ragged)
+                     _same_domain, _to_array_maybe_ragged,
+                     _reshape_eval_points)

--- a/skfda/misc/operators/_operators.py
+++ b/skfda/misc/operators/_operators.py
@@ -42,7 +42,8 @@ def compute_triang_functional(evaluated_basis,
         """Multiply the two evaluations."""
         res = evaluated_basis([x])
 
-        res = res.reshape((res.shape[0], -1))
+        # Remove n_points dimension
+        res = res[:, 0, :]
 
         return res[indices[0]] * res[indices[1]]
 
@@ -53,7 +54,10 @@ def compute_triang_functional(evaluated_basis,
     integral = scipy.integrate.quad_vec(
         cross_product, domain_range[0], domain_range[1])[0]
 
-    return integral[..., 0]
+    # Sum the integrals of each codomain dimension
+    integral_sum = np.sum(integral, axis=-1)
+
+    return integral_sum
 
 
 def compute_triang_multivariate(evaluated_basis,

--- a/skfda/misc/operators/_operators.py
+++ b/skfda/misc/operators/_operators.py
@@ -40,7 +40,9 @@ def compute_triang_functional(evaluated_basis,
                               basis):
     def cross_product(x):
         """Multiply the two evaluations."""
-        res = evaluated_basis([x])[:, 0]
+        res = evaluated_basis([x])
+
+        res = res.reshape((res.shape[0], -1))
 
         return res[indices[0]] * res[indices[1]]
 

--- a/skfda/preprocessing/smoothing/_basis.py
+++ b/skfda/preprocessing/smoothing/_basis.py
@@ -108,7 +108,7 @@ class _Matrix():
 
     def transform(self, estimator, X, y=None):
         if estimator.return_basis:
-            coefficients = (X.data_matrix[..., 0]
+            coefficients = (X.data_matrix.reshape((X.n_samples, -1))
                             @ estimator._cached_coef_matrix.T)
 
             fdatabasis = FDataBasis(
@@ -325,11 +325,11 @@ class BasisSmoother(_LinearSmoother):
     def _method_function(self):
         """ Return the method function"""
         method_function = self.method
-        if not callable(method_function):
+        if not isinstance(method_function, self.SolverMethod):
             method_function = self.SolverMethod[
-                method_function.lower()].value
+                method_function.lower()]
 
-        return method_function
+        return method_function.value
 
     def _coef_matrix(self, input_points):
         """Get the matrix that gives the coefficients"""
@@ -371,7 +371,6 @@ class BasisSmoother(_LinearSmoother):
             self (object)
 
         """
-        _check_r_to_r(X)
 
         self.input_points_ = X.sample_points[0]
         self.output_points_ = (self.output_points

--- a/skfda/preprocessing/smoothing/_basis.py
+++ b/skfda/preprocessing/smoothing/_basis.py
@@ -398,8 +398,6 @@ class BasisSmoother(_LinearSmoother):
         """
         from ...misc.regularization import compute_penalty_matrix
 
-        _check_r_to_r(X)
-
         self.input_points_ = X.sample_points[0]
         self.output_points_ = (self.output_points
                                if self.output_points is not None

--- a/skfda/representation/basis/__init__.py
+++ b/skfda/representation/basis/__init__.py
@@ -5,3 +5,4 @@ from ._constant import Constant
 from ._fdatabasis import FDataBasis, FDataBasisDType
 from ._fourier import Fourier
 from ._monomial import Monomial
+from ._vector_basis import VectorValued

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -162,6 +162,37 @@ class Basis(ABC):
         """
         self.to_basis().plot(chart=chart, **kwargs)
 
+    def _coordinate_nonfull(self, fdatabasis, key):
+        """
+        Returns a fdatagrid for the coordinate functions indexed by key.
+
+        Subclasses can override this to provide coordinate indexing.
+
+        The key parameter has been already validated and is an integer or
+        slice in the range [0, self.dim_codomain.
+
+        """
+        raise NotImplementedError("Coordinate indexing not implemented")
+
+    def _coordinate(self, fdatabasis, key):
+        """Returns a fdatagrid for the coordinate functions indexed by key."""
+
+        # Raises error if not in range and normalize key
+        r_key = range(self.dim_codomain)[key]
+
+        if isinstance(r_key, range) and len(r_key) == 0:
+            raise IndexError("Empty number of coordinates selected")
+
+        # Full fdatabasis case
+        if (self.dim_codomain == 1 and r_key == 0) or (
+                isinstance(r_key, range) and len(r_key) == self.dim_codomain):
+
+            return fdatabasis.copy()
+
+        else:
+
+            return self._coordinate_nonfull(fdatabasis=fdatabasis, key=r_key)
+
     @abstractmethod
     def basis_of_product(self, other):
         pass

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -59,9 +59,16 @@ class Basis(ABC):
 
         self._domain_range = domain_range
         self.n_basis = n_basis
-        self._drop_index_lst = []
 
         super().__init__()
+
+    @property
+    def dim_domain(self):
+        return 1
+
+    @property
+    def dim_codomain(self):
+        return 1
 
     @property
     def domain_range(self):
@@ -188,14 +195,6 @@ class Basis(ABC):
             domain_range = self.domain_range
 
         return type(self)(domain_range, self.n_basis)
-
-    def same_domain(self, other):
-        r"""Returns if two basis are defined on the same domain range.
-
-            Args:
-                other (Basis): Basis to check the domain range definition
-        """
-        return _same_domain(self, other)
 
     def copy(self):
         """Basis copy"""

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -114,7 +114,8 @@ class Basis(ABC):
             raise ValueError("The list of points where the function is "
                              "evaluated can not contain nan values.")
 
-        return self._evaluate(eval_points)
+        return self._evaluate(eval_points).reshape(
+            (self.n_basis, len(eval_points), self.dim_codomain))
 
     def __call__(self, *args, **kwargs):
         return self.evaluate(*args, **kwargs)

--- a/skfda/representation/basis/_basis.py
+++ b/skfda/representation/basis/_basis.py
@@ -12,7 +12,7 @@ import scipy.integrate
 
 import numpy as np
 
-from ..._utils import _list_of_arrays, _same_domain
+from ..._utils import _list_of_arrays, _same_domain, _reshape_eval_points
 
 
 __author__ = "Miguel Carbajo Berrocal"
@@ -109,10 +109,10 @@ class Basis(ABC):
                           "derivative function instead.", DeprecationWarning)
             return self.derivative(order=derivative)(eval_points)
 
-        eval_points = np.atleast_1d(eval_points)
-        if np.any(np.isnan(eval_points)):
-            raise ValueError("The list of points where the function is "
-                             "evaluated can not contain nan values.")
+        eval_points = _reshape_eval_points(eval_points,
+                                           aligned=True,
+                                           n_samples=self.n_basis,
+                                           dim_domain=self.dim_domain)
 
         return self._evaluate(eval_points).reshape(
             (self.n_basis, len(eval_points), self.dim_codomain))

--- a/skfda/representation/basis/_bspline.py
+++ b/skfda/representation/basis/_bspline.py
@@ -56,9 +56,15 @@ class BSpline(Basis):
 
         >>> bss = BSpline(n_basis=3, order=3)
         >>> bss([0, 0.5, 1])
-        array([[ 1.  ,  0.25,  0.  ],
-               [ 0.  ,  0.5 ,  0.  ],
-               [ 0.  ,  0.25,  1.  ]])
+        array([[[ 1.  ],
+                [ 0.25],
+                [ 0.  ]],
+               [[ 0.  ],
+                [ 0.5 ],
+                [ 0.  ]],
+               [[ 0.  ],
+                [ 0.25],
+                [ 1.  ]]])
 
         And evaluates first derivative
 

--- a/skfda/representation/basis/_bspline.py
+++ b/skfda/representation/basis/_bspline.py
@@ -171,6 +171,9 @@ class BSpline(Basis):
 
     def _evaluate(self, eval_points):
 
+        # Input is scalar
+        eval_points = eval_points[..., 0]
+
         # Places m knots at the boundaries
         knots = self._evaluation_knots()
 

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -233,9 +233,6 @@ class FDataBasis(FData):
 
     def _evaluate(self, eval_points,  *, aligned=True):
 
-        #  Only suported 1D objects
-        eval_points = eval_points[..., 0]
-
         if aligned:
 
             # Each row contains the values of one element of the basis

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -60,15 +60,14 @@ class FDataBasis(FData):
 
         def __iter__(self):
             """Return an iterator through the image coordinates."""
-            yield self._fdatabasis.copy()
+
+            for i in range(len(self)):
+                yield self[i]
 
         def __getitem__(self, key):
             """Get a specific coordinate."""
 
-            if key != 0:
-                return NotImplemented
-
-            return self._fdatabasis.copy()
+            return self._fdatabasis.basis._coordinate(self._fdatabasis, key)
 
         def __len__(self):
             """Return the number of coordinates."""

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -196,15 +196,13 @@ class FDataBasis(FData):
     def dim_domain(self):
         """Return number of dimensions of the domain."""
 
-        # Only domain dimension equal to 1 is supported
-        return 1
+        return self.basis.dim_domain
 
     @property
     def dim_codomain(self):
         """Return number of dimensions of the image."""
 
-        # Only image dimension equal to 1 is supported
-        return 1
+        return self.basis.dim_codomain
 
     @property
     def coordinates(self):
@@ -230,7 +228,7 @@ class FDataBasis(FData):
 
     @property
     def domain_range(self):
-        """Definition range."""
+
         return self.basis.domain_range
 
     def _evaluate(self, eval_points,  *, aligned=True):
@@ -245,7 +243,8 @@ class FDataBasis(FData):
 
             res = np.tensordot(self.coefficients, basis_values, axes=(1, 0))
 
-            return res.reshape((self.n_samples, len(eval_points), 1))
+            return res.reshape(
+                (self.n_samples, len(eval_points), self.dim_codomain))
 
         else:
 
@@ -259,7 +258,8 @@ class FDataBasis(FData):
                 np.multiply(basis_values, self.coefficients[i], out=_matrix)
                 np.sum(_matrix, axis=1, out=res_matrix[i])
 
-            return res_matrix.reshape((self.n_samples, eval_points.shape[1], 1))
+            return res_matrix.reshape(
+                (self.n_samples, eval_points.shape[1], self.dim_codomain))
 
     def shift(self, shifts, *, restrict_domain=False, extrapolation=None,
               eval_points=None, **kwargs):

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -248,18 +248,16 @@ class FDataBasis(FData):
 
         else:
 
-            res_matrix = np.empty((self.n_samples, eval_points.shape[1]))
-
-            _matrix = np.empty((eval_points.shape[1], self.n_basis))
+            res_matrix = np.empty(
+                (self.n_samples, eval_points.shape[1], self.dim_codomain))
 
             for i in range(self.n_samples):
-                basis_values = self.basis.evaluate(eval_points[i]).T
+                basis_values = self.basis.evaluate(eval_points[i])
 
-                np.multiply(basis_values, self.coefficients[i], out=_matrix)
-                np.sum(_matrix, axis=1, out=res_matrix[i])
+                values = self.coefficients[i] * basis_values.T
+                np.sum(values.T, axis=0, out=res_matrix[i])
 
-            return res_matrix.reshape(
-                (self.n_samples, eval_points.shape[1], self.dim_codomain))
+            return res_matrix
 
     def shift(self, shifts, *, restrict_domain=False, extrapolation=None,
               eval_points=None, **kwargs):

--- a/skfda/representation/basis/_fourier.py
+++ b/skfda/representation/basis/_fourier.py
@@ -108,6 +108,10 @@ class Fourier(Basis):
         self._period = value
 
     def _evaluate(self, eval_points):
+
+        # Input is scalar
+        eval_points = eval_points[..., 0]
+
         functions = [np.sin, np.cos]
         omega = 2 * np.pi / self.period
 

--- a/skfda/representation/basis/_fourier.py
+++ b/skfda/representation/basis/_fourier.py
@@ -36,9 +36,18 @@ class Fourier(Basis):
 
         >>> fb = Fourier((0, np.pi), n_basis=3, period=1)
         >>> fb([0, np.pi / 4, np.pi / 2, np.pi]).round(2)
-        array([[ 1.  ,  1.  ,  1.  ,  1.  ],
-               [ 0.  , -1.38, -0.61,  1.1 ],
-               [ 1.41,  0.31, -1.28,  0.89]])
+        array([[[ 1.  ],
+                [ 1.  ],
+                [ 1.  ],
+                [ 1.  ]],
+               [[ 0.  ],
+                [-1.38],
+                [-0.61],
+                [ 1.1 ]],
+               [[ 1.41],
+                [ 0.31],
+                [-1.28],
+                [ 0.89]]])
 
         And evaluate second derivative
 

--- a/skfda/representation/basis/_monomial.py
+++ b/skfda/representation/basis/_monomial.py
@@ -29,9 +29,15 @@ class Monomial(Basis):
         values.
 
         >>> bs_mon([0., 1., 2.])
-        array([[ 1., 1., 1.],
-               [ 0., 1., 2.],
-               [ 0., 1., 4.]])
+        array([[[ 1.],
+                [ 1.],
+                [ 1.]],
+               [[ 0.],
+                [ 1.],
+                [ 2.]],
+               [[ 0.],
+                [ 1.],
+                [ 4.]]])
 
         And also evaluates its derivatives
 

--- a/skfda/representation/basis/_monomial.py
+++ b/skfda/representation/basis/_monomial.py
@@ -66,6 +66,10 @@ class Monomial(Basis):
     """
 
     def _evaluate(self, eval_points):
+
+        # Input is scalar
+        eval_points = eval_points[..., 0]
+
         exps = np.arange(self.n_basis)
         raised = np.power.outer(eval_points, exps)
 

--- a/skfda/representation/basis/_vector_basis.py
+++ b/skfda/representation/basis/_vector_basis.py
@@ -105,6 +105,29 @@ class VectorValued(Basis):
     def _derivative_basis_and_coefs(self, coefs, order=1):
         pass
 
+    def _coordinate_nonfull(self, fdatabasis, key):
+
+        r_key = key
+        if isinstance(r_key, int):
+            r_key = range(r_key, r_key + 1)
+
+        coef_indexes = np.concatenate([
+            np.ones(b.n_basis, dtype=np.bool_) if i in r_key
+            else np.zeros(b.n_basis, dtype=np.bool_)
+            for i, b in enumerate(self.basis_list)])
+
+        new_basis_list = self.basis_list[key]
+
+        basis = (new_basis_list if isinstance(new_basis_list, Basis)
+                 else VectorValued(new_basis_list))
+
+        coefs = fdatabasis.coefficients[:, coef_indexes]
+
+        axes_labels = fdatabasis._get_labels_coordinates(key)
+
+        return fdatabasis.copy(basis=basis, coefficients=coefs,
+                               axes_labels=axes_labels)
+
     def basis_of_product(self, other):
         pass
 

--- a/skfda/representation/basis/_vector_basis.py
+++ b/skfda/representation/basis/_vector_basis.py
@@ -1,0 +1,112 @@
+'''
+Created on 2 jul. 2020
+
+@author: Carlos
+'''
+import scipy.linalg
+
+import numpy as np
+
+from ..._utils import _same_domain
+from ._basis import Basis
+
+
+class VectorValued(Basis):
+    r"""Vector-valued basis.
+
+    Basis for vector-valued functions constructed from scalar-valued bases.
+
+    For each dimension in the codomain, it uses a scalar-valued basis
+    multiplying each basis by the corresponding unitary vector.
+
+    Attributes:
+        domain_range (tuple): a tuple of length ``dim_domain`` containing
+            the range of input values for each dimension.
+        n_basis (int): number of functions in the basis.
+
+    Examples:
+        Defines a vector-valued base over the interval :math:`[0, 5]`
+        consisting on the functions
+
+        .. math::
+
+            1 \vec{i}, t \vec{i}, t^2 \vec{i}, 1 \vec{j}, t \vec{j}
+
+        >>> from skfda.representation.basis import VectorValued, Monomial
+        >>>
+        >>> basis_x = Monomial((0,5), n_basis=3)
+        >>> basis_y = Monomial((0,5), n_basis=2)
+        >>>
+        >>> basis = VectorValued([basis_x, basis_y])
+
+
+        And evaluates all the functions in the basis in a list of descrete
+        values.
+
+        >>> basis([0., 1., 2.])
+        array([[[ 1.,  0.],
+                [ 1.,  0.],
+                [ 1.,  0.]],
+               [[ 0.,  0.],
+                [ 1.,  0.],
+                [ 2.,  0.]],
+               [[ 0.,  0.],
+                [ 1.,  0.],
+                [ 4.,  0.]],
+               [[ 0.,  1.],
+                [ 0.,  1.],
+                [ 0.,  1.]],
+               [[ 0.,  0.],
+                [ 0.,  1.],
+                [ 0.,  2.]]])
+
+    """
+
+    def __init__(self, basis_list):
+
+        if not all(b.dim_codomain == 1 for b in basis_list):
+            raise ValueError("The basis functions must be "
+                             "scalar valued")
+
+        if any(b.dim_domain != basis_list[0].dim_domain or
+               not _same_domain(b,  basis_list[0])
+               for b in basis_list):
+            raise ValueError("The basis must all have the same domain "
+                             "dimension an range")
+
+        self.basis_list = basis_list
+
+        super().__init__(
+            domain_range=basis_list[0].domain_range,
+            n_basis=sum(b.n_basis for b in basis_list))
+
+    @property
+    def dim_domain(self):
+        return self.basis_list[0].dim_domain
+
+    @property
+    def dim_codomain(self):
+        return len(self.basis_list)
+
+    def _evaluate(self, eval_points):
+        matrix = np.zeros((self.n_basis, len(eval_points), self.dim_codomain))
+
+        n_basis_evaluated = 0
+
+        basis_evaluations = [b._evaluate(eval_points) for b in self.basis_list]
+
+        for i, ev in enumerate(basis_evaluations):
+
+            matrix[n_basis_evaluated:n_basis_evaluated + len(ev), :, i] = ev
+            n_basis_evaluated += len(ev)
+
+        return matrix
+
+    def _derivative_basis_and_coefs(self, coefs, order=1):
+        pass
+
+    def basis_of_product(self, other):
+        pass
+
+    def rbasis_of_product(self, other):
+        pass

--- a/skfda/representation/basis/_vector_basis.py
+++ b/skfda/representation/basis/_vector_basis.py
@@ -103,7 +103,21 @@ class VectorValued(Basis):
         return matrix
 
     def _derivative_basis_and_coefs(self, coefs, order=1):
-        pass
+
+        n_basis_list = [b.n_basis for b in self.basis_list]
+        indexes = np.cumsum(n_basis_list)
+
+        coefs_per_basis = np.hsplit(coefs, indexes[:-1])
+
+        basis_and_coefs = [b._derivative_basis_and_coefs(
+            c, order=order) for b, c in zip(self.basis_list, coefs_per_basis)]
+
+        new_basis_list, new_coefs_list = zip(*basis_and_coefs)
+
+        new_basis = VectorValued(new_basis_list)
+        new_coefs = np.hstack(new_coefs_list)
+
+        return new_basis, new_coefs
 
     def _coordinate_nonfull(self, fdatabasis, key):
 

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -771,12 +771,16 @@ class FDataGrid(FData):
             array([[ 2.  , 0.71, 0.71]])
 
         """
-        if self.dim_domain > 1:
-            raise NotImplementedError("Only support 1 dimension on the "
-                                      "domain.")
-        elif self.dim_codomain > 1:
-            raise NotImplementedError("Only support 1 dimension on the "
-                                      "image.")
+        if self.dim_domain != basis.dim_domain:
+            raise ValueError(f"The domain of the function has "
+                             f"dimension {self.dim_domain} "
+                             f"but the domain of the basis has "
+                             f"dimension {basis.dim_domain}")
+        elif self.dim_codomain != basis.dim_codomain:
+            raise ValueError(f"The codomain of the function has "
+                             f"dimension {self.dim_codomain} "
+                             f"but the codomain of the basis has "
+                             f"dimension {basis.dim_codomain}")
 
         # Readjust the domain range if there was not an explicit one
         if basis._domain_range is None:

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -787,8 +787,8 @@ class FDataGrid(FData):
             basis = basis.copy()
             basis.domain_range = self.domain_range
 
-        return fdbasis.FDataBasis.from_data(self.data_matrix[..., 0],
-                                            self.sample_points[0],
+        return fdbasis.FDataBasis.from_data(self.data_matrix,
+                                            self.sample_points,
                                             basis,
                                             **kwargs)
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,6 +1,6 @@
 from skfda import concatenate
 from skfda.representation.basis import (Basis, FDataBasis, Constant, Monomial,
-                                        BSpline, Fourier, VectorValued)
+                                        BSpline, Fourier)
 from skfda.representation.grid import FDataGrid
 import unittest
 
@@ -449,38 +449,6 @@ class TestBasis(unittest.TestCase):
         np.testing.assert_equal(fd.dim_domain, 1)
         np.testing.assert_array_equal(fd.coefficients, np.concatenate(
             [fd1.coefficients, fd2.coefficients]))
-
-    def test_vector_valued_constant(self):
-
-        basis_first = Constant()
-        basis_second = Constant()
-
-        basis = VectorValued([basis_first, basis_second])
-
-        fd = FDataBasis(basis=basis, coefficients=[[1, 2], [3, 4]])
-
-        self.assertEqual(fd.dim_codomain, 2)
-
-        res = np.array([[[1, 2]], [[3, 4]]])
-
-        np.testing.assert_allclose(fd(0), res)
-
-    def test_vector_valued_constant_monomial(self):
-
-        basis_first = Constant(domain_range=(0, 5))
-        basis_second = Monomial(n_basis=3, domain_range=(0, 5))
-
-        basis = VectorValued([basis_first, basis_second])
-
-        fd = FDataBasis(basis=basis, coefficients=[[1, 2, 3, 4], [3, 4, 5, 6]])
-
-        self.assertEqual(fd.dim_codomain, 2)
-
-        np.testing.assert_allclose(fd.domain_range[0], (0, 5))
-
-        res = np.array([[[1, 2], [1, 9], [1, 24]], [[3, 4], [3, 15], [3, 38]]])
-
-        np.testing.assert_allclose(fd([0, 1, 2]), res)
 
 
 if __name__ == '__main__':

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,7 +1,7 @@
-from skfda.representation.basis import (Basis, FDataBasis, Constant, Monomial,
-                                        BSpline, Fourier)
-from skfda.representation.grid import FDataGrid
 from skfda import concatenate
+from skfda.representation.basis import (Basis, FDataBasis, Constant, Monomial,
+                                        BSpline, Fourier, VectorValued)
+from skfda.representation.grid import FDataGrid
 import unittest
 
 import numpy as np
@@ -449,6 +449,39 @@ class TestBasis(unittest.TestCase):
         np.testing.assert_equal(fd.dim_domain, 1)
         np.testing.assert_array_equal(fd.coefficients, np.concatenate(
             [fd1.coefficients, fd2.coefficients]))
+
+    def test_vector_valued_constant(self):
+
+        basis_first = Constant()
+        basis_second = Constant()
+
+        basis = VectorValued([basis_first, basis_second])
+
+        fd = FDataBasis(basis=basis, coefficients=[[1, 2], [3, 4]])
+
+        self.assertEqual(fd.dim_codomain, 2)
+
+        res = np.array([[[1, 2]], [[3, 4]]])
+
+        np.testing.assert_allclose(fd(0), res)
+
+    def test_vector_valued_constant_monomial(self):
+
+        basis_first = Constant(domain_range=(0, 5))
+        basis_second = Monomial(n_basis=3, domain_range=(0, 5))
+
+        basis = VectorValued([basis_first, basis_second])
+
+        fd = FDataBasis(basis=basis, coefficients=[[1, 2, 3, 4], [3, 4, 5, 6]])
+
+        self.assertEqual(fd.dim_codomain, 2)
+
+        np.testing.assert_allclose(fd.domain_range[0], (0, 5))
+
+        res = np.array([[[1, 2], [1, 9], [1, 24]], [[3, 4], [3, 15], [3, 38]]])
+
+        np.testing.assert_allclose(fd([0, 1, 2]), res)
+
 
 if __name__ == '__main__':
     print()

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -454,14 +454,25 @@ class TestBasis(unittest.TestCase):
     def test_vector_valued(self):
         X, y = skfda.datasets.fetch_weather(return_X_y=True)
 
+        basis_dim = skfda.representation.basis.Fourier(
+            n_basis=7, domain_range=X.domain_range)
         basis = skfda.representation.basis.VectorValued(
-            [skfda.representation.basis.Fourier(
-                n_basis=7, domain_range=X.domain_range)] * 2
+            [basis_dim] * 2
         )
 
         X_basis = X.to_basis(basis)
 
         self.assertEqual(X_basis.dim_codomain, 2)
+
+        self.assertEqual(X_basis.coordinates[0].basis, basis_dim)
+        np.testing.assert_allclose(
+            X_basis.coordinates[0].coefficients,
+            X.coordinates[0].to_basis(basis_dim).coefficients)
+
+        self.assertEqual(X_basis.coordinates[1].basis, basis_dim)
+        np.testing.assert_allclose(
+            X_basis.coordinates[1].coefficients,
+            X.coordinates[1].to_basis(basis_dim).coefficients)
 
 
 if __name__ == '__main__':

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,4 +1,5 @@
 from skfda import concatenate
+import skfda
 from skfda.representation.basis import (Basis, FDataBasis, Constant, Monomial,
                                         BSpline, Fourier)
 from skfda.representation.grid import FDataGrid
@@ -449,6 +450,18 @@ class TestBasis(unittest.TestCase):
         np.testing.assert_equal(fd.dim_domain, 1)
         np.testing.assert_array_equal(fd.coefficients, np.concatenate(
             [fd1.coefficients, fd2.coefficients]))
+
+    def test_vector_valued(self):
+        X, y = skfda.datasets.fetch_weather(return_X_y=True)
+
+        basis = skfda.representation.basis.VectorValued(
+            [skfda.representation.basis.Fourier(
+                n_basis=7, domain_range=X.domain_range)] * 2
+        )
+
+        X_basis = X.to_basis(basis)
+
+        self.assertEqual(X_basis.dim_codomain, 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_basis_evaluation.py
+++ b/tests/test_basis_evaluation.py
@@ -1,5 +1,6 @@
 
-from skfda.representation.basis import FDataBasis, Monomial, BSpline, Fourier
+from skfda.representation.basis import (
+    FDataBasis, Monomial, BSpline, Fourier, Constant, VectorValued)
 import unittest
 
 import numpy as np
@@ -412,6 +413,43 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
 
             np.testing.assert_array_almost_equal(f(t).round(3), res)
             np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
+
+
+class TestBasisEvaluationVectorValued(unittest.TestCase):
+
+    def test_vector_valued_constant(self):
+
+        basis_first = Constant()
+        basis_second = Constant()
+
+        basis = VectorValued([basis_first, basis_second])
+
+        fd = FDataBasis(basis=basis, coefficients=[[1, 2], [3, 4]])
+
+        self.assertEqual(fd.dim_codomain, 2)
+
+        res = np.array([[[1, 2]], [[3, 4]]])
+
+        np.testing.assert_allclose(fd(0), res)
+
+    def test_vector_valued_constant_monomial(self):
+
+        basis_first = Constant(domain_range=(0, 5))
+        basis_second = Monomial(n_basis=3, domain_range=(0, 5))
+
+        basis = VectorValued([basis_first, basis_second])
+
+        fd = FDataBasis(basis=basis, coefficients=[
+                        [1, 2, 3, 4], [3, 4, 5, 6]])
+
+        self.assertEqual(fd.dim_codomain, 2)
+
+        np.testing.assert_allclose(fd.domain_range[0], (0, 5))
+
+        res = np.array([[[1, 2], [1, 9], [1, 24]],
+                        [[3, 4], [3, 15], [3, 38]]])
+
+        np.testing.assert_allclose(fd([0, 1, 2]), res)
 
 
 if __name__ == '__main__':

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -184,7 +184,8 @@ class TestEndpointsDifferenceRegularization(unittest.TestCase):
         smoother = skfda.preprocessing.smoothing.BasisSmoother(
             basis=skfda.representation.basis.BSpline(
                 n_basis=10, domain_range=fd.domain_range),
-            regularization=TikhonovRegularization(lambda x: x(1) - x(0)),
+            regularization=TikhonovRegularization(
+                lambda x: x(1)[:, 0] - x(0)[:, 0]),
             smoothing_parameter=10000)
 
         fd_basis = smoother.fit_transform(fd)


### PR DESCRIPTION
- The `VectorValued` basis construct a basis for vector valued functions from several scalar valued basis (one per axis).
- Can be derived, and converted from a `FDataGrid`.
- Regularization takes codomain dimension into account.