### PR TITLE
Speed up evaluation of FDataGrid

### DIFF
--- a/examples/plot_composition.py
+++ b/examples/plot_composition.py
@@ -10,12 +10,10 @@ This example shows the composition of multidimensional FDataGrids.
 
 # sphinx_gallery_thumbnail_number = 3
 
-import skfda
-
+import numpy as np
 from mpl_toolkits.mplot3d import axes3d
 
-import numpy as np
-
+import skfda
 
 ##############################################################################
 # Function composition can be applied to our data once is in functional
@@ -44,7 +42,8 @@ g = skfda.FDataGrid(data_matrix, grid_points)
 
 # Sets cubic interpolation
 g.interpolation = skfda.representation.interpolation.SplineInterpolation(
-    interpolation_order=3)
+    interpolation_order=3,
+)
 
 # Plots the surface
 g.plot()
@@ -55,7 +54,7 @@ g.plot()
 # :math:`g \circ f:\mathbb{R} \rightarrow \mathbb{R}` will be another
 # functional object with the values of :math:`g` along the path given by
 # :math:`f`.
-#
+
 
 # Creation of circunference in parametric form
 t = np.linspace(0, 2 * np.pi, 100)
@@ -71,10 +70,9 @@ gof.plot()
 ##############################################################################
 # In the following chart it is plotted the curve
 # :math:`(10 \, \cos(t), 10 \, sin(t), g \circ f (t))` and the surface.
-#
 
 # Plots surface
-fig = g.plot(alpha=.8)
+fig = g.plot(alpha=0.8)
 
 # Plots path along the surface
 path = f(t)[0]
@@ -85,4 +83,3 @@ fig
 ##############################################################################
 # [1] Function composition `https://en.wikipedia.org/wiki/Function_composition
 # <https://en.wikipedia.org/wiki/Function_composition>`_.
-#

--- a/examples/plot_composition.py
+++ b/examples/plot_composition.py
@@ -40,11 +40,6 @@ grid_points = [X[0, :], Y[:, 0]]
 
 g = skfda.FDataGrid(data_matrix, grid_points)
 
-# Sets cubic interpolation
-g.interpolation = skfda.representation.interpolation.SplineInterpolation(
-    interpolation_order=3,
-)
-
 # Plots the surface
 g.plot()
 

--- a/examples/plot_interpolation.py
+++ b/examples/plot_interpolation.py
@@ -61,35 +61,6 @@ fd.scatter(fig=fig)
 plt.show()
 
 ##############################################################################
-# Smooth interpolation could be performed with the attribute
-# ``smoothness_parameter`` of the spline interpolation.
-
-# Sample with noise
-fd_smooth = skfda.datasets.make_sinusoidal_process(
-    n_samples=1,
-    n_features=30,
-    random_state=1,
-    error_std=0.3,
-)
-
-# Cubic interpolation
-fd_smooth.interpolation = SplineInterpolation(interpolation_order=3)
-
-fig = fd_smooth.plot(label="Cubic")
-
-# Smooth interpolation
-fd_smooth.interpolation = SplineInterpolation(
-    interpolation_order=3,
-    smoothness_parameter=1.5,
-)
-
-fd_smooth.plot(fig=fig, label="Cubic smoothed")
-
-fd_smooth.scatter(fig=fig)
-fig.legend()
-plt.show()
-
-##############################################################################
 # Sometimes our samples are required to be monotone, in these cases it is
 # possible to use monotone cubic interpolation with the attribute
 # ``monotone``. A piecewise cubic hermite interpolating polynomial (PCHIP)
@@ -134,30 +105,10 @@ plt.show()
 
 ##############################################################################
 # In the following figure it is shown the result of the cubic interpolation
-# applied to the surface.
-#
-# The degree of the interpolation polynomial does not have to coincide in both
-# directions, for example, cubic interpolation in the first
-# component and quadratic in the second one could be defined using a tuple
-# with the values (3,2).
+# applied to the surface (requires SciPy >= 1.9).
 
 fd.interpolation = SplineInterpolation(interpolation_order=3)
 
 fig = fd.plot()
 fd.scatter(fig=fig)
 plt.show()
-
-##############################################################################
-# The following table shows the interpolation methods available by the class
-# :class:`~skfda.representation.interpolation.SplineInterpolation` depending
-# on the domain dimension.
-#
-# +------------------+--------+----------------+----------+-------------+
-# | Domain dimension | Linear | Up to degree 5 | Monotone |  Smoothing  |
-# +==================+========+================+==========+=============+
-# |         1        |   ✔    |       ✔        |    ✔     |      ✔      |
-# +------------------+--------+----------------+----------+-------------+
-# |         2        |   ✔    |       ✔        |    ✖     |      ✔      |
-# +------------------+--------+----------------+----------+-------------+
-# |     3 or more    |   ✔    |       ✖        |    ✖     |      ✖      |
-# +------------------+--------+----------------+----------+-------------+

--- a/examples/plot_interpolation.py
+++ b/examples/plot_interpolation.py
@@ -104,10 +104,10 @@ fd.scatter(fig=fig)
 plt.show()
 
 ##############################################################################
-# In the following figure it is shown the result of the cubic interpolation
-# applied to the surface (requires SciPy >= 1.9).
+# In the following figure it is shown the result of the constant interpolation
+# applied to the surface.
 
-fd.interpolation = SplineInterpolation(interpolation_order=3)
+fd.interpolation = SplineInterpolation(interpolation_order=0)
 
 fig = fd.plot()
 fd.scatter(fig=fig)

--- a/skfda/exploratory/stats/_functional_transformers.py
+++ b/skfda/exploratory/stats/_functional_transformers.py
@@ -251,7 +251,7 @@ def occupation_measure(
         ...     ),
         ...     decimals=2,
         ... )
-        array([[ 0.98,  1.02],
+        array([[ 0.98,  1.  ],
                [ 0.5 ,  0.52],
                [ 6.28,  0.  ]])
 

--- a/skfda/preprocessing/feature_construction/_function_transformers.py
+++ b/skfda/preprocessing/feature_construction/_function_transformers.py
@@ -144,7 +144,7 @@ class OccupationMeasureTransformer(BaseEstimator, TransformerMixin):
         ... )
 
         >>> np.around(occupation_measure.fit_transform(fd_grid), decimals=2)
-        array([[ 0.98,  1.02],
+        array([[ 0.98,  1.  ],
                [ 0.5 ,  0.52],
                [ 6.28,  0.  ]])
     """

--- a/skfda/representation/interpolation.py
+++ b/skfda/representation/interpolation.py
@@ -4,414 +4,111 @@ Module to interpolate functional data objects.
 from __future__ import annotations
 
 import abc
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Iterable,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import numpy as np
 from scipy.interpolate import (
     PchipInterpolator,
-    RectBivariateSpline,
     RegularGridInterpolator,
-    UnivariateSpline,
+    make_interp_spline,
 )
 
-from ._typing import ArrayLike, NDArrayFloat
+from ._typing import ArrayLike, EvaluationPoints, NDArrayFloat
 from .evaluator import Evaluator
 
 if TYPE_CHECKING:
-    from . import FData
-
-SplineCallable = Callable[..., np.ndarray]
+    from . import FDataGrid
 
 
-class _SplineList(abc.ABC):
-    """ABC for list of interpolations."""
-
-    def __init__(
-        self,
-        fdatagrid: FData,
-        interpolation_order: Union[int, Sequence[int]] = 1,
-        smoothness_parameter: float = 0,
-    ):
-
-        super().__init__()
-
-        self.fdatagrid = fdatagrid
-        self.interpolation_order = interpolation_order
-        self.smoothness_parameter = smoothness_parameter
-        self.splines: Sequence[Sequence[SplineCallable]]
-
-    # @abc.abstractmethod
-    # @property
-    # def splines(self) -> Sequence[SplineCallable]:
-        # pass
+class _BaseInterpolation(Evaluator):
+    """ABC for interpolations."""
 
     @abc.abstractmethod
-    def _evaluate_one(
+    def _evaluate_aligned(
         self,
-        spline: SplineCallable,
-        eval_points: NDArrayFloat,
+        fdata: FDataGrid,
+        eval_points: EvaluationPoints,
     ) -> NDArrayFloat:
-        """Evaluate one spline of the list."""
+        """Evaluate at aligned points."""
         pass
 
-    def _evaluate_codomain(
+    def _evaluate_unaligned(
         self,
-        spline_list: Sequence[SplineCallable],
-        eval_points: NDArrayFloat,
+        fdata: FDataGrid,
+        eval_points: EvaluationPoints,
     ) -> NDArrayFloat:
-        """Evaluate a multidimensional sample."""
-        return np.array([
-            self._evaluate_one(spl, eval_points)
-            for spl in spline_list
-        ]).T
+        """Evaluate at unaligned points."""
+        return np.vstack([
+            self._evaluate_aligned(f, e)
+            for f, e in zip(fdata, eval_points)
+        ])
 
-    def evaluate(
+    def _evaluate(  # noqa: D102
         self,
-        fdata: FData,
+        fdata: FDataGrid,
         eval_points: ArrayLike,
         *,
         aligned: bool = True,
     ) -> NDArrayFloat:
 
-        res: NDArrayFloat
+        from ..misc.validation import validate_evaluation_points
 
-        if aligned:
+        eval_points = validate_evaluation_points(
+            eval_points,
+            aligned=aligned,
+            n_samples=fdata.n_samples,
+            dim_domain=fdata.dim_domain,
+        )
 
-            eval_points = np.asarray(eval_points)
-
-            # Points evaluated inside the domain
-            res = np.apply_along_axis(
-                self._evaluate_codomain,
-                1,
-                self.splines,
-                eval_points,
-            )
-
-            res = res.reshape(
-                fdata.n_samples,
-                eval_points.shape[0],
-                fdata.dim_codomain,
-            )
-
-        else:
-            eval_points = cast(Iterable[ArrayLike], eval_points)
-
-            res = np.asarray([
-                self._evaluate_codomain(s, np.asarray(e))
-                for s, e in zip(self.splines, eval_points)
-            ])
-
-        return res
+        return (
+            self._evaluate_aligned(fdata, eval_points)
+            if aligned
+            else self._evaluate_unaligned(fdata, eval_points)
+        )
 
 
-class _SplineList1D(_SplineList):
-    """List of interpolations for curves.
-
-    List of interpolations for objects with domain
-    dimension = 1. Calling internally during the creation of the
-    evaluator.
-
-    Uses internally the scipy interpolation UnivariateSpline or
-    PchipInterpolator.
-
-    Args:
-        fdatagrid (FDatagrid): Fdatagrid to interpolate.
-        interpolation_order (int, optional): Order of the interpolation, 1
-            for linear interpolation, 2 for cuadratic, 3 for cubic and so
-            on. In case of curves and surfaces there is available
-            interpolation up to degree 5. For higher dimensional objects
-            only linear or nearest interpolation is available. Default
-            lineal interpolation.
-        smoothness_parameter (float, optional): Penalisation to perform
-            smoothness interpolation. Option only available for curves and
-            surfaces. If 0 the residuals of the interpolation will be 0.
-            Defaults 0.
-        monotone (boolean, optional): Performs monotone interpolation in
-            curves using a PCHIP interpolator. Only valid for curves (domain
-            dimension equal to 1) and interpolation order equal to 1 or 3.
-            Defaults false.
-
-    Returns:
-        (np.ndarray): Array of size n_samples x dim_codomain with the
-        corresponding interpolation of the sample i, and image dimension j
-        in the entry (i,j) of the array.
-
-    Raises:
-        ValueError: If the value of the interpolation k is not valid.
-
-    """
+class _RegularGridInterpolatorWrapper():
 
     def __init__(
         self,
-        fdatagrid: FData,
-        interpolation_order: Union[int, Sequence[int]] = 1,
-        smoothness_parameter: float = 0,
-        monotone: bool = False,
-    ):
-
-        super().__init__(
-            fdatagrid=fdatagrid,
-            interpolation_order=interpolation_order,
-            smoothness_parameter=smoothness_parameter,
-        )
-
-        self.monotone = monotone
-
-        if (
-            isinstance(self.interpolation_order, Sequence)
-            or not 1 <= self.interpolation_order <= 5
-        ):
-            raise ValueError(
-                f"Invalid degree of interpolation "
-                f"({self.interpolation_order}). Must be "
-                f"an integer greater than 0 and lower or "
-                f"equal than 5.",
-            )
-
-        if self.monotone and self.smoothness_parameter != 0:
-            raise ValueError(
-                "Smoothing interpolation is not supported with "
-                "monotone interpolation",
-            )
-
-        if self.monotone and self.interpolation_order in {2, 4}:
-            raise ValueError(
-                f"monotone interpolation of degree "
-                f"{self.interpolation_order}"
-                f"not supported.",
-            )
-
-        # Monotone interpolation of degree 1 is performed with linear spline
-        monotone = self.monotone
-        if self.monotone and self.interpolation_order == 1:
-            monotone = False
-
-        grid_points = fdatagrid.grid_points[0]
-
-        if monotone:
-            def constructor(  # noqa: WPS430
-                data: NDArrayFloat,
-            ) -> SplineCallable:
-                """Construct an unidimensional cubic monotone interpolation."""
-                return PchipInterpolator(grid_points, data)
-
-        else:
-
-            def constructor(  # noqa: WPS430, WPS440
-                data: NDArrayFloat,
-            ) -> SplineCallable:
-                """Construct an unidimensional interpolation."""
-                return UnivariateSpline(
-                    grid_points,
-                    data,
-                    s=self.smoothness_parameter,
-                    k=self.interpolation_order,
-                )
-
-        self.splines = np.apply_along_axis(
-            constructor,
-            1,
-            fdatagrid.data_matrix,
-        )
-
-    def _evaluate_one(
-        self,
-        spline: SplineCallable,
-        eval_points: NDArrayFloat,
-    ) -> NDArrayFloat:
-        try:
-            return spline(eval_points)[:, 0]
-        except ValueError:
-            return np.zeros_like(eval_points)
-
-
-class _SplineList2D(_SplineList):
-    """List of interpolations for surfaces.
-
-    List of interpolations for objects with domain
-    dimension = 2. Calling internally during the creationg of the
-    evaluator.
-
-    Uses internally the scipy interpolation RectBivariateSpline.
-
-    Args:
-        fdatagrid (FDatagrid): Fdatagrid to interpolate.
-        interpolation_order (int, optional): Order of the interpolation, 1
-            for linear interpolation, 2 for cuadratic, 3 for cubic and so
-            on. In case of curves and surfaces there is available
-            interpolation up to degree 5. For higher dimensional objects
-            only linear or nearest interpolation is available. Default
-            lineal interpolation.
-        smoothness_parameter (float, optional): Penalisation to perform
-            smoothness interpolation. Option only available for curves and
-            surfaces. If 0 the residuals of the interpolation will be 0.
-            Defaults 0.
-        monotone (boolean, optional): Performs monotone interpolation in
-            curves using a PCHIP interpolator. Only valid for curves (domain
-            dimension equal to 1) and interpolation order equal to 1 or 3.
-            Defaults false.
-
-    Returns:
-        (np.ndarray): Array of size n_samples x dim_codomain with the
-        corresponding interpolation of the sample i, and image dimension j
-        in the entry (i,j) of the array.
-
-    Raises:
-        ValueError: If the value of the interpolation k is not valid.
-
-    """
-
-    def __init__(
-        self,
-        fdatagrid: FData,
-        interpolation_order: Union[int, Sequence[int]] = 1,
-        smoothness_parameter: float = 0,
-    ):
-
-        super().__init__(
-            fdatagrid=fdatagrid,
-            interpolation_order=interpolation_order,
-            smoothness_parameter=smoothness_parameter,
-        )
-
-        if isinstance(self.interpolation_order, int):
-            kx = self.interpolation_order
-            ky = kx
-        elif len(self.interpolation_order) == 2:
-            kx = self.interpolation_order[0]
-            ky = self.interpolation_order[1]
-        else:
-            raise ValueError("k should be numeric or a tuple of length 2.")
-
-        if kx > 5 or kx <= 0 or ky > 5 or ky <= 0:
-            raise ValueError(
-                f"Invalid degree of interpolation ({kx},{ky}). "
-                f"Must be an integer greater than 0 and lower or "
-                f"equal than 5.",
-            )
-
-        # Matrix of splines
-        splines = np.empty(
-            (fdatagrid.n_samples, fdatagrid.dim_codomain),
-            dtype=object,
-        )
-
-        for i in range(fdatagrid.n_samples):
-            for j in range(fdatagrid.dim_codomain):
-                splines[i, j] = RectBivariateSpline(
-                    fdatagrid.grid_points[0],
-                    fdatagrid.grid_points[1],
-                    fdatagrid.data_matrix[i, :, :, j],
-                    kx=kx,
-                    ky=ky,
-                    s=self.smoothness_parameter,
-                )
-
-        self.splines = splines
-
-    def _evaluate_one(
-        self,
-        spline: SplineCallable,
-        eval_points: np.ndarray,
-    ) -> np.ndarray:
-
-        return spline(
-            eval_points[:, 0],
-            eval_points[:, 1],
-            grid=False,
-        )
-
-
-class _SplineListND(_SplineList):
-    """
-    List of interpolations.
-
-    List of interpolations for objects with domain
-    dimension > 2. Calling internally during the creationg of the
-    evaluator.
-
-    Only linear and nearest interpolations are available for objects with
-    domain dimension >= 3. Uses internally the scipy interpolation
-    RegularGridInterpolator.
-
-    Args:
-        grid_points (np.ndarray): Sample points of the fdatagrid.
-        data_matrix (np.ndarray): Data matrix of the fdatagrid.
-        k (integer): Order of the spline interpolations.
-
-    Returns:
-        (np.ndarray): Array of size n_samples x dim_codomain with the
-        corresponding interpolation of the sample i, and image dimension j
-        in the entry (i,j) of the array.
-
-    Raises:
-        ValueError: If the value of the interpolation k is not valid.
-
-    """
-
-    def __init__(
-        self,
-        fdatagrid: FData,
-        interpolation_order: Union[int, Sequence[int]] = 1,
-        smoothness_parameter: float = 0,
+        fdatagrid: FDataGrid,
+        interpolation_order: int,
     ) -> None:
-        super().__init__(
-            fdatagrid=fdatagrid,
-            interpolation_order=interpolation_order,
-            smoothness_parameter=smoothness_parameter,
-        )
+        self.fdatagrid = fdatagrid
+        self.interpolation_order = interpolation_order
 
-        if self.smoothness_parameter != 0:
-            raise ValueError(
-                "Smoothing interpolation is only supported with "
-                "domain dimension up to 2.",
-            )
-
-        # Parses method of interpolation
         if self.interpolation_order == 0:
             method = 'nearest'
         elif self.interpolation_order == 1:
             method = 'linear'
+        elif self.interpolation_order == 3:
+            method = 'cubic'
+        elif self.interpolation_order == 5:
+            method = 'quintic'
         else:
             raise ValueError(
-                "interpolation order should be 0 (nearest) or 1 (linear).",
+                f"Invalid interpolation order: {self.interpolation_order}.",
             )
-
-        splines = np.empty(
-            (fdatagrid.n_samples, fdatagrid.dim_codomain),
-            dtype=object,
+        self.interpolator = RegularGridInterpolator(
+            self.fdatagrid.grid_points,
+            np.moveaxis(self.fdatagrid.data_matrix, 0, -2),
+            method=method,
+            bounds_error=False,
+            fill_value=None,
         )
 
-        for i in range(fdatagrid.n_samples):
-            for j in range(fdatagrid.dim_codomain):
-                splines[i, j] = RegularGridInterpolator(
-                    fdatagrid.grid_points,
-                    fdatagrid.data_matrix[i, ..., j],
-                    method=method,
-                    bounds_error=False,
-                )
-
-        self.splines = splines
-
-    def _evaluate_one(
+    def __call__(
         self,
-        spline: SplineCallable,
-        eval_points: NDArrayFloat,
+        eval_points: EvaluationPoints,
     ) -> NDArrayFloat:
+        return np.moveaxis(
+            self.interpolator(eval_points),
+            0,
+            1,
+        )
 
-        return spline(eval_points)
 
-
-class SplineInterpolation(Evaluator):
+class SplineInterpolation(_BaseInterpolation):
     """
     Spline interpolation.
 
@@ -441,47 +138,69 @@ class SplineInterpolation(Evaluator):
 
     def __init__(
         self,
-        interpolation_order: Union[int, Sequence[int]] = 1,
+        interpolation_order: int = 1,
         *,
-        smoothness_parameter: float = 0,
         monotone: bool = False,
     ) -> None:
-        self._interpolation_order = interpolation_order
-        self._smoothness_parameter = smoothness_parameter
-        self._monotone = monotone
+        self.interpolation_order = interpolation_order
+        self.monotone = monotone
 
-    @property
-    def interpolation_order(self) -> Union[int, Tuple[int, ...]]:
-        """Interpolation order."""
+    def _get_interpolator_1d(
+        self,
+        fdatagrid: FDataGrid,
+    ) -> Callable[[EvaluationPoints], NDArrayFloat]:
+        if (
+            isinstance(self.interpolation_order, Sequence)
+            or not 1 <= self.interpolation_order <= 5
+        ):
+            raise ValueError(
+                f"Invalid degree of interpolation "
+                f"({self.interpolation_order}). Must be "
+                f"an integer greater than 0 and lower or "
+                f"equal than 5.",
+            )
 
-        return (
-            self._interpolation_order
-            if isinstance(self._interpolation_order, int)
-            else tuple(self._interpolation_order)
+        if self.monotone and self.interpolation_order not in {1, 3}:
+            raise ValueError(
+                f"monotone interpolation of degree "
+                f"{self.interpolation_order}"
+                f"not supported.",
+            )
+
+        # Monotone interpolation of degree 1 is performed with linear spline
+        monotone = self.monotone and self.interpolation_order > 1
+
+        if monotone:
+            return PchipInterpolator(  # type: ignore[no-any-return]
+                fdatagrid.grid_points[0],
+                fdatagrid.data_matrix,
+                axis=1,
+            )
+
+        return make_interp_spline(  # type: ignore[no-any-return]
+            fdatagrid.grid_points[0],
+            fdatagrid.data_matrix,
+            k=self.interpolation_order,
+            axis=1,
         )
 
-    @property
-    def smoothness_parameter(self) -> float:
-        """Smoothness parameter."""
-        return self._smoothness_parameter
-
-    @property
-    def monotone(self) -> bool:
-        """Flag to perform monotone interpolation."""
-        return self._monotone
-
-    def _build_interpolator(
+    def _get_interpolator_nd(
         self,
-        fdatagrid: FData,
-    ) -> _SplineList:
+        fdatagrid: FDataGrid,
+    ) -> Callable[[EvaluationPoints], NDArrayFloat]:
+
+        return _RegularGridInterpolatorWrapper(
+            fdatagrid,
+            interpolation_order=self.interpolation_order,
+        )
+
+    def _get_interpolator(
+        self,
+        fdatagrid: FDataGrid,
+    ) -> Callable[[EvaluationPoints], NDArrayFloat]:
 
         if fdatagrid.dim_domain == 1:
-            return _SplineList1D(
-                fdatagrid=fdatagrid,
-                interpolation_order=self.interpolation_order,
-                smoothness_parameter=self.smoothness_parameter,
-                monotone=self.monotone,
-            )
+            return self._get_interpolator_1d(fdatagrid)
 
         elif self.monotone:
             raise ValueError(
@@ -489,36 +208,24 @@ class SplineInterpolation(Evaluator):
                 "domain dimension equal to 1.",
             )
 
-        elif fdatagrid.dim_domain == 2:
-            return _SplineList2D(
-                fdatagrid=fdatagrid,
-                interpolation_order=self.interpolation_order,
-                smoothness_parameter=self.smoothness_parameter,
-            )
+        return self._get_interpolator_nd(fdatagrid)
 
-        return _SplineListND(
-            fdatagrid=fdatagrid,
-            interpolation_order=self.interpolation_order,
-            smoothness_parameter=self.smoothness_parameter,
-        )
-
-    def _evaluate(  # noqa: D102
+    def _evaluate_aligned(  # noqa: D102
         self,
-        fdata: FData,
-        eval_points: ArrayLike,
-        *,
-        aligned: bool = True,
+        fdata: FDataGrid,
+        eval_points: EvaluationPoints,
     ) -> NDArrayFloat:
 
-        spline_list = self._build_interpolator(fdata)
-
-        return spline_list.evaluate(fdata, eval_points, aligned=aligned)
+        interpolator = self._get_interpolator(fdata)
+        return np.reshape(
+            interpolator(eval_points),
+            (fdata.n_samples, -1, fdata.dim_codomain),
+        )
 
     def __repr__(self) -> str:
         return (
             f"{type(self).__name__}("
             f"interpolation_order={self.interpolation_order}, "
-            f"smoothness_parameter={self.smoothness_parameter}, "
             f"monotone={self.monotone})"
         )
 
@@ -526,6 +233,5 @@ class SplineInterpolation(Evaluator):
         return (
             super().__eq__(other)
             and self.interpolation_order == other.interpolation_order
-            and self.smoothness_parameter == other.smoothness_parameter
             and self.monotone == other.monotone
         )

--- a/skfda/tests/test_interpolation.py
+++ b/skfda/tests/test_interpolation.py
@@ -222,7 +222,7 @@ class TestEvaluationSplineUnivariate(unittest.TestCase):
 
     def test_evaluation_nodes(self) -> None:
         """Test interpolation in nodes for all dimensions."""
-        for degree in range(1, 6):
+        for degree in range(1, 6, 2):
             interpolation = SplineInterpolation(degree)
 
             f = FDataGrid(
@@ -381,7 +381,7 @@ class TestEvaluationSplineArbitraryImage(unittest.TestCase):
 
     def test_evaluation_nodes(self) -> None:
         """Test interpolation in nodes for all dimensions."""
-        for degree in range(1, 6):
+        for degree in range(1, 6, 2):
             interpolation = SplineInterpolation(degree)
 
             f = FDataGrid(


### PR DESCRIPTION
- Vectorizes interpolation of FDataGrid using the "new" SciPy API.
- Removes spline smoothing functionality from interpolators, as it was not true interpolation and was not vectorizable.
- Due to some Scipy limitations not all interpolation orders are available in oldest SciPy versions for every domain dimension. As interpolation is rarely changed, though, and most algorithms do not interpolate, we will break backwards compatibility here to achieve vectorization.
- In the rare cases where a user needs the old behaviour, they can always create their own interpolation class from the old code.