### PR TITLE
Remove indexing in FDataGrid additional dimensions.

### DIFF
--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -1016,17 +1016,6 @@ class FDataGrid(FData):
 
     def __getitem__(self, key):
         """Return self[key]."""
-        if isinstance(key, tuple):
-            # If there are not values for every dimension, the remaining ones
-            # are kept
-            key += (slice(None),) * (self.dim_domain + 1 - len(key))
-
-            sample_points = [self.sample_points[i][subkey]
-                             for i, subkey in enumerate(
-                                 key[1:1 + self.dim_domain])]
-
-            return self.copy(data_matrix=self.data_matrix[key],
-                             sample_points=sample_points)
 
         if isinstance(key, numbers.Integral):  # To accept also numpy ints
             key = int(key)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -49,15 +49,12 @@ class TestFDataGrid(unittest.TestCase):
             np.array([[0., 0.25, 0.5, 0.75, 1.]]))
 
     def test_slice(self):
-        t = 10
+        t = (5, 3)
         fd = FDataGrid(data_matrix=np.ones(t))
-        fd = fd[:, 0]
+        fd = fd[1:3]
         np.testing.assert_array_equal(
             fd.data_matrix[..., 0],
-            np.array([[1]]))
-        np.testing.assert_array_equal(
-            fd.sample_points,
-            np.array([[0]]))
+            np.array([[1, 1, 1], [1, 1, 1]]))
 
     def test_concatenate(self):
         fd1 = FDataGrid([[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]])


### PR DESCRIPTION
`FDataGrid` (as `FDataBasis`) should behave as an array of functions, so there should not be indexed using tuples. Closes #57.