### PR TITLE
Handle ops between FDGrid and Python functions

### DIFF
--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -711,7 +711,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def _get_op_matrix(
         self,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> Union[None, float, NDArrayFloat, NDArrayInt]:
         if isinstance(other, numbers.Real):
             return float(other)
@@ -742,13 +742,14 @@ class FDataGrid(FData):  # noqa: WPS214
             return other.data_matrix
 
         elif isinstance(other, Callable):
-            return np.array([[other(x) for x in _gp] for _gp in self.grid_points]).T
+            coordinates = np.array(np.meshgrid(*self.grid_points, indexing='ij')).T.reshape(-1, self.dim_domain)
+            return np.array([other(x) for x in coordinates]).reshape((1,) + self.data_matrix.shape[1:])
 
         return None
 
     def __add__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -759,14 +760,14 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __radd__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         return self.__add__(other)
 
     def __sub__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -777,7 +778,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __rsub__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -788,7 +789,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __mul__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -799,14 +800,14 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __rmul__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         return self.__mul__(other)
 
     def __truediv__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -817,7 +818,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __rtruediv__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable[[Union[float, NDArrayFloat]], Union[float, NDArrayFloat]]],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -13,6 +13,7 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Iterable,
     Optional,
     Sequence,
@@ -710,12 +711,11 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def _get_op_matrix(
         self,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> Union[None, float, NDArrayFloat, NDArrayInt]:
         if isinstance(other, numbers.Real):
             return float(other)
         elif isinstance(other, np.ndarray):
-
             if other.shape in {(), (1,)}:
                 return other
             elif other.shape == (self.n_samples,):
@@ -741,11 +741,14 @@ class FDataGrid(FData):  # noqa: WPS214
             self._check_same_dimensions(other)
             return other.data_matrix
 
+        elif isinstance(other, Callable):
+            return np.array([[other(x) for x in _gp] for _gp in self.grid_points]).T
+
         return None
 
     def __add__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -756,14 +759,14 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __radd__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         return self.__add__(other)
 
     def __sub__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -774,7 +777,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __rsub__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -785,7 +788,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __mul__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -796,14 +799,14 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __rmul__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         return self.__mul__(other)
 
     def __truediv__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)
@@ -814,7 +817,7 @@ class FDataGrid(FData):  # noqa: WPS214
 
     def __rtruediv__(
         self: T,
-        other: Union[T, NDArrayFloat, NDArrayInt, float],
+        other: Union[T, NDArrayFloat, NDArrayInt, float, Callable],
     ) -> T:
 
         data_matrix = self._get_op_matrix(other)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -151,6 +151,21 @@ class TestFDataGrid(unittest.TestCase):
 
     def test_add(self):
         fd1 = FDataGrid([[1, 2, 3, 4], [2, 3, 4, 5]], [0, 1, 2, 3])
+        fd_2d_in = FDataGrid([
+            [[[0], [0]], [[0], [0]]],
+            [[[1], [1]], [[1], [1]]]],
+            [[0, 1], [0, 1]]
+        )
+        fd_2d_out = FDataGrid([
+            [[0, 0], [1, 1]],
+            [[1, 1], [0, 0]]],
+            [[0, 1]]
+        )
+        fd_2d_in_out = FDataGrid([
+            [[[0, 0], [0, 1]], [[1, 0], [1, 1]]],
+            [[[1, 1], [1, 0]], [[0, 1], [0, 0]]]],
+            [[0, 1], [0, 1]]
+        )
 
         fd2 = fd1 + fd1
         np.testing.assert_array_equal(fd2.data_matrix[..., 0],
@@ -163,6 +178,24 @@ class TestFDataGrid(unittest.TestCase):
         fd2 = fd1 + (lambda x: x)
         np.testing.assert_array_equal(fd2.data_matrix[..., 0],
                                       [[1, 3, 5, 7], [2, 4, 6, 8]])
+
+        fd2 = fd_2d_in + np.max
+        np.testing.assert_array_equal(fd2.data_matrix[..., 0], [
+            [[0, 1], [1, 1]],
+            [[1, 2], [2, 2]]    
+        ])
+
+        fd2 = fd_2d_out + (lambda x: np.array([x, x]))
+        np.testing.assert_array_equal(fd2.data_matrix, [
+            [[0, 0], [2, 2]],
+            [[1, 1], [1, 1]]
+        ])
+
+        fd2 = fd_2d_in_out + (lambda x: x)
+        np.testing.assert_array_equal(fd2.data_matrix, [
+            [[[0, 0], [1, 1]], [[1, 1], [2, 2]]],
+            [[[1, 1], [2, 0]], [[0, 2], [1, 1]]]
+        ])
 
         fd2 = fd1 + np.array(2)
         np.testing.assert_array_equal(fd2.data_matrix[..., 0],

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -7,7 +7,6 @@ import scipy.stats.mstats
 
 import numpy as np
 
-
 class TestFDataGrid(unittest.TestCase):
 
     # def setUp(self): could be defined for set up before any test
@@ -151,7 +150,7 @@ class TestFDataGrid(unittest.TestCase):
             fd.data_matrix)
 
     def test_add(self):
-        fd1 = FDataGrid([[1, 2, 3, 4], [2, 3, 4, 5]])
+        fd1 = FDataGrid([[1, 2, 3, 4], [2, 3, 4, 5]], [0, 1, 2, 3])
 
         fd2 = fd1 + fd1
         np.testing.assert_array_equal(fd2.data_matrix[..., 0],
@@ -160,6 +159,10 @@ class TestFDataGrid(unittest.TestCase):
         fd2 = fd1 + 2
         np.testing.assert_array_equal(fd2.data_matrix[..., 0],
                                       [[3, 4, 5, 6], [4, 5, 6, 7]])
+
+        fd2 = fd1 + (lambda x: x)
+        np.testing.assert_array_equal(fd2.data_matrix[..., 0],
+                                      [[1, 3, 5, 7], [2, 4, 6, 8]])
 
         fd2 = fd1 + np.array(2)
         np.testing.assert_array_equal(fd2.data_matrix[..., 0],


### PR DESCRIPTION
Hi there 👋

The goal of this PR is to be able to make it easier to do operations between FDGrids and normal python functions, like this
```python
fd + (lambda x: x**2)
```

The feature seems to work and tests are still green but the PR probably needs a little bit more work to be mergeable (I don't think I manage well all possible grids since it's not clear to me what is possible to have as a grid), so I would be happy to get guidance on this.

Cheers!
