### PR TITLE
Preserve attributes in FDataBasis derivative, and do not change dataset_name

### DIFF
--- a/examples/plot_elastic_registration.py
+++ b/examples/plot_elastic_registration.py
@@ -10,13 +10,12 @@ Shows the usage of the elastic registration to perform a groupwise alignment.
 
 # sphinx_gallery_thumbnail_number = 5
 
-import skfda
-from skfda.datasets import make_multimodal_samples, fetch_growth
-from skfda.preprocessing.registration import ElasticRegistration
-from skfda.preprocessing.registration.elastic import elastic_mean
-
 import numpy as np
 
+import skfda
+from skfda.datasets import fetch_growth, make_multimodal_samples
+from skfda.preprocessing.registration import ElasticRegistration
+from skfda.preprocessing.registration.elastic import elastic_mean
 
 ##############################################################################
 # In the example of pairwise alignment was shown the usage of
@@ -31,7 +30,7 @@ import numpy as np
 #
 # We will create a synthetic dataset to show the basic usage of the
 # registration.
-#
+
 fd = make_multimodal_samples(n_modes=2, stop=4, random_state=1)
 fd.plot()
 
@@ -78,15 +77,16 @@ fd = growth['data'][growth['target'] == 0]
 
 # Obtain velocity curves
 fd.interpolation = skfda.representation.interpolation.SplineInterpolation(3)
-fd = fd.to_grid(np.linspace(*fd.domain_range[0], 200)).derivative()
-fd = fd.to_grid(np.linspace(*fd.domain_range[0], 50))
-fd.plot()
+fd_derivative = fd.to_grid(np.linspace(*fd.domain_range[0], 200)).derivative()
+fd_derivative = fd_derivative.to_grid(np.linspace(*fd.domain_range[0], 50))
+fd_derivative.dataset_name = f"{fd.dataset_name} - derivative"
+fd_derivative.plot()
 
 ##############################################################################
 # We now show the aligned curves:
 
-fd_align = elastic_registration.fit_transform(fd)
-fd_align.dataset_name += " - aligned"
+fd_align = elastic_registration.fit_transform(fd_derivative)
+fd_align.dataset_name = f"{fd.dataset_name} - derivative aligned"
 
 fd_align.plot()
 
@@ -94,10 +94,10 @@ fd_align.plot()
 # * Srivastava, Anuj & Klassen, Eric P. (2016). Functional and shape data
 #   analysis. In *Functional Data and Elastic Registration* (pp. 73-122).
 #   Springer.
-# 
+#
 # * Tucker, J. D., Wu, W. and Srivastava, A. (2013). Generative Models for
-#   Functional Data using Phase and Amplitude Separation. Computational Statistics
-#   and Data Analysis, Vol. 61, 50-66.
+#   Functional Data using Phase and Amplitude Separation.
+#   Computational Statistics and Data Analysis, Vol. 61, 50-66.
 #
 # * J. S. Marron, James O. Ramsay, Laura M. Sangalli and Anuj Srivastava
 #   (2015). Functional Data Analysis of Amplitude and Phase Variation.

--- a/examples/plot_explore.py
+++ b/examples/plot_explore.py
@@ -9,10 +9,9 @@ means and derivatives.
 # Author: Miguel Carbajo Berrocal
 # License: MIT
 
-import skfda
-
 import numpy as np
 
+import skfda
 
 ##############################################################################
 # In this example we are going to explore the functional properties of the
@@ -33,11 +32,18 @@ fat = y['fat'].values
 low_fat = fat < 20
 labels = np.full(fd.n_samples, 'high fat')
 labels[low_fat] = 'low fat'
-colors = {'high fat': 'red',
-          'low fat': 'blue'}
+colors = {
+    'high fat': 'red',
+    'low fat': 'blue',
+}
 
-fig = fd.plot(group=labels, group_colors=colors,
-              linewidth=0.5, alpha=0.7, legend=True)
+fig = fd.plot(
+    group=labels,
+    group_colors=colors,
+    linewidth=0.5,
+    alpha=0.7,
+    legend=True,
+)
 
 ##############################################################################
 # The means of each group are the following ones.
@@ -47,9 +53,13 @@ mean_high = skfda.exploratory.stats.mean(fd[~low_fat])
 
 means = mean_high.concatenate(mean_low)
 
-means.dataset_name = fd.dataset_name + ' - means'
-means.plot(group=['high fat', 'low fat'], group_colors=colors,
-           linewidth=0.5, legend=True)
+means.dataset_name = f"{fd.dataset_name} - means"
+means.plot(
+    group=['high fat', 'low fat'],
+    group_colors=colors,
+    linewidth=0.5,
+    legend=True,
+)
 
 ##############################################################################
 # In this dataset, the vertical shift in the original trajectories is not
@@ -60,11 +70,23 @@ means.plot(group=['high fat', 'low fat'], group_colors=colors,
 # The first derivative is shown below:
 
 fdd = fd.derivative()
-fig = fdd.plot(group=labels, group_colors=colors,
-               linewidth=0.5, alpha=0.7, legend=True)
+fdd.dataset_name = f"{fd.dataset_name} - derivative"
+fig = fdd.plot(
+    group=labels,
+    group_colors=colors,
+    linewidth=0.5,
+    alpha=0.7,
+    legend=True,
+)
 
 ##############################################################################
 # We now show the second derivative:
 fdd = fd.derivative(order=2)
-fig = fdd.plot(group=labels, group_colors=colors,
-               linewidth=0.5, alpha=0.7, legend=True)
+fdd.dataset_name = f"{fd.dataset_name} - second derivative"
+fig = fdd.plot(
+    group=labels,
+    group_colors=colors,
+    linewidth=0.5,
+    alpha=0.7,
+    legend=True,
+)

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -348,7 +348,7 @@ class FDataBasis(FData):  # noqa: WPS214
             order,
         )
 
-        return FDataBasis(basis, coefficients)
+        return self.copy(basis=basis, coefficients=coefficients)
 
     def sum(  # noqa: WPS125
         self: T,

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -465,14 +465,8 @@ class FDataGrid(FData):  # noqa: WPS214
         ])
         data_matrix = operator(self.data_matrix.astype(float))
 
-        dataset_name = (
-            f"{self.dataset_name} - {order} derivative"
-            if self.dataset_name else None
-        )
-
         return self.copy(
             data_matrix=data_matrix,
-            dataset_name=dataset_name,
         )
 
     def _check_same_dimensions(self: T, other: T) -> None:


### PR DESCRIPTION
Fix #324.

Remove the change of dataset_name for FDataGrid derivative, and fix the
examples that relied in the old behaviour.