### PR TITLE
Make weights parameter private

### DIFF
--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Callable, Optional, TypeVar, Union
 
 import numpy as np

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -331,17 +331,17 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
         if self.weights is None:
             # grid_points is a list with one array in the 1D case
             identity = np.eye(len(X.grid_points[0]))
-            self.weights_ = scipy.integrate.simps(identity, X.grid_points[0])
+            self.weights = scipy.integrate.simps(identity, X.grid_points[0])
         elif callable(self.weights):
-            self.weights_ = self.weights(X.grid_points[0])
+            self.weights = self.weights(X.grid_points[0])
             # if its a FDataGrid then we need to reduce the dimension to 1-D
             # array
             if isinstance(self.weights, FDataGrid):
-                self.weights_ = np.squeeze(self.weights.data_matrix)
+                self.weights = np.squeeze(self.weights.data_matrix)
         else:
-            self.weights_ = self.weights
+            self.weights = self.weights
 
-        weights_matrix = np.diag(self.weights_)
+        weights_matrix = np.diag(self.weights)
 
         basis = FDataGrid(
             data_matrix=np.identity(n_points_discretization),
@@ -407,7 +407,7 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
 
         return (  # type: ignore[no-any-return]
             X.data_matrix.reshape(X.data_matrix.shape[:-1])
-            * self.weights_
+            * self.weights
             @ np.transpose(
                 self.components_.data_matrix.reshape(
                     self.components_.data_matrix.shape[:-1],

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -95,7 +95,7 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
         self.n_components = n_components
         self.centering = centering
         self.regularization = regularization
-        self.weights = _weights
+        self._weights = _weights
         self.components_basis = components_basis
 
     def _center_if_necessary(
@@ -328,20 +328,20 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
         X = self._center_if_necessary(X)
 
         # establish weights for each point of discretization
-        if self.weights is None:
+        if self._weights is None:
             # grid_points is a list with one array in the 1D case
             identity = np.eye(len(X.grid_points[0]))
-            self.weights = scipy.integrate.simps(identity, X.grid_points[0])
-        elif callable(self.weights):
-            self.weights = self.weights(X.grid_points[0])
+            self._weights = scipy.integrate.simps(identity, X.grid_points[0])
+        elif callable(self._weights):
+            self._weights = self._weights(X.grid_points[0])
             # if its a FDataGrid then we need to reduce the dimension to 1-D
             # array
-            if isinstance(self.weights, FDataGrid):
-                self.weights = np.squeeze(self.weights.data_matrix)
+            if isinstance(self._weights, FDataGrid):
+                self._weights = np.squeeze(self._weights.data_matrix)
         else:
-            self.weights = self.weights
+            self._weights = self._weights
 
-        weights_matrix = np.diag(self.weights)
+        weights_matrix = np.diag(self._weights)
 
         basis = FDataGrid(
             data_matrix=np.identity(n_points_discretization),
@@ -407,7 +407,7 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
 
         return (  # type: ignore[no-any-return]
             X.data_matrix.reshape(X.data_matrix.shape[:-1])
-            * self.weights
+            * self._weights
             @ np.transpose(
                 self.components_.data_matrix.reshape(
                     self.components_.data_matrix.shape[:-1],

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -29,8 +29,8 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
     Principal component analysis.
 
     Class that implements functional principal component analysis for both
-    basis and grid representations of the data. Most parameters are shared
-    when fitting a FDataBasis or FDataGrid, except weights and
+    basis and grid representations of the data. The parameters are shared
+    when fitting a FDataBasis or FDataGrid, except for
     ``components_basis``.
 
     Parameters:
@@ -45,14 +45,6 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
             components. We can use a different basis than the basis contained
             in the passed FDataBasis object. This parameter is only used when
             fitting a FDataBasis.
-        weights: the weights vector used for
-            discrete integration. If none then Simpson's rule is used for
-            computing the weights. If a callable object is passed, then the
-            weight vector will be obtained by evaluating the object at the
-            sample points of the passed FDataGrid object in the fit method.
-            This parameter is only used when fitting a FDataGrid.
-
-            .. deprecated:: 0.7.2
 
     Attributes:
         components\_: this contains the principal components.
@@ -98,19 +90,14 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
         n_components: int = 3,
         centering: bool = True,
         regularization: Optional[L2Regularization[FData]] = None,
-        weights: Optional[Union[ArrayLike, WeightsCallable]] = None,
         components_basis: Optional[Basis] = None,
+        _weights: Optional[Union[ArrayLike, WeightsCallable]] = None,
     ) -> None:
         self.n_components = n_components
         self.centering = centering
         self.regularization = regularization
-        self.weights = weights
+        self.weights = _weights
         self.components_basis = components_basis
-        if weights is not None:
-            warnings.warn(
-                "The 'weights' parameter is deprecated and will be removed.",
-                DeprecationWarning,
-            )
 
     def _center_if_necessary(
         self,

--- a/skfda/tests/test_fpca.py
+++ b/skfda/tests/test_fpca.py
@@ -251,7 +251,7 @@ class FPCATestCase(unittest.TestCase):
 
         fd_data = fetch_weather()['data'].coordinates[0]
 
-        fpca = FPCA(n_components=n_components, weights=[1] * 365)
+        fpca = FPCA(n_components=n_components, _weights=[1] * 365)
         fpca.fit(fd_data)
 
         pca = PCA(n_components=n_components)
@@ -297,7 +297,7 @@ class FPCATestCase(unittest.TestCase):
 
         fd_data = fetch_weather()['data'].coordinates[0]
 
-        fpca = FPCA(n_components=n_components, weights=[1] * 365)
+        fpca = FPCA(n_components=n_components, _weights=[1] * 365)
         fpca.fit(fd_data)
 
         # Results obtained using fda.usc for the first component
@@ -410,7 +410,7 @@ class FPCATestCase(unittest.TestCase):
 
         fd_data = fetch_weather()['data'].coordinates[0]
 
-        fpca = FPCA(n_components=n_components, weights=[1] * 365)
+        fpca = FPCA(n_components=n_components, _weights=[1] * 365)
         fpca.fit(fd_data)
         scores = fpca.transform(fd_data)
 
@@ -437,7 +437,7 @@ class FPCATestCase(unittest.TestCase):
 
         fpca = FPCA(
             n_components=n_components,
-            weights=[1] * 365,
+            _weights=[1] * 365,
             regularization=L2Regularization(
                 LinearDifferentialOperator(2),
             ),


### PR DESCRIPTION
Choosing the weights for the numerical quadrature used during the calculation of FPCA does not seem like a parameter that the end user should need to tweak. Therefore, it has been removed from the documentation, and its name in the constructor has been prepended with an underscore to indicate that it is a private parameter now