### PR TITLE
Use inverse transform when comparing scores in fpca tests

### DIFF
--- a/skfda/tests/test_fpca.py
+++ b/skfda/tests/test_fpca.py
@@ -7,7 +7,6 @@ from sklearn.decomposition import PCA
 
 from skfda import FDataBasis, FDataGrid
 from skfda.datasets import fetch_weather
-from skfda.misc.metrics import l2_norm
 from skfda.misc.operators import LinearDifferentialOperator
 from skfda.misc.regularization import L2Regularization
 from skfda.preprocessing.dim_reduction import FPCA
@@ -439,17 +438,10 @@ class FPCATestCase(unittest.TestCase):
 
         untransformed_scores = fpca.inverse_transform(scores)
         untransformed_results = fpca.inverse_transform(results.reshape(-1, 1))
-        differences = l2_norm(untransformed_scores - untransformed_results)
-
-        # Take into account the length of the interval:
-        differences /= (
-            fd_data.domain_range[0][1] - fd_data.domain_range[0][0]
-        )
-        
         np.testing.assert_allclose(
-            differences,
-            [0] * results.shape[0],
-            atol=0.001,
+            untransformed_scores.data_matrix.ravel(),
+            untransformed_results.data_matrix.ravel(),
+            atol=0.1,
         )
 
     def test_grid_fpca_regularization_fit_result(self) -> None:

--- a/skfda/tests/test_fpca.py
+++ b/skfda/tests/test_fpca.py
@@ -416,7 +416,9 @@ class FPCATestCase(unittest.TestCase):
 
         # Ramsay uses a different inner product to calculate the scores
         # so we need to use the same inner product to compare the results
-        fpca.weights = scipy.integrate.simps(
+        # flake8 ignore comment required since a protected member is being
+        # accessed
+        fpca._weights = scipy.integrate.simps(  # noqa: WPS437
             np.eye(len(fd_data.grid_points[0])),
             fd_data.grid_points[0],
         )


### PR DESCRIPTION
Compare the functions obtained with the `inverse_transform` instead of the scores obtained in `transform` directly.
In doing so, we can use a smaller tolerance (0.25 before vs 0.1 now). 

There are two things to keep in mind:

-  The internal weights parameter of FPCA is changed between the calls to  `fit` and `transform` because fda.usc uses different quadratures for these two operations.
- Using `inverse_transform` with coefficients obtained from fda.usc is not strictly correct since the principal components calculated in fda.usc are slightly different. However, the result is very similar, and this difference is not the cause of still having to use a high tolerance (0.1).