### PR TITLE
Refactor registration scorers

### DIFF
--- a/skfda/_utils/_utils.py
+++ b/skfda/_utils/_utils.py
@@ -32,7 +32,7 @@ from ..representation.evaluator import Evaluator
 RandomStateLike = Optional[Union[int, np.random.RandomState]]
 
 if TYPE_CHECKING:
-    from ..representation import FData
+    from ..representation import FData, FDataGrid
     from ..representation.basis import Basis
 
 
@@ -95,7 +95,11 @@ def check_is_univariate(fd: FData) -> None:
         )
 
 
-def _to_grid(X, y, eval_points=None):
+def _to_grid(
+    X: FData,
+    y: FData,
+    eval_points: Optional[np.ndarray] = None,
+) -> Tuple[FDataGrid, FDataGrid]:
     """Transform a pair of FDatas in grids to perform calculations."""
 
     from .. import FDataGrid

--- a/skfda/_utils/_utils.py
+++ b/skfda/_utils/_utils.py
@@ -17,8 +17,9 @@ from typing import (
 )
 
 import numpy as np
-import scipy.integrate
 from pandas.api.indexers import check_array_indexer
+
+import scipy.integrate
 
 from ..representation._typing import (
     DomainRange,
@@ -64,12 +65,11 @@ class _FDataCallable():
                               n_samples=new_nsamples)
 
 
-def check_is_univariate(fd):
-    """Checks if an FData is univariate and raises an error
+def check_is_univariate(fd: FData) -> None:
+    """Check if an FData is univariate and raises an error.
 
     Args:
-        fd (:class:`~skfda.FData`): Functional object to check if is
-            univariate.
+        fd: Functional object to check if is univariate.
 
     Raises:
         ValueError: If it is not univariate, i.e., `fd.dim_domain != 1` or
@@ -77,13 +77,22 @@ def check_is_univariate(fd):
 
     """
     if fd.dim_domain != 1 or fd.dim_codomain != 1:
-        raise ValueError(f"The functional data must be univariate, i.e., " +
-                         f"with dim_domain=1 " +
-                         (f"" if fd.dim_domain == 1
-                          else f"(currently is {fd.dim_domain}) ") +
-                         f"and dim_codomain=1 " +
-                         (f"" if fd.dim_codomain == 1 else
-                          f"(currently is  {fd.dim_codomain})"))
+
+        domain_str = (
+            "" if fd.dim_domain == 1
+            else f"(currently is {fd.dim_domain}) "
+        )
+
+        codomain_str = (
+            "" if fd.dim_codomain == 1
+            else f"(currently is  {fd.dim_codomain})"
+        )
+
+        raise ValueError(
+            f"The functional data must be univariate, i.e., "
+            f"with dim_domain=1 {domain_str}"
+            f"and dim_codomain=1 {codomain_str}",
+        )
 
 
 def _to_grid(X, y, eval_points=None):

--- a/skfda/preprocessing/registration/base.py
+++ b/skfda/preprocessing/registration/base.py
@@ -4,13 +4,21 @@ This module contains the abstract base class for all registration methods.
 """
 
 from abc import ABC
+
+import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
+
 from ... import FData
 
-class RegistrationTransformer(ABC, BaseEstimator, TransformerMixin):
+
+class RegistrationTransformer(
+    ABC,
+    BaseEstimator,  # type: ignore
+    TransformerMixin,  # type: ignore
+):
     """Base class for the registration methods."""
 
-    def score(self, X: FData, y=None):
+    def score(self, X: FData, y: None=None) -> np.ndarray:
         r"""Returns the percentage of total variation removed.
 
         Computes the squared multiple correlation index of the proportion of

--- a/skfda/preprocessing/registration/base.py
+++ b/skfda/preprocessing/registration/base.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Registration method.
+"""Registration methods base class.
+
 This module contains the abstract base class for all registration methods.
+
 """
 
 from abc import ABC
 
-import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from ... import FData
@@ -18,8 +19,8 @@ class RegistrationTransformer(
 ):
     """Base class for the registration methods."""
 
-    def score(self, X: FData, y: None=None) -> np.ndarray:
-        r"""Returns the percentage of total variation removed.
+    def score(self, X: FData, y: None = None) -> float:
+        r"""Return the percentage of total variation removed.
 
         Computes the squared multiple correlation index of the proportion of
         the total variation due to phase, defined as:

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -184,12 +184,12 @@ class TestElasticRegistration(unittest.TestCase):
         with np.testing.assert_raises(ValueError):
             reg.transform(self.unimodal_samples[0])
 
-    def test_score(self):
-        """Test score method of the transformer"""
+    def test_score(self) -> None:
+        """Test score method of the transformer."""
         reg = ElasticRegistration()
         reg.fit(self.unimodal_samples)
         score = reg.score(self.unimodal_samples)
-        np.testing.assert_almost_equal(score,  0.9994225)
+        np.testing.assert_almost_equal(score, 0.999389)
 
     def test_warping_mean(self):
         warping = make_random_warping(start=-1, random_state=0)

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -376,20 +376,21 @@ class TestRegistrationValidation(unittest.TestCase):
         score = scorer(self.shift_registration, self.X)
         np.testing.assert_allclose(score, 0.923962, rtol=1e-6)
 
-    def test_pairwise_correlation(self):
+    def test_pairwise_correlation(self) -> None:
+        """Test PairwiseCorrelation."""
         scorer = PairwiseCorrelation()
         score = scorer(self.shift_registration, self.X)
         np.testing.assert_allclose(score, 1.816228, rtol=1e-6)
 
     def test_mse_decomposition(self) -> None:
-
+        """Test obtaining all stats from AmplitudePhaseDecomposition."""
         fd = make_multimodal_samples(n_samples=3, random_state=1)
         landmarks = make_multimodal_landmarks(n_samples=3, random_state=1)
         landmarks = landmarks.squeeze()
         warping = landmark_registration_warping(fd, landmarks)
         fd_registered = fd.compose(warping)
-        scorer = AmplitudePhaseDecomposition(return_stats=True)
-        ret = scorer.score_function(fd, fd_registered)
+        scorer = AmplitudePhaseDecomposition()
+        ret = scorer.stats(fd, fd_registered)
         np.testing.assert_allclose(ret.mse_amplitude, 0.0009465483)
         np.testing.assert_allclose(ret.mse_phase, 0.1051769136)
         np.testing.assert_allclose(ret.r_squared, 0.9910806875)

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,21 +1,33 @@
-from skfda import FDataGrid
-from skfda._utils import _check_estimator
-from skfda.datasets import (make_multimodal_samples, make_multimodal_landmarks,
-                            make_sinusoidal_process)
-from skfda.exploratory.stats import mean
-from skfda.preprocessing.registration import (
-    normalize_warping, invert_warping, landmark_shift_deltas, landmark_shift,
-    landmark_registration_warping, landmark_registration, ShiftRegistration)
-from skfda.preprocessing.registration.validation import (
-    AmplitudePhaseDecomposition, LeastSquares,
-    SobolevLeastSquares, PairwiseCorrelation)
-from skfda.representation.basis import Fourier
-from skfda.representation.interpolation import SplineInterpolation
 import unittest
 
+import numpy as np
 from sklearn.exceptions import NotFittedError
 
-import numpy as np
+from skfda import FDataGrid
+from skfda._utils import _check_estimator
+from skfda.datasets import (
+    make_multimodal_landmarks,
+    make_multimodal_samples,
+    make_sinusoidal_process,
+)
+from skfda.exploratory.stats import mean
+from skfda.preprocessing.registration import (
+    ShiftRegistration,
+    invert_warping,
+    landmark_registration,
+    landmark_registration_warping,
+    landmark_shift,
+    landmark_shift_deltas,
+    normalize_warping,
+)
+from skfda.preprocessing.registration.validation import (
+    AmplitudePhaseDecomposition,
+    LeastSquares,
+    PairwiseCorrelation,
+    SobolevLeastSquares,
+)
+from skfda.representation.basis import Fourier
+from skfda.representation.interpolation import SplineInterpolation
 
 
 class TestWarping(unittest.TestCase):
@@ -327,51 +339,49 @@ class TestShiftRegistration(unittest.TestCase):
 
 
 class TestRegistrationValidation(unittest.TestCase):
-    """Test shift registration"""
+    """Test validation functions."""
 
-    def setUp(self):
-        """Initialization of samples"""
+    def setUp(self) -> None:
+        """Initialize the samples."""
         self.X = make_sinusoidal_process(error_std=0, random_state=0)
         self.shift_registration = ShiftRegistration().fit(self.X)
 
-    def test_amplitude_phase_score(self):
+    def test_amplitude_phase_score(self) -> None:
+        """Test basic usage of AmplitudePhaseDecomposition."""
         scorer = AmplitudePhaseDecomposition()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.971144, rtol=1e-6)
 
-    def test_amplitude_phase_score_with_output_points(self):
-        eval_points = self.X.grid_points[0]
-        scorer = AmplitudePhaseDecomposition(eval_points=eval_points)
-        score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
-
-    def test_amplitude_phase_score_with_basis(self):
+    def test_amplitude_phase_score_with_basis(self) -> None:
+        """Test the AmplitudePhaseDecomposition with FDataBasis."""
         scorer = AmplitudePhaseDecomposition()
         X = self.X.to_basis(Fourier())
         score = scorer(self.shift_registration, X)
         np.testing.assert_allclose(score, 0.995087, rtol=1e-6)
 
-    def test_default_score(self):
-
+    def test_default_score(self) -> None:
+        """Test default score of a registration transformer."""
         score = self.shift_registration.score(self.X)
-        np.testing.assert_allclose(score, 0.972095, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.971144, rtol=1e-6)
 
-    def test_least_squares_score(self):
+    def test_least_squares_score(self) -> None:
+        """Test LeastSquares."""
         scorer = LeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.795933, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.953355, rtol=1e-6)
 
-    def test_sobolev_least_squares_score(self):
+    def test_sobolev_least_squares_score(self) -> None:
+        """Test SobolevLeastSquares."""
         scorer = SobolevLeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.76124, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.923962, rtol=1e-6)
 
     def test_pairwise_correlation(self):
         scorer = PairwiseCorrelation()
         score = scorer(self.shift_registration, self.X)
         np.testing.assert_allclose(score, 1.816228, rtol=1e-6)
 
-    def test_mse_decomposition(self):
+    def test_mse_decomposition(self) -> None:
 
         fd = make_multimodal_samples(n_samples=3, random_state=1)
         landmarks = make_multimodal_landmarks(n_samples=3, random_state=1)
@@ -379,11 +389,11 @@ class TestRegistrationValidation(unittest.TestCase):
         warping = landmark_registration_warping(fd, landmarks)
         fd_registered = fd.compose(warping)
         scorer = AmplitudePhaseDecomposition(return_stats=True)
-        ret = scorer.score_function(fd, fd_registered, warping=warping)
-        np.testing.assert_allclose(ret.mse_amp, 0.0009866997121476962)
-        np.testing.assert_allclose(ret.mse_pha, 0.11576935495450151)
-        np.testing.assert_allclose(ret.r_squared, 0.9915489952877273)
-        np.testing.assert_allclose(ret.c_r, 0.999999, rtol=1e-6)
+        ret = scorer.score_function(fd, fd_registered)
+        np.testing.assert_allclose(ret.mse_amplitude, 0.0009465483)
+        np.testing.assert_allclose(ret.mse_phase, 0.1051769136)
+        np.testing.assert_allclose(ret.r_squared, 0.9910806875)
+        np.testing.assert_allclose(ret.c_r, 0.9593073773)
 
     def test_raises_amplitude_phase(self):
         scorer = AmplitudePhaseDecomposition()
@@ -394,7 +404,7 @@ class TestRegistrationValidation(unittest.TestCase):
 
         # Inconsistent number of functions registered
         with np.testing.assert_raises(ValueError):
-            scorer.score_function(self.X, self.X, warping=self.X[:2])
+            scorer.score_function(self.X, self.X[:-1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added typing and refactor code according to our style guide.
- All but one scorer do not longer require the discretization of functions, relying instead on the L2 distance.
- Fixed some errors where the L2 distance was not properly squared to match the formula.

@pablomm I know you are not longer as involved with the project as before, but as you are the original author of this module I appreciate any suggestions that you can make.