### PR TITLE
Feature/rename basis

### DIFF
--- a/docs/modules/representation.rst
+++ b/docs/modules/representation.rst
@@ -51,10 +51,10 @@ The following classes are used to define different basis for
 .. autosummary::
    :toctree: autosummary
 
-   skfda.representation.basis.BSpline
-   skfda.representation.basis.Fourier
-   skfda.representation.basis.Monomial
-   skfda.representation.basis.Constant
+   skfda.representation.basis.BSplineBasis
+   skfda.representation.basis.FourierBasis
+   skfda.representation.basis.MonomialBasis
+   skfda.representation.basis.ConstantBasis
    
 The following classes, allow the construction of a basis for
 :math:`\mathbb{R}^n \to \mathbb{R}` functions.
@@ -62,8 +62,8 @@ The following classes, allow the construction of a basis for
 .. autosummary::
    :toctree: autosummary
 
-   skfda.representation.basis.Tensor
-   skfda.representation.basis.FiniteElement
+   skfda.representation.basis.TensorBasis
+   skfda.representation.basis.FiniteElementBasis
 
 The following class, allows the construction of a basis for
 :math:`\mathbb{R}^n \to \mathbb{R}^m` functions from
@@ -72,7 +72,7 @@ several :math:`\mathbb{R}^n \to \mathbb{R}` bases.
 .. autosummary::
    :toctree: autosummary
 
-   skfda.representation.basis.VectorValued
+   skfda.representation.basis.VectorValuedBasis
    
 All the aforementioned basis inherit the basics from an
 abstract base class :class:`Basis`. Users can create their own
@@ -107,3 +107,18 @@ interval using extrapolation methods.
    :maxdepth: 4
 
    representation/extrapolation
+
+Deprecated Classes
+----------------------
+
+.. autosummary::
+   :toctree: autosummary
+
+   skfda.representation.basis.BSpline
+   skfda.representation.basis.Fourier
+   skfda.representation.basis.Monomial
+   skfda.representation.basis.Constant
+   skfda.representation.basis.Tensor
+   skfda.representation.basis.FiniteElement
+   skfda.representation.basis.VectorValued
+

--- a/examples/plot_extrapolation.py
+++ b/examples/plot_extrapolation.py
@@ -44,13 +44,15 @@ fdgrid = skfda.datasets.make_sinusoidal_process(
     n_samples=2, error_std=0, random_state=0)
 fdgrid.dataset_name = "Grid"
 
-fd_fourier = fdgrid.to_basis(skfda.representation.basis.Fourier())
+fd_fourier = fdgrid.to_basis(skfda.representation.basis.FourierBasis())
 fd_fourier.dataset_name = "Fourier Basis"
 
-fd_monomial = fdgrid.to_basis(skfda.representation.basis.Monomial(n_basis=5))
+fd_monomial = fdgrid.to_basis(
+    skfda.representation.basis.MonomialBasis(n_basis=5))
 fd_monomial.dataset_name = "Monomial Basis"
 
-fd_bspline = fdgrid.to_basis(skfda.representation.basis.BSpline(n_basis=5))
+fd_bspline = fdgrid.to_basis(
+    skfda.representation.basis.BSplineBasis(n_basis=5))
 fd_bspline.dataset_name = "BSpline Basis"
 
 

--- a/examples/plot_fpca.py
+++ b/examples/plot_fpca.py
@@ -14,7 +14,7 @@ import skfda
 from skfda.datasets import fetch_growth
 from skfda.exploratory.visualization import FPCAPlot
 from skfda.preprocessing.dim_reduction import FPCA
-from skfda.representation.basis import BSpline, Fourier, Monomial
+from skfda.representation.basis import BSplineBasis, FourierBasis, MonomialBasis
 
 ##############################################################################
 # In this example we are going to use functional principal component analysis
@@ -50,7 +50,7 @@ fpca_discretized.components_.plot()
 # We also plot the data for better visual representation.
 dataset = fetch_growth()
 fd = dataset['data']
-basis = skfda.representation.basis.BSpline(n_basis=7)
+basis = skfda.representation.basis.BSplineBasis(n_basis=7)
 basis_fd = fd.to_basis(basis)
 basis_fd.plot()
 
@@ -90,8 +90,8 @@ FPCAPlot(
 # basis
 dataset = fetch_growth()
 fd = dataset['data']
-basis_fd = fd.to_basis(BSpline(n_basis=7))
-fpca = FPCA(n_components=2, components_basis=Fourier(n_basis=7))
+basis_fd = fd.to_basis(BSplineBasis(n_basis=7))
+fpca = FPCA(n_components=2, components_basis=FourierBasis(n_basis=7))
 fpca.fit(basis_fd)
 fpca.components_.plot()
 
@@ -103,7 +103,7 @@ fpca.components_.plot()
 # principal components
 dataset = fetch_growth()
 fd = dataset['data']
-basis_fd = fd.to_basis(BSpline(n_basis=7))
-fpca = FPCA(n_components=2, components_basis=Monomial(n_basis=4))
+basis_fd = fd.to_basis(BSplineBasis(n_basis=7))
+fpca = FPCA(n_components=2, components_basis=MonomialBasis(n_basis=4))
 fpca.fit(basis_fd)
 fpca.components_.plot()

--- a/examples/plot_kernel_regression.py
+++ b/examples/plot_kernel_regression.py
@@ -117,7 +117,7 @@ print('Score NW:', nw_res)
 # number of functions in the basis affects the estimation result and should
 # ideally also be chosen using cross-validation.
 
-fourier = skfda.representation.basis.Fourier(n_basis=10)
+fourier = skfda.representation.basis.FourierBasis(n_basis=10)
 
 X_basis = X.to_basis(basis=fourier)
 X_basis_train, X_basis_test, y_train, y_test = train_test_split(

--- a/examples/plot_neighbors_functional_regression.py
+++ b/examples/plot_neighbors_functional_regression.py
@@ -14,7 +14,7 @@ from sklearn.model_selection import train_test_split
 
 import skfda
 from skfda.ml.regression import KNeighborsRegressor
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 ##############################################################################
 #
@@ -54,7 +54,7 @@ y.plot()
 # to make a smoothing of the precipitation curves using a basis
 # representation, employing for it a fourier basis with 5 elements.
 
-y = y.to_basis(Fourier(n_basis=5))
+y = y.to_basis(FourierBasis(n_basis=5))
 
 y.plot()
 

--- a/examples/plot_oneway.py
+++ b/examples/plot_oneway.py
@@ -14,7 +14,7 @@ real dataset.
 import skfda
 from skfda.inference.anova import oneway_anova
 from skfda.representation import FDataGrid, FDataBasis
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 ################################################################################
 # *One-way ANOVA* (analysis of variance) is a test that can be used to
@@ -31,7 +31,7 @@ from skfda.representation.basis import Fourier
 # of hips and knees from 39 different boys in a 20 point movement cycle.
 dataset = skfda.datasets.fetch_gait()
 fd_hip = dataset['data'].coordinates[0]
-fd_knee = dataset['data'].coordinates[1].to_basis(Fourier(n_basis=10))
+fd_knee = dataset['data'].coordinates[1].to_basis(FourierBasis(n_basis=10))
 
 ################################################################################
 # Let's start with the first feature, the angle of the hip. The sample

--- a/examples/plot_representation.py
+++ b/examples/plot_representation.py
@@ -80,14 +80,14 @@ fd.plot()
 
 ##############################################################################
 # We will represent it using a basis of B-splines.
-fd_basis = fd.to_basis(basis.BSpline(n_basis=4))
+fd_basis = fd.to_basis(basis.BSplineBasis(n_basis=4))
 
 fd_basis.plot()
 
 ##############################################################################
 # We can increase the number of elements in the basis to try to reproduce the
 # original data with more fidelity.
-fd_basis_big = fd.to_basis(basis.BSpline(n_basis=7))
+fd_basis_big = fd.to_basis(basis.BSplineBasis(n_basis=7))
 
 fd_basis_big.plot()
 
@@ -105,7 +105,7 @@ fig.axes[0].legend(['Original', '4 elements', '7 elements'])
 # For example, in the Fourier basis the functions start and end at the same
 # points if the period is equal to the domain range, so this basis is clearly
 # non suitable for the Growth dataset.
-fd_basis = fd.to_basis(basis.Fourier(n_basis=7))
+fd_basis = fd.to_basis(basis.FourierBasis(n_basis=7))
 
 fd_basis.plot()
 

--- a/examples/plot_shift_registration.py
+++ b/examples/plot_shift_registration.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 
 from skfda.datasets import make_sinusoidal_process
 from skfda.preprocessing.registration import LeastSquaresShiftRegistration
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 ##############################################################################
 # In this example we will use a
@@ -36,7 +36,7 @@ fd.plot()
 # is essential due to the use of derivatives in the optimization process.
 # Because of their sinusoidal nature we will use a Fourier basis.
 
-fd_basis = fd.to_basis(Fourier(n_basis=11))
+fd_basis = fd.to_basis(FourierBasis(n_basis=11))
 fd_basis.plot()
 
 ##############################################################################

--- a/full_examples/plot_tecator_regression.py
+++ b/full_examples/plot_tecator_regression.py
@@ -23,7 +23,7 @@ from skfda.preprocessing.dim_reduction.variable_selection.maxima_hunting import 
     MaximaHunting,
     RelativeLocalMaximaSelector,
 )
-from skfda.representation.basis import BSpline
+from skfda.representation.basis import BSplineBasis
 
 ##############################################################################
 # We will first load the Tecator data, keeping only the fat content target,
@@ -43,7 +43,7 @@ plt.show()
 ##############################################################################
 # In order to compute functional linear regression we first convert the data
 # to a basis expansion.
-basis = BSpline(
+basis = BSplineBasis(
     n_basis=10,
 )
 X_der_basis = X_der.to_basis(basis)

--- a/skfda/inference/hotelling/_hotelling.py
+++ b/skfda/inference/hotelling/_hotelling.py
@@ -66,8 +66,8 @@ def hotelling_t2(
         >>> fd2 = FDataGrid([[3, 3, 3], [5, 5, 5]])
         >>> '%.2f' % hotelling_t2(fd1, fd2)
         '2.00'
-        >>> fd1 = fd1.to_basis(basis.Fourier(n_basis=3))
-        >>> fd2 = fd2.to_basis(basis.Fourier(n_basis=3))
+        >>> fd1 = fd1.to_basis(basis.FourierBasis(n_basis=3))
+        >>> fd2 = fd2.to_basis(basis.FourierBasis(n_basis=3))
         >>> '%.2f' % hotelling_t2(fd1, fd2)
         '2.00'
 

--- a/skfda/misc/_math.py
+++ b/skfda/misc/_math.py
@@ -296,21 +296,21 @@ def inner_product(
 
         It also work with basis objects
 
-        >>> basis = skfda.representation.basis.Monomial(n_basis=3)
+        >>> basis = skfda.representation.basis.MonomialBasis(n_basis=3)
         >>>
         >>> fd1 = skfda.FDataBasis(basis, [0, 1, 0])
         >>> fd2 = skfda.FDataBasis(basis, [1, 0, 0])
         >>> inner_product(fd1, fd2)
         array([ 0.5])
 
-        >>> basis = skfda.representation.basis.Monomial(n_basis=3)
+        >>> basis = skfda.representation.basis.MonomialBasis(n_basis=3)
         >>>
         >>> fd1 = skfda.FDataBasis(basis, [[0, 1, 0], [0, 0, 1]])
         >>> fd2 = skfda.FDataBasis(basis, [1, 0, 0])
         >>> inner_product(fd1, fd2)
         array([ 0.5       , 0.33333333])
 
-        >>> basis = skfda.representation.basis.Monomial(n_basis=3)
+        >>> basis = skfda.representation.basis.MonomialBasis(n_basis=3)
         >>>
         >>> fd1 = skfda.FDataBasis(basis, [[0, 1, 0], [0, 0, 1]])
         >>> fd2 = skfda.FDataBasis(basis, [[1, 0, 0], [0, 1, 0]])
@@ -615,21 +615,21 @@ def cosine_similarity(
 
         It also work with basis objects
 
-        >>> basis = skfda.representation.basis.Monomial(n_basis=3)
+        >>> basis = skfda.representation.basis.MonomialBasis(n_basis=3)
         >>>
         >>> fd1 = skfda.FDataBasis(basis, [0, 1, 0])
         >>> fd2 = skfda.FDataBasis(basis, [1, 0, 0])
         >>> cosine_similarity(fd1, fd2)
         array([ 0.8660254])
 
-        >>> basis = skfda.representation.basis.Monomial(n_basis=3)
+        >>> basis = skfda.representation.basis.MonomialBasis(n_basis=3)
         >>>
         >>> fd1 = skfda.FDataBasis(basis, [[0, 1, 0], [0, 0, 1]])
         >>> fd2 = skfda.FDataBasis(basis, [1, 0, 0])
         >>> cosine_similarity(fd1, fd2)
         array([ 0.8660254 ,  0.74535599])
 
-        >>> basis = skfda.representation.basis.Monomial(n_basis=3)
+        >>> basis = skfda.representation.basis.MonomialBasis(n_basis=3)
         >>>
         >>> fd1 = skfda.FDataBasis(basis, [[0, 1, 0], [0, 0, 1]])
         >>> fd2 = skfda.FDataBasis(basis, [[1, 0, 0], [0, 1, 0]])

--- a/skfda/misc/operators/_linear_differential_operator.py
+++ b/skfda/misc/operators/_linear_differential_operator.py
@@ -9,7 +9,13 @@ from numpy import polyder, polyint, polymul, polyval
 from scipy.interpolate import PPoly
 
 from ...representation import FData, FDataGrid
-from ...representation.basis import Basis, BSplineBasis, ConstantBasis, FourierBasis, MonomialBasis
+from ...representation.basis import (
+    Basis,
+    BSplineBasis,
+    ConstantBasis,
+    FourierBasis,
+    MonomialBasis,
+)
 from ...typing._base import DomainRangeLike
 from ...typing._numpy import NDArrayFloat
 from ._operators import Operator, gramian_matrix_optimization

--- a/skfda/misc/operators/_linear_differential_operator.py
+++ b/skfda/misc/operators/_linear_differential_operator.py
@@ -9,7 +9,7 @@ from numpy import polyder, polyint, polymul, polyval
 from scipy.interpolate import PPoly
 
 from ...representation import FData, FDataGrid
-from ...representation.basis import Basis, BSpline, Constant, Fourier, Monomial
+from ...representation.basis import Basis, BSplineBasis, ConstantBasis, FourierBasis, MonomialBasis
 from ...typing._base import DomainRangeLike
 from ...typing._numpy import NDArrayFloat
 from ._operators import Operator, gramian_matrix_optimization
@@ -60,7 +60,8 @@ class LinearDifferentialOperator(
 
         >>> from skfda.misc.operators import LinearDifferentialOperator
         >>> from skfda.representation.basis import (FDataBasis,
-        ...                                         Monomial, Constant)
+        ...                                         MonomialBasis,
+        ...                                         ConstantBasis)
         >>>
         >>> LinearDifferentialOperator(2)
         LinearDifferentialOperator(
@@ -77,23 +78,23 @@ class LinearDifferentialOperator(
 
         Create a linear differential operator with non-constant weights.
 
-        >>> constant = Constant()
-        >>> monomial = Monomial(domain_range=(0, 1), n_basis=3)
+        >>> constant = ConstantBasis()
+        >>> monomial = MonomialBasis(domain_range=(0, 1), n_basis=3)
         >>> fdlist = [FDataBasis(constant, [0.]),
         ...           FDataBasis(constant, [0.]),
         ...           FDataBasis(monomial, [1., 2., 3.])]
         >>> LinearDifferentialOperator(weights=fdlist)
         LinearDifferentialOperator(
         weights=(FDataBasis(
-                basis=Constant(domain_range=((0.0, 1.0),), n_basis=1),
+                basis=ConstantBasis(domain_range=((0.0, 1.0),), n_basis=1),
                 coefficients=[[ 0.]],
                 ...),
             FDataBasis(
-                basis=Constant(domain_range=((0.0, 1.0),), n_basis=1),
+                basis=ConstantBasis(domain_range=((0.0, 1.0),), n_basis=1),
                 coefficients=[[ 0.]],
                 ...),
             FDataBasis(
-                basis=Monomial(domain_range=((0.0, 1.0),), n_basis=3),
+                basis=MonomialBasis(domain_range=((0.0, 1.0),), n_basis=3),
                 coefficients=[[ 1. 2. 3.]],
                 ...)),
         )
@@ -219,7 +220,7 @@ class LinearDifferentialOperator(
 @gramian_matrix_optimization.register
 def constant_penalty_matrix_optimized(
     linear_operator: LinearDifferentialOperator,
-    basis: Constant,
+    basis: ConstantBasis,
 ) -> NDArrayFloat:
     """Optimized version for Constant basis."""
     coefs = linear_operator.constant_weights()
@@ -233,7 +234,7 @@ def constant_penalty_matrix_optimized(
 
 
 def _monomial_evaluate_constant_linear_diff_op(
-    basis: Monomial,
+    basis: MonomialBasis,
     weights: NDArrayFloat,
 ) -> NDArrayFloat:
     """Evaluate constant weights over the monomial basis."""
@@ -295,7 +296,7 @@ def _monomial_evaluate_constant_linear_diff_op(
 @gramian_matrix_optimization.register
 def monomial_penalty_matrix_optimized(
     linear_operator: LinearDifferentialOperator,
-    basis: Monomial,
+    basis: MonomialBasis,
 ) -> NDArrayFloat:
     """Optimized version for Monomial basis."""
     weights = linear_operator.constant_weights()
@@ -358,7 +359,7 @@ def monomial_penalty_matrix_optimized(
 
 
 def _fourier_penalty_matrix_optimized_orthonormal(
-    basis: Fourier,
+    basis: FourierBasis,
     weights: NDArrayFloat,
 ) -> NDArrayFloat:
     """Return the penalty when the basis is orthonormal."""
@@ -423,7 +424,7 @@ def _fourier_penalty_matrix_optimized_orthonormal(
 @gramian_matrix_optimization.register
 def fourier_penalty_matrix_optimized(
     linear_operator: LinearDifferentialOperator,
-    basis: Fourier,
+    basis: FourierBasis,
 ) -> NDArrayFloat:
     """Optimized version for Fourier basis."""
     weights = linear_operator.constant_weights()
@@ -441,7 +442,7 @@ def fourier_penalty_matrix_optimized(
 @gramian_matrix_optimization.register
 def bspline_penalty_matrix_optimized(
     linear_operator: LinearDifferentialOperator,
-    basis: BSpline,
+    basis: BSplineBasis,
 ) -> NDArrayFloat:
     """Optimized version for BSpline basis."""
     coefs = linear_operator.constant_weights()

--- a/skfda/ml/regression/_historical_linear_model.py
+++ b/skfda/ml/regression/_historical_linear_model.py
@@ -10,7 +10,8 @@ from sklearn.utils.validation import check_is_fitted
 from ..._utils import _cartesian_product, _pairwise_symmetric
 from ..._utils._sklearn_adapter import BaseEstimator, RegressorMixin
 from ...representation import FData, FDataBasis, FDataGrid
-from ...representation.basis import Basis, FiniteElement, VectorValued
+from ...representation.basis import Basis, FiniteElementBasis 
+from ...representation.basis import VectorValuedBasis
 from ...typing._numpy import NDArrayFloat
 
 _MeanType = Union[FDataGrid, float]
@@ -185,7 +186,7 @@ def _create_fem_basis(
     stop: float,
     n_intervals: int,
     lag: float,
-) -> FiniteElement:
+) -> FiniteElementBasis:
 
     interval_len = (stop - start) / n_intervals
 
@@ -202,7 +203,7 @@ def _create_fem_basis(
         valid_points=valid_points,
     )
 
-    return FiniteElement(
+    return FiniteElementBasis(
         vertices=final_points,
         cells=triangles,
         domain_range=((start, stop),) * 2,
@@ -354,7 +355,7 @@ class HistoricalLinearRegression(
             lag=self.lag,
         )
 
-        self._basis = VectorValued(
+        self._basis = VectorValuedBasis(
             [fem_basis] * X_centered.dim_codomain
         )
 

--- a/skfda/ml/regression/_historical_linear_model.py
+++ b/skfda/ml/regression/_historical_linear_model.py
@@ -10,8 +10,11 @@ from sklearn.utils.validation import check_is_fitted
 from ..._utils import _cartesian_product, _pairwise_symmetric
 from ..._utils._sklearn_adapter import BaseEstimator, RegressorMixin
 from ...representation import FData, FDataBasis, FDataGrid
-from ...representation.basis import Basis, FiniteElementBasis 
-from ...representation.basis import VectorValuedBasis
+from ...representation.basis import (
+    Basis,
+    FiniteElementBasis,
+    VectorValuedBasis,
+)
 from ...typing._numpy import NDArrayFloat
 
 _MeanType = Union[FDataGrid, float]

--- a/skfda/ml/regression/_linear_regression.py
+++ b/skfda/ml/regression/_linear_regression.py
@@ -111,14 +111,14 @@ class LinearRegression(
 
     Examples:
         >>> from skfda.ml.regression import LinearRegression
-        >>> from skfda.representation.basis import (FDataBasis, Monomial,
-        ...                                         Constant)
+        >>> from skfda.representation.basis import (FDataBasis, MonomialBasis,
+        ...                                         ConstantBasis)
         >>> import pandas as pd
 
         Multivariate linear regression can be used with functions expressed in
         a basis. Also, a functional basis for the weights can be specified:
 
-        >>> x_basis = Monomial(n_basis=3)
+        >>> x_basis = MonomialBasis(n_basis=3)
         >>> x_fd = FDataBasis(x_basis, [[0, 0, 1],
         ...                             [0, 1, 0],
         ...                             [0, 1, 1],
@@ -128,7 +128,7 @@ class LinearRegression(
         >>> _ = linear.fit(x_fd, y)
         >>> linear.coef_[0]
         FDataBasis(
-            basis=Monomial(domain_range=((0.0, 1.0),), n_basis=3),
+            basis=MonomialBasis(domain_range=((0.0, 1.0),), n_basis=3),
             coefficients=[[-15.  96. -90.]],
             ...)
         >>> linear.intercept_
@@ -138,7 +138,7 @@ class LinearRegression(
 
         Covariates can include also multivariate data:
 
-        >>> x_basis = Monomial(n_basis=2)
+        >>> x_basis = MonomialBasis(n_basis=2)
         >>> x_fd = FDataBasis(x_basis, [[0, 2],
         ...                             [0, 4],
         ...                             [1, 0],
@@ -148,13 +148,13 @@ class LinearRegression(
         >>> x = [[1, 7], [2, 3], [4, 2], [1, 1], [3, 1], [2, 5]]
         >>> y = [11, 10, 12, 6, 10, 13]
         >>> linear = LinearRegression(
-        ...              coef_basis=[None, Constant()])
+        ...              coef_basis=[None, ConstantBasis()])
         >>> _ = linear.fit([x, x_fd], y)
         >>> linear.coef_[0]
         array([ 2.,  1.])
         >>> linear.coef_[1]
         FDataBasis(
-        basis=Constant(domain_range=((0.0, 1.0),), n_basis=1),
+        basis=ConstantBasis(domain_range=((0.0, 1.0),), n_basis=1),
         coefficients=[[ 1.]],
         ...)
         >>> linear.intercept_
@@ -166,7 +166,7 @@ class LinearRegression(
 
         First example:
 
-        >>> x_basis = Monomial(n_basis=3)
+        >>> x_basis = MonomialBasis(n_basis=3)
         >>> x_fd = FDataBasis(x_basis, [[0, 0, 1],
         ...                             [0, 1, 0],
         ...                             [0, 1, 1],
@@ -178,7 +178,7 @@ class LinearRegression(
         >>> _ = linear.fit(df, y)
         >>> linear.coef_[0]
         FDataBasis(
-            basis=Monomial(domain_range=((0.0, 1.0),), n_basis=3),
+            basis=MonomialBasis(domain_range=((0.0, 1.0),), n_basis=3),
             coefficients=[[-15.  96. -90.]],
             ...)
         >>> linear.intercept_
@@ -188,7 +188,7 @@ class LinearRegression(
 
         Second example:
 
-        >>> x_basis = Monomial(n_basis=2)
+        >>> x_basis = MonomialBasis(n_basis=2)
         >>> x_fd = FDataBasis(x_basis, [[0, 2],
         ...                             [0, 4],
         ...                             [1, 0],
@@ -201,7 +201,7 @@ class LinearRegression(
         >>> df = pd.DataFrame(cov_dict)
         >>> y = [11, 10, 12, 6, 10, 13]
         >>> linear = LinearRegression(
-        ...              coef_basis=[None, Constant(), Constant()])
+        ...              coef_basis=[None, ConstantBasis(), ConstantBasis()])
         >>> _ = linear.fit(df, y)
         >>> linear.coef_[0]
         array([ 2.])
@@ -209,7 +209,7 @@ class LinearRegression(
         array([ 1.])
         >>> linear.coef_[2]
         FDataBasis(
-            basis=Constant(domain_range=((0.0, 1.0),), n_basis=1),
+            basis=ConstantBasis(domain_range=((0.0, 1.0),), n_basis=1),
             coefficients=[[ 1.]],
             ...)
         >>> linear.intercept_

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -64,7 +64,7 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
         >>> data_matrix = np.array([[1.0, 0.0], [0.0, 2.0]])
         >>> grid_points = [0, 1]
         >>> fd = FDataGrid(data_matrix, grid_points)
-        >>> basis = skfda.representation.basis.Monomial(
+        >>> basis = skfda.representation.basis.MonomialBasis(
         ...     domain_range=(0,1), n_basis=2
         ... )
         >>> basis_fd = fd.to_basis(basis)

--- a/skfda/preprocessing/feature_construction/_coefficients_transformer.py
+++ b/skfda/preprocessing/feature_construction/_coefficients_transformer.py
@@ -25,9 +25,9 @@ class CoefficientsTransformer(
         ... )
         >>> from skfda.representation.basis import (
         ...     FDataBasis,
-        ...     Monomial,
+        ...     MonomialBasis,
         ... )
-        >>> basis = Monomial(n_basis=4)
+        >>> basis = MonomialBasis(n_basis=4)
         >>> coefficients = [[0.5, 1, 2, .5], [1.5, 1, 4, .5]]
         >>> fd = FDataBasis(basis, coefficients)
         >>>

--- a/skfda/preprocessing/feature_construction/_evaluation_trasformer.py
+++ b/skfda/preprocessing/feature_construction/_evaluation_trasformer.py
@@ -51,7 +51,7 @@ class EvaluationTransformer(
         >>> from skfda.preprocessing.feature_construction import (
         ...     EvaluationTransformer,
         ... )
-        >>> from skfda.representation.basis import Monomial
+        >>> from skfda.representation.basis import MonomialBasis
 
         Functional data object with 2 samples
         representing a function :math:`f : \mathbb{R}\longmapsto\mathbb{R}`.
@@ -91,7 +91,7 @@ class EvaluationTransformer(
 
         Evaluation of a functional data object at several points.
 
-        >>> basis = Monomial(n_basis=4)
+        >>> basis = MonomialBasis(n_basis=4)
         >>> coefficients = [[0.5, 1, 2, .5], [1.5, 1, 4, .5]]
         >>> fd = FDataBasis(basis, coefficients)
         >>>

--- a/skfda/preprocessing/registration/_landmark_registration.py
+++ b/skfda/preprocessing/registration/_landmark_registration.py
@@ -371,7 +371,7 @@ def landmark_elastic_registration(
         >>> from skfda.preprocessing.registration import (
         ...     landmark_elastic_registration,
         ... )
-        >>> from skfda.representation.basis import BSpline
+        >>> from skfda.representation.basis import BSplineBasis
 
         We will create a data with landmarks as example
 
@@ -388,7 +388,7 @@ def landmark_elastic_registration(
 
         This method will work for FDataBasis as for FDataGrids
 
-        >>> fd = fd.to_basis(BSpline(n_basis=12))
+        >>> fd = fd.to_basis(BSplineBasis(n_basis=12))
         >>> landmark_elastic_registration(fd, landmarks)
         FDataGrid(...)
 

--- a/skfda/preprocessing/registration/_lstsq_shift_registration.py
+++ b/skfda/preprocessing/registration/_lstsq_shift_registration.py
@@ -101,7 +101,7 @@ class LeastSquaresShiftRegistration(
         ...     LeastSquaresShiftRegistration,
         ... )
         >>> from skfda.datasets import make_sinusoidal_process
-        >>> from skfda.representation.basis import Fourier
+        >>> from skfda.representation.basis import FourierBasis
 
 
         Registration and creation of dataset in discretized form:
@@ -126,7 +126,7 @@ class LeastSquaresShiftRegistration(
 
         >>> fd = make_sinusoidal_process(n_samples=2, error_std=0,
         ...                              random_state=2)
-        >>> fd_basis = fd.to_basis(Fourier())
+        >>> fd_basis = fd.to_basis(FourierBasis())
         >>> reg.transform(fd_basis)
         FDataGrid(...)
 

--- a/skfda/preprocessing/smoothing/_basis.py
+++ b/skfda/preprocessing/smoothing/_basis.py
@@ -95,7 +95,7 @@ class BasisSmoother(_LinearSmoother):
         array([ 3.,  3.,  1.,  1.,  3.])
 
         >>> fd = skfda.FDataGrid(data_matrix=x, grid_points=t)
-        >>> basis = skfda.representation.basis.Fourier((0, 1), n_basis=3)
+        >>> basis = skfda.representation.basis.FourierBasis((0, 1), n_basis=3)
         >>> smoother = skfda.preprocessing.smoothing.BasisSmoother(basis)
         >>> fd_smooth = smoother.fit_transform(fd)
         >>> fd_smooth.data_matrix.round(2)
@@ -109,7 +109,7 @@ class BasisSmoother(_LinearSmoother):
         in basis form, by default, without extra smoothing:
 
         >>> fd = skfda.FDataGrid(data_matrix=x, grid_points=t)
-        >>> basis = skfda.representation.basis.Fourier((0, 1), n_basis=3)
+        >>> basis = skfda.representation.basis.FourierBasis((0, 1), n_basis=3)
         >>> smoother = skfda.preprocessing.smoothing.BasisSmoother(
         ...     basis,
         ...     method='cholesky',
@@ -150,7 +150,7 @@ class BasisSmoother(_LinearSmoother):
         >>> from skfda.misc.operators import LinearDifferentialOperator
         >>>
         >>> fd = skfda.FDataGrid(data_matrix=x, grid_points=t)
-        >>> basis = skfda.representation.basis.Fourier((0, 1), n_basis=3)
+        >>> basis = skfda.representation.basis.FourierBasis((0, 1), n_basis=3)
         >>> smoother = skfda.preprocessing.smoothing.BasisSmoother(
         ...     basis,
         ...     method='cholesky',
@@ -164,7 +164,7 @@ class BasisSmoother(_LinearSmoother):
         array([[ 2.04,  0.51,  0.55]])
 
         >>> fd = skfda.FDataGrid(data_matrix=x, grid_points=t)
-        >>> basis = skfda.representation.basis.Fourier((0, 1), n_basis=3)
+        >>> basis = skfda.representation.basis.FourierBasis((0, 1), n_basis=3)
         >>> smoother = skfda.preprocessing.smoothing.BasisSmoother(
         ...     basis,
         ...     method='qr',
@@ -178,7 +178,7 @@ class BasisSmoother(_LinearSmoother):
         array([[ 2.04,  0.51,  0.55]])
 
         >>> fd = skfda.FDataGrid(data_matrix=x, grid_points=t)
-        >>> basis = skfda.representation.basis.Fourier((0, 1), n_basis=3)
+        >>> basis = skfda.representation.basis.FourierBasis((0, 1), n_basis=3)
         >>> smoother = skfda.preprocessing.smoothing.BasisSmoother(
         ...     basis,
         ...     method='svd',

--- a/skfda/representation/basis/__init__.py
+++ b/skfda/representation/basis/__init__.py
@@ -8,26 +8,40 @@ __getattr__, __dir__, __all__ = lazy.attach(
     submod_attrs={
         '_basis': ["Basis"],
         "_bspline_basis": ["BSplineBasis"],
+        "_bspline": ["BSpline"],
         "_constant_basis": ["ConstantBasis"],
+        "_constant": ["Constant"],
         "_fdatabasis": ["FDataBasis", "FDataBasisDType"],
         "_finite_element_basis": ["FiniteElementBasis"],
+        "_finite_element": ["FiniteElement"],
         "_fourier_basis": ["FourierBasis"],
+        "_fourier": ["Fourier"],
         "_monomial_basis": ["MonomialBasis"],
+        "_monomial": ["Monomial"],
         "_tensor_basis": ["TensorBasis"],
+        "_tensor": ["Tensor"],
         "_vector_basis": ["VectorValuedBasis"],
+        "_vector": ["VectorValued"],
     },
 )
 
 if TYPE_CHECKING:
     from ._basis import Basis as Basis
+    from ._bspline import BSpline as BSpline
     from ._bspline_basis import BSplineBasis as BSplineBasis
+    from ._constant import Constant as Constant
     from ._constant_basis import ConstantBasis as ConstantBasis
     from ._fdatabasis import (
         FDataBasis as FDataBasis,
         FDataBasisDType as FDataBasisDType,
     )
+    from ._finite_element import FiniteElement as FiniteElement
     from ._finite_element_basis import FiniteElementBasis as FiniteElementBasis
+    from ._fourier import Fourier as Fourier
     from ._fourier_basis import FourierBasis as FourierBasis
+    from ._monomial import Monomial as Monomial
     from ._monomial_basis import MonomialBasis as MonomialBasis
+    from ._tensor import Tensor as Tensor
     from ._tensor_basis import TensorBasis as TensorBasis
+    from ._vector import VectorValued as VectorValued
     from ._vector_basis import VectorValuedBasis as VectorValuedBasis

--- a/skfda/representation/basis/__init__.py
+++ b/skfda/representation/basis/__init__.py
@@ -7,27 +7,27 @@ __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
         '_basis': ["Basis"],
-        "_bspline": ["BSpline"],
-        "_constant": ["Constant"],
+        "_bspline_basis": ["BSplineBasis"],
+        "_constant_basis": ["ConstantBasis"],
         "_fdatabasis": ["FDataBasis", "FDataBasisDType"],
-        "_finite_element": ["FiniteElement"],
-        "_fourier": ["Fourier"],
-        "_monomial": ["Monomial"],
-        "_tensor_basis": ["Tensor"],
-        "_vector_basis": ["VectorValued"],
+        "_finite_element_basis": ["FiniteElementBasis"],
+        "_fourier_basis": ["FourierBasis"],
+        "_monomial_basis": ["MonomialBasis"],
+        "_tensor_basis": ["TensorBasis"],
+        "_vector_basis": ["VectorValuedBasis"],
     },
 )
 
 if TYPE_CHECKING:
     from ._basis import Basis as Basis
-    from ._bspline import BSpline as BSpline
-    from ._constant import Constant as Constant
+    from ._bspline_basis import BSplineBasis as BSplineBasis
+    from ._constant_basis import ConstantBasis as ConstantBasis
     from ._fdatabasis import (
         FDataBasis as FDataBasis,
         FDataBasisDType as FDataBasisDType,
     )
-    from ._finite_element import FiniteElement as FiniteElement
-    from ._fourier import Fourier as Fourier
-    from ._monomial import Monomial as Monomial
-    from ._tensor_basis import Tensor as Tensor
-    from ._vector_basis import VectorValued as VectorValued
+    from ._finite_element_basis import FiniteElementBasis as FiniteElementBasis
+    from ._fourier_basis import FourierBasis as FourierBasis
+    from ._monomial_basis import MonomialBasis as MonomialBasis
+    from ._tensor_basis import TensorBasis as TensorBasis
+    from ._vector_basis import VectorValuedBasis as VectorValuedBasis

--- a/skfda/representation/basis/_bspline.py
+++ b/skfda/representation/basis/_bspline.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import warnings
+from typing import Sequence
+
+from ...typing._base import DomainRangeLike
+from ._bspline_basis import BSplineBasis
+
+
+class BSpline(BSplineBasis):
+    r"""BSpline basis.
+
+    BSpline basis elements are defined recursively as:
+
+    .. math::
+        B_{i, 1}(x) = 1 \quad \text{if } t_i \le x < t_{i+1},
+        \quad 0 \text{ otherwise}
+
+    .. math::
+        B_{i, k}(x) = \frac{x - t_i}{t_{i+k} - t_i} B_{i, k-1}(x)
+        + \frac{t_{i+k+1} - x}{t_{i+k+1} - t_{i+1}} B_{i+1, k-1}(x)
+
+    Where k indicates the order of the spline.
+
+    .. deprecated:: 0.8
+        Use BSplineBasis instead.
+
+    Implementation details: In order to allow a discontinuous behaviour at
+    the boundaries of the domain it is necessary to placing m knots at the
+    boundaries [RS05]_. This is automatically done so that the user only has to
+    specify a single knot at the boundaries.
+
+
+    Parameters:
+        domain_range: A tuple of length 2 containing the initial and
+            end values of the interval over which the basis can be evaluated.
+        n_basis: Number of functions in the basis.
+        order: Order of the splines. One greather than their degree.
+        knots: List of knots of the spline functions.
+
+    Examples:
+        Constructs specifying number of basis and order.
+
+        >>> bss = BSpline(n_basis=8, order=4)
+
+        If no order is specified defaults to 4 because cubic splines are
+        the most used. So the previous example is the same as:
+
+        >>> bss = BSplineBasis(n_basis=8)
+
+        It is also possible to create a BSpline basis specifying the knots.
+
+        >>> bss = BSplineBasis(knots=[0, 0.2, 0.4, 0.6, 0.8, 1])
+
+        Once we create a basis we can evaluate each of its functions at a
+        set of points.
+
+        >>> bss = BSplineBasis(n_basis=3, order=3)
+        >>> bss([0, 0.5, 1])
+        array([[[ 1.  ],
+                [ 0.25],
+                [ 0.  ]],
+               [[ 0.  ],
+                [ 0.5 ],
+                [ 0.  ]],
+               [[ 0.  ],
+                [ 0.25],
+                [ 1.  ]]])
+
+        And evaluates first derivative
+
+        >>> deriv = bss.derivative()
+        >>> deriv([0, 0.5, 1])
+        array([[[-2.],
+                [-1.],
+                [ 0.]],
+               [[ 2.],
+                [ 0.],
+                [-2.]],
+               [[ 0.],
+                [ 1.],
+                [ 2.]]])
+
+    References:
+        .. [RS05] Ramsay, J., Silverman, B. W. (2005). *Functional Data
+            Analysis*. Springer. 50-51.
+
+    """
+
+    def __init__(  # noqa: WPS238
+        self,
+        domain_range: DomainRangeLike | None = None,
+        n_basis: int | None = None,
+        order: int = 4,
+        knots: Sequence[float] | None = None,
+    ) -> None:
+        super().__init__(
+            domain_range=domain_range,
+            n_basis=n_basis,
+            order=order,
+            knots=knots,
+        )
+        warnings.warn(
+            "The BSplines class is deprecated. Use "
+            "BSplineBasis instead.",
+            DeprecationWarning,
+        )

--- a/skfda/representation/basis/_bspline_basis.py
+++ b/skfda/representation/basis/_bspline_basis.py
@@ -10,10 +10,10 @@ from ...typing._base import DomainRangeLike
 from ...typing._numpy import NDArrayFloat
 from ._basis import Basis
 
-T = TypeVar("T", bound='BSpline')
+T = TypeVar("T", bound='BSplineBasis')
 
 
-class BSpline(Basis):
+class BSplineBasis(Basis):
     r"""BSpline basis.
 
     BSpline basis elements are defined recursively as:
@@ -43,21 +43,21 @@ class BSpline(Basis):
     Examples:
         Constructs specifying number of basis and order.
 
-        >>> bss = BSpline(n_basis=8, order=4)
+        >>> bss = BSplineBasis(n_basis=8, order=4)
 
         If no order is specified defaults to 4 because cubic splines are
         the most used. So the previous example is the same as:
 
-        >>> bss = BSpline(n_basis=8)
+        >>> bss = BSplineBasis(n_basis=8)
 
         It is also possible to create a BSpline basis specifying the knots.
 
-        >>> bss = BSpline(knots=[0, 0.2, 0.4, 0.6, 0.8, 1])
+        >>> bss = BSplineBasis(knots=[0, 0.2, 0.4, 0.6, 0.8, 1])
 
         Once we create a basis we can evaluate each of its functions at a
         set of points.
 
-        >>> bss = BSpline(n_basis=3, order=3)
+        >>> bss = BSplineBasis(n_basis=3, order=3)
         >>> bss([0, 0.5, 1])
         array([[[ 1.  ],
                 [ 0.25],

--- a/skfda/representation/basis/_constant.py
+++ b/skfda/representation/basis/_constant.py
@@ -1,0 +1,35 @@
+import warnings
+from typing import Optional
+
+from ...typing._base import DomainRangeLike
+from ._constant_basis import ConstantBasis
+
+
+class Constant(ConstantBasis):
+    """Constant basis.
+
+    Basis for constant functions
+
+    .. deprecated:: 0.8
+        Use :class:`~skfda.representation.basis.ConstantBasis` instead.
+
+    Parameters:
+        domain_range: The :term:`domain range` over which the basis can be
+            evaluated.
+
+    Examples:
+        Defines a contant base over the interval :math:`[0, 5]` consisting
+        on the constant function 1 on :math:`[0, 5]`.
+
+        >>> bs_cons = ConstantBasis((0,5))
+
+    """
+
+    def __init__(self, domain_range: Optional[DomainRangeLike] = None) -> None:
+        """Constant basis constructor."""
+        warnings.warn(
+            "The Constant class is deprecated. Use "
+            "ConstantBasis instead.",
+            DeprecationWarning,
+        )
+        super().__init__(domain_range=domain_range)

--- a/skfda/representation/basis/_constant_basis.py
+++ b/skfda/representation/basis/_constant_basis.py
@@ -6,10 +6,10 @@ from ...typing._base import DomainRangeLike
 from ...typing._numpy import NDArrayFloat
 from ._basis import Basis
 
-T = TypeVar("T", bound='Constant')
+T = TypeVar("T", bound='ConstantBasis')
 
 
-class Constant(Basis):
+class ConstantBasis(Basis):
     """Constant basis.
 
     Basis for constant functions
@@ -22,7 +22,7 @@ class Constant(Basis):
         Defines a contant base over the interval :math:`[0, 5]` consisting
         on the constant function 1 on :math:`[0, 5]`.
 
-        >>> bs_cons = Constant((0,5))
+        >>> bs_cons = ConstantBasis((0,5))
 
     """
 

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -359,7 +359,8 @@ class FDataBasis(FData):  # noqa: WPS214
 
         Examples:
             We first create the data basis.
-                >>> from skfda.representation.basis import FDataBasis, MonomialBasis
+                >>> from skfda.representation.basis import FDataBasis
+                >>> from skfda.representation.basis import MonomialBasis
                 >>> basis = MonomialBasis(n_basis=4)
                 >>> coefficients = [1, 1, 3, .5]
                 >>> fdata = FDataBasis(basis, coefficients)

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -65,13 +65,13 @@ class FDataBasis(FData):  # noqa: WPS214
             types of extrapolation.
 
     Examples:
-        >>> from skfda.representation.basis import FDataBasis, Monomial
+        >>> from skfda.representation.basis import FDataBasis, MonomialBasis
         >>>
-        >>> basis = Monomial(n_basis=4)
+        >>> basis = MonomialBasis(n_basis=4)
         >>> coefficients = [1, 1, 3, .5]
         >>> FDataBasis(basis, coefficients)
         FDataBasis(
-            basis=Monomial(domain_range=((0.0, 1.0),), n_basis=4),
+            basis=MonomialBasis(domain_range=((0.0, 1.0),), n_basis=4),
             coefficients=[[ 1.   1.   3.   0.5]],
             ...)
 
@@ -176,8 +176,8 @@ class FDataBasis(FData):  # noqa: WPS214
             >>> x
             array([ 3.,  3.,  1.,  1.,  3.])
 
-            >>> from skfda.representation.basis import FDataBasis, Fourier
-            >>> basis = Fourier((0, 1), n_basis=3)
+            >>> from skfda.representation.basis import FDataBasis, FourierBasis
+            >>> basis = FourierBasis((0, 1), n_basis=3)
             >>> fd = FDataBasis.from_data(x, grid_points=t, basis=basis)
             >>> fd.coefficients.round(2)
             array([[ 2.  , 0.71, 0.71]])
@@ -359,8 +359,8 @@ class FDataBasis(FData):  # noqa: WPS214
 
         Examples:
             We first create the data basis.
-                >>> from skfda.representation.basis import FDataBasis, Monomial
-                >>> basis = Monomial(n_basis=4)
+                >>> from skfda.representation.basis import FDataBasis, MonomialBasis
+                >>> basis = MonomialBasis(n_basis=4)
                 >>> coefficients = [1, 1, 3, .5]
                 >>> fdata = FDataBasis(basis, coefficients)
 
@@ -409,12 +409,12 @@ class FDataBasis(FData):  # noqa: WPS214
             FDataBasis object.
 
         Examples:
-            >>> from skfda.representation.basis import FDataBasis, Monomial
-            >>> basis = Monomial(n_basis=4)
+            >>> from skfda.representation.basis import FDataBasis, MonomialBasis
+            >>> basis = MonomialBasis(n_basis=4)
             >>> coefficients = [[0.5, 1, 2, .5], [1.5, 1, 4, .5]]
             >>> FDataBasis(basis, coefficients).sum()
             FDataBasis(
-                basis=Monomial(domain_range=((0.0, 1.0),), n_basis=4),
+                basis=MonomialBasis(domain_range=((0.0, 1.0),), n_basis=4),
                 coefficients=[[ 2.  2.  6.  1.]],
                 ...)
 
@@ -501,9 +501,9 @@ class FDataBasis(FData):  # noqa: WPS214
               object.
 
         Examples:
-            >>> from skfda.representation.basis import FDataBasis, Monomial
+            >>> from skfda.representation.basis import FDataBasis, MonomialBasis
             >>> fd = FDataBasis(coefficients=[[1, 1, 1], [1, 0, 1]],
-            ...                 basis=Monomial(domain_range=(0,5), n_basis=3))
+            ...                 basis=MonomialBasis(domain_range=(0,5), n_basis=3))
             >>> fd.to_grid([0, 1, 2])
             FDataGrid(
                 array([[[ 1.],

--- a/skfda/representation/basis/_finite_element.py
+++ b/skfda/representation/basis/_finite_element.py
@@ -1,0 +1,84 @@
+import warnings
+from typing import Optional
+
+from ...typing._base import DomainRangeLike
+from ...typing._numpy import ArrayLike
+from ._finite_element_basis import FiniteElementBasis
+
+
+class FiniteElement(FiniteElementBasis):
+    """Finite element basis.
+
+    Given a n-dimensional grid made of simplices, each element of the basis
+    is a piecewise linear function that takes the value 1 at exactly one
+    vertex and 0 in the other vertices.
+
+    .. deprecated:: 0.8
+        Use :class:`~skfda.representation.basis.FiniteElementBasis` instead.
+
+    Parameters:
+        vertices: The vertices of the grid.
+        cells: A list of individual cells, consisting in the indexes of
+            :math:`n+1` vertices for an n-dimensional domain space.
+
+    Examples:
+        >>> from skfda.representation.basis import FiniteElementBasis
+        >>> basis = FiniteElementBasis(
+        ...     vertices=[[0, 0], [0, 1], [1, 0], [1, 1]],
+        ...     cells=[[0, 1, 2], [1, 2, 3]],
+        ...     domain_range=[(0, 1), (0, 1)],
+        ... )
+
+        Evaluates all the functions in the basis in a list of discrete
+        values.
+
+        >>> basis([[0.1, 0.1], [0.6, 0.6], [0.1, 0.2], [0.8, 0.9]])
+        array([[[ 0.8],
+                [ 0. ],
+                [ 0.7],
+                [ 0. ]],
+               [[ 0.1],
+                [ 0.4],
+                [ 0.2],
+                [ 0.2]],
+               [[ 0.1],
+                [ 0.4],
+                [ 0.1],
+                [ 0.1]],
+               [[ 0. ],
+                [ 0.2],
+                [ 0. ],
+                [ 0.7]]])
+
+
+        >>> from scipy.spatial import Delaunay
+        >>> import numpy as np
+        >>>
+        >>> n_points = 10
+        >>> points = np.random.uniform(size=(n_points, 2))
+        >>> delaunay = Delaunay(points)
+        >>> basis = FiniteElementBasis(
+        ...     vertices=delaunay.points,
+        ...     cells=delaunay.simplices,
+        ... )
+        >>> basis.n_basis
+        10
+
+     """
+
+    def __init__(
+        self,
+        vertices: ArrayLike,
+        cells: ArrayLike,
+        domain_range: Optional[DomainRangeLike] = None,
+    ) -> None:
+        super().__init__(
+            vertices=vertices,
+            cells=cells,
+            domain_range=domain_range,
+        )
+        warnings.warn(
+            "The FiniteElement class is deprecated. Use "
+            "FiniteElementBasis instead.",
+            DeprecationWarning,
+        )

--- a/skfda/representation/basis/_finite_element_basis.py
+++ b/skfda/representation/basis/_finite_element_basis.py
@@ -6,10 +6,10 @@ from ...typing._base import DomainRangeLike
 from ...typing._numpy import ArrayLike, NDArrayFloat
 from ._basis import Basis
 
-T = TypeVar("T", bound='FiniteElement')
+T = TypeVar("T", bound='FiniteElementBasis')
 
 
-class FiniteElement(Basis):
+class FiniteElementBasis(Basis):
     """Finite element basis.
 
     Given a n-dimensional grid made of simplices, each element of the basis
@@ -22,8 +22,8 @@ class FiniteElement(Basis):
             :math:`n+1` vertices for an n-dimensional domain space.
 
     Examples:
-        >>> from skfda.representation.basis import FiniteElement
-        >>> basis = FiniteElement(
+        >>> from skfda.representation.basis import FiniteElementBasis
+        >>> basis = FiniteElementBasis(
         ...     vertices=[[0, 0], [0, 1], [1, 0], [1, 1]],
         ...     cells=[[0, 1, 2], [1, 2, 3]],
         ...     domain_range=[(0, 1), (0, 1)],
@@ -57,7 +57,7 @@ class FiniteElement(Basis):
         >>> n_points = 10
         >>> points = np.random.uniform(size=(n_points, 2))
         >>> delaunay = Delaunay(points)
-        >>> basis = FiniteElement(
+        >>> basis = FiniteElementBasis(
         ...     vertices=delaunay.points,
         ...     cells=delaunay.simplices,
         ... )

--- a/skfda/representation/basis/_fourier.py
+++ b/skfda/representation/basis/_fourier.py
@@ -1,0 +1,93 @@
+import warnings
+from typing import Optional
+
+import numpy as np
+
+from ...typing._base import DomainRangeLike
+from ._fourier_basis import FourierBasis
+
+
+class Fourier(FourierBasis):
+    r"""Fourier basis.
+
+    Defines a functional basis for representing functions on a fourier
+    series expansion of period :math:`T`. The number of basis is always odd.
+    If instantiated with an even number of basis, they will be incremented
+    automatically by one.
+
+    .. math::
+        \phi_0(t) = \frac{1}{\sqrt{2}}
+
+    .. math::
+        \phi_{2n -1}(t) = \frac{sin\left(\frac{2 \pi n}{T} t\right)}
+                                                    {\sqrt{\frac{T}{2}}}
+
+    .. math::
+        \phi_{2n}(t) = \frac{cos\left(\frac{2 \pi n}{T} t\right)}
+                                                    {\sqrt{\frac{T}{2}}}
+
+
+    This basis will be orthonormal if the period coincides with the length
+    of the interval in which it is defined.
+
+    .. deprecated:: 0.8
+        Use :class:`~skfda.representation.basis.FourierBasis` instead.
+
+    Parameters:
+        domain_range: A tuple of length 2 containing the initial and
+            end values of the interval over which the basis can be evaluated.
+        n_basis: Number of functions in the basis.
+        period: Period (:math:`T`).
+
+    Examples:
+        Constructs specifying number of basis, definition interval and period.
+
+        >>> fb = FourierBasis((0, np.pi), n_basis=3, period=1)
+        >>> fb([0, np.pi / 4, np.pi / 2, np.pi]).round(2)
+        array([[[ 1.  ],
+                [ 1.  ],
+                [ 1.  ],
+                [ 1.  ]],
+               [[ 0.  ],
+                [-1.38],
+                [-0.61],
+                [ 1.1 ]],
+               [[ 1.41],
+                [ 0.31],
+                [-1.28],
+                [ 0.89]]])
+
+        And evaluate second derivative
+
+        >>> deriv2 = fb.derivative(order=2)
+        >>> deriv2([0, np.pi / 4, np.pi / 2, np.pi]).round(2)
+        array([[[  0.  ],
+                [  0.  ],
+                [  0.  ],
+                [  0.  ]],
+               [[  0.  ],
+                [ 54.46],
+                [ 24.02],
+                [-43.37]],
+               [[-55.83],
+                [-12.32],
+                [ 50.4 ],
+                [-35.16]]])
+
+    """
+
+    def __init__(
+        self,
+        domain_range: Optional[DomainRangeLike] = None,
+        n_basis: int = 3,
+        period: Optional[float] = None,
+    ) -> None:
+        warnings.warn(
+            "The Fourier class is deprecated. Use FourierBasis instead.",
+            DeprecationWarning,
+        )
+        super().__init__(
+            domain_range=domain_range,
+            n_basis=n_basis,
+            period=period,
+        )

--- a/skfda/representation/basis/_fourier_basis.py
+++ b/skfda/representation/basis/_fourier_basis.py
@@ -7,7 +7,7 @@ from ...typing._base import DomainRangeLike
 from ...typing._numpy import NDArrayFloat
 from ._basis import Basis
 
-T = TypeVar("T", bound='Fourier')
+T = TypeVar("T", bound='FourierBasis')
 
 
 class _SinCos(Protocol):
@@ -20,7 +20,7 @@ class _SinCos(Protocol):
         pass
 
 
-class Fourier(Basis):
+class FourierBasis(Basis):
     r"""Fourier basis.
 
     Defines a functional basis for representing functions on a fourier
@@ -52,7 +52,7 @@ class Fourier(Basis):
     Examples:
         Constructs specifying number of basis, definition interval and period.
 
-        >>> fb = Fourier((0, np.pi), n_basis=3, period=1)
+        >>> fb = FourierBasis((0, np.pi), n_basis=3, period=1)
         >>> fb([0, np.pi / 4, np.pi / 2, np.pi]).round(2)
         array([[[ 1.  ],
                 [ 1.  ],
@@ -93,7 +93,7 @@ class Fourier(Basis):
         period: Optional[float] = None,
     ) -> None:
         """
-        Construct a Fourier object.
+        Construct a FourierBasis object.
 
         It forces the object to have an odd number of basis. If n_basis is
         even, it is incremented by one.

--- a/skfda/representation/basis/_monomial.py
+++ b/skfda/representation/basis/_monomial.py
@@ -1,0 +1,84 @@
+import warnings
+from typing import Optional
+
+from ...typing._base import DomainRangeLike
+from ._monomial_basis import MonomialBasis
+
+
+class Monomial(MonomialBasis):
+    """Monomial basis.
+
+    Basis formed by powers of the argument :math:`t`:
+
+    .. math::
+        1, t, t^2, t^3...
+
+    .. deprecated:: 0.8
+        Use :class:`~skfda.representation.basis.MonomialBasis` instead.
+
+    Attributes:
+        domain_range: a tuple of length 2 containing the initial and
+            end values of the interval over which the basis can be evaluated.
+        n_basis: number of functions in the basis.
+
+    Examples:
+        Defines a monomial base over the interval :math:`[0, 5]` consisting
+        on the first 3 powers of :math:`t`: :math:`1, t, t^2`.
+
+        >>> bs_mon = MonomialBasis(domain_range=(0,5), n_basis=3)
+
+        And evaluates all the functions in the basis in a list of descrete
+        values.
+
+        >>> bs_mon([0., 1., 2.])
+        array([[[ 1.],
+                [ 1.],
+                [ 1.]],
+               [[ 0.],
+                [ 1.],
+                [ 2.]],
+               [[ 0.],
+                [ 1.],
+                [ 4.]]])
+
+        And also evaluates its derivatives
+
+        >>> deriv = bs_mon.derivative()
+        >>> deriv([0, 1, 2])
+        array([[[ 0.],
+                [ 0.],
+                [ 0.]],
+               [[ 1.],
+                [ 1.],
+                [ 1.]],
+               [[ 0.],
+                [ 2.],
+                [ 4.]]])
+        >>> deriv2 = bs_mon.derivative(order=2)
+        >>> deriv2([0, 1, 2])
+        array([[[ 0.],
+                [ 0.],
+                [ 0.]],
+               [[ 0.],
+                [ 0.],
+                [ 0.]],
+               [[ 2.],
+                [ 2.],
+                [ 2.]]])
+    """
+
+    def __init__(
+        self,
+        *,
+        domain_range: Optional[DomainRangeLike] = None,
+        n_basis: int = 1,
+    ):
+        super().__init__(
+            domain_range=domain_range,
+            n_basis=n_basis,
+        )
+        warnings.warn(
+            "The BSplines class is deprecated. Use "
+            "BSplineBasis instead.",
+            DeprecationWarning,
+        )

--- a/skfda/representation/basis/_monomial_basis.py
+++ b/skfda/representation/basis/_monomial_basis.py
@@ -6,10 +6,10 @@ import scipy.linalg
 from ...typing._numpy import NDArrayFloat
 from ._basis import Basis
 
-T = TypeVar("T", bound='Monomial')
+T = TypeVar("T", bound='MonomialBasis')
 
 
-class Monomial(Basis):
+class MonomialBasis(Basis):
     """Monomial basis.
 
     Basis formed by powers of the argument :math:`t`:
@@ -26,7 +26,7 @@ class Monomial(Basis):
         Defines a monomial base over the interval :math:`[0, 5]` consisting
         on the first 3 powers of :math:`t`: :math:`1, t, t^2`.
 
-        >>> bs_mon = Monomial(domain_range=(0,5), n_basis=3)
+        >>> bs_mon = MonomialBasis(domain_range=(0,5), n_basis=3)
 
         And evaluates all the functions in the basis in a list of descrete
         values.

--- a/skfda/representation/basis/_tensor.py
+++ b/skfda/representation/basis/_tensor.py
@@ -1,0 +1,73 @@
+
+import warnings
+from typing import Iterable
+
+from ._basis import Basis
+from ._tensor_basis import TensorBasis
+
+
+class Tensor(TensorBasis):
+    r"""Tensor basis.
+
+    Basis for multivariate functions constructed as a tensor product of
+    :math:`\mathbb{R} \to \mathbb{R}` bases.
+
+    .. deprecated:: 0.8
+        Use :class:`~skfda.representation.basis.TensorBasis` instead.
+
+    Attributes:
+        domain_range (tuple): a tuple of length ``dim_domain`` containing
+            the range of input values for each dimension.
+        n_basis (int): number of functions in the basis.
+
+    Examples:
+        Defines a tensor basis over the interval :math:`[0, 5] \times [0, 3]`
+        consisting on the functions
+
+        .. math::
+
+            1, v, u, uv, u^2, u^2v
+
+        >>> from skfda.representation.basis import TensorBasis, MonomialBasis
+        >>>
+        >>> basis_x = MonomialBasis(domain_range=(0,5), n_basis=3)
+        >>> basis_y = MonomialBasis(domain_range=(0,3), n_basis=2)
+        >>>
+        >>> basis = TensorBasis([basis_x, basis_y])
+
+
+        And evaluates all the functions in the basis in a list of descrete
+        values.
+
+        >>> basis([(0., 2.), (3., 0), (2., 3.)])
+        array([[[  1.],
+                [  1.],
+                [  1.]],
+               [[  2.],
+                [  0.],
+                [  3.]],
+               [[  0.],
+                [  3.],
+                [  2.]],
+               [[  0.],
+                [  0.],
+                [  6.]],
+               [[  0.],
+                [  9.],
+                [  4.]],
+               [[  0.],
+                [  0.],
+                [ 12.]]])
+
+    """
+
+    def __init__(self, basis_list: Iterable[Basis]):
+
+        super().__init__(
+            basis_list=basis_list,
+        )
+        warnings.warn(
+            "The Tensor class is deprecated. Use "
+            "TensorBasis instead.",
+            DeprecationWarning,
+        )

--- a/skfda/representation/basis/_tensor_basis.py
+++ b/skfda/representation/basis/_tensor_basis.py
@@ -8,7 +8,7 @@ from ...typing._numpy import NDArrayFloat
 from ._basis import Basis
 
 
-class Tensor(Basis):
+class TensorBasis(Basis):
     r"""Tensor basis.
 
     Basis for multivariate functions constructed as a tensor product of
@@ -28,12 +28,12 @@ class Tensor(Basis):
 
             1, v, u, uv, u^2, u^2v
 
-        >>> from skfda.representation.basis import Tensor, Monomial
+        >>> from skfda.representation.basis import TensorBasis, MonomialBasis
         >>>
-        >>> basis_x = Monomial(domain_range=(0,5), n_basis=3)
-        >>> basis_y = Monomial(domain_range=(0,3), n_basis=2)
+        >>> basis_x = MonomialBasis(domain_range=(0,5), n_basis=3)
+        >>> basis_y = MonomialBasis(domain_range=(0,3), n_basis=2)
         >>>
-        >>> basis = Tensor([basis_x, basis_y])
+        >>> basis = TensorBasis([basis_x, basis_y])
 
 
         And evaluates all the functions in the basis in a list of descrete

--- a/skfda/representation/basis/_vector.py
+++ b/skfda/representation/basis/_vector.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import warnings
+from typing import Iterable
+
+from ._basis import Basis
+from ._vector_basis import VectorValuedBasis
+
+
+class VectorValued(VectorValuedBasis):
+    r"""Vector-valued basis.
+
+    Basis for :term:`vector-valued functions <vector-valued function>`
+    constructed from scalar-valued bases.
+
+    For each dimension in the :term:`codomain`, it uses a scalar-valued basis
+    multiplying each basis by the corresponding unitary vector.
+
+    .. deprecated:: 0.8
+        Use :class:`~skfda.representation.basis.VectorValuedBasis` instead.
+
+    Attributes:
+        domain_range (tuple): a tuple of length ``dim_domain`` containing
+            the range of input values for each dimension.
+        n_basis (int): number of functions in the basis.
+
+    Examples:
+        Defines a vector-valued base over the interval :math:`[0, 5]`
+        consisting on the functions
+
+        .. math::
+
+            1 \vec{i}, t \vec{i}, t^2 \vec{i}, 1 \vec{j}, t \vec{j}
+
+        >>> from skfda.representation.basis import VectorValuedBasis
+        >>> from skfda.representation.basis import MonomialBasis
+        >>>
+        >>> basis_x = MonomialBasis(domain_range=(0,5), n_basis=3)
+        >>> basis_y = MonomialBasis(domain_range=(0,5), n_basis=2)
+        >>>
+        >>> basis = VectorValuedBasis([basis_x, basis_y])
+
+
+        And evaluates all the functions in the basis in a list of descrete
+        values.
+
+        >>> basis([0., 1., 2.])
+        array([[[ 1.,  0.],
+                [ 1.,  0.],
+                [ 1.,  0.]],
+               [[ 0.,  0.],
+                [ 1.,  0.],
+                [ 2.,  0.]],
+               [[ 0.,  0.],
+                [ 1.,  0.],
+                [ 4.,  0.]],
+               [[ 0.,  1.],
+                [ 0.,  1.],
+                [ 0.,  1.]],
+               [[ 0.,  0.],
+                [ 0.,  1.],
+                [ 0.,  2.]]])
+
+    """
+
+    def __init__(self, basis_list: Iterable[Basis]) -> None:
+        super().__init__(
+            basis_list=basis_list,
+        )
+
+        warnings.warn(
+            "The VectorValued class is deprecated. Use "
+            "VectorValuedBasis instead.",
+            DeprecationWarning,
+        )

--- a/skfda/representation/basis/_vector_basis.py
+++ b/skfda/representation/basis/_vector_basis.py
@@ -8,10 +8,10 @@ import scipy.linalg
 from ...typing._numpy import NDArrayFloat
 from ._basis import Basis
 
-T = TypeVar("T", bound='VectorValued')
+T = TypeVar("T", bound='VectorValuedBasis')
 
 
-class VectorValued(Basis):
+class VectorValuedBasis(Basis):
     r"""Vector-valued basis.
 
     Basis for :term:`vector-valued functions <vector-valued function>`
@@ -33,12 +33,13 @@ class VectorValued(Basis):
 
             1 \vec{i}, t \vec{i}, t^2 \vec{i}, 1 \vec{j}, t \vec{j}
 
-        >>> from skfda.representation.basis import VectorValued, Monomial
+        >>> from skfda.representation.basis import VectorValuedBasis
+        >>> from skfda.representation.basis import MonomialBasis
         >>>
-        >>> basis_x = Monomial(domain_range=(0,5), n_basis=3)
-        >>> basis_y = Monomial(domain_range=(0,5), n_basis=2)
+        >>> basis_x = MonomialBasis(domain_range=(0,5), n_basis=3)
+        >>> basis_y = MonomialBasis(domain_range=(0,5), n_basis=2)
         >>>
-        >>> basis = VectorValued([basis_x, basis_y])
+        >>> basis = VectorValuedBasis([basis_x, basis_y])
 
 
         And evaluates all the functions in the basis in a list of descrete
@@ -159,7 +160,7 @@ class VectorValued(Basis):
 
         new_basis = self.basis_list[key]
         if not isinstance(new_basis, Basis):
-            new_basis = VectorValued(new_basis)
+            new_basis = VectorValuedBasis(new_basis)
 
         new_coefs = coef_splits[key]
         if not isinstance(new_coefs, np.ndarray):

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -918,7 +918,7 @@ class FDataGrid(FData):  # noqa: WPS214
             array([ 3.,  3.,  1.,  1.,  3.])
 
             >>> fd = FDataGrid(x, t)
-            >>> basis = skfda.representation.basis.Fourier(n_basis=3)
+            >>> basis = skfda.representation.basis.FourierBasis(n_basis=3)
             >>> fd_b = fd.to_basis(basis)
             >>> fd_b.coefficients.round(2)
             array([[ 2.  , 0.71, 0.71]])

--- a/skfda/tests/test_basis.py
+++ b/skfda/tests/test_basis.py
@@ -10,11 +10,11 @@ from skfda import concatenate
 from skfda.datasets import fetch_weather
 from skfda.misc import inner_product_matrix
 from skfda.representation.basis import (
-    BSpline,
-    Constant,
+    BSplineBasis,
+    ConstantBasis,
     FDataBasis,
-    Fourier,
-    Monomial,
+    FourierBasis,
+    MonomialBasis,
 )
 from skfda.representation.grid import FDataGrid
 
@@ -28,7 +28,7 @@ class TestBasis(unittest.TestCase):
         """Test basis conversion using Cholesky method."""
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
-        basis = BSpline((0, 1), n_basis=5)
+        basis = BSplineBasis((0, 1), n_basis=5)
         np.testing.assert_array_almost_equal(
             FDataBasis.from_data(
                 x,
@@ -43,7 +43,7 @@ class TestBasis(unittest.TestCase):
         """Test basis conversion using QR method."""
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
-        basis = BSpline((0, 1), n_basis=5)
+        basis = BSplineBasis((0, 1), n_basis=5)
         np.testing.assert_array_almost_equal(
             FDataBasis.from_data(
                 x,
@@ -56,7 +56,7 @@ class TestBasis(unittest.TestCase):
 
     def test_basis_inner_matrix(self) -> None:
         """Test the inner product matrix of FDataBasis objects."""
-        basis = Monomial(n_basis=3)
+        basis = MonomialBasis(n_basis=3)
 
         np.testing.assert_array_almost_equal(
             basis.inner_product_matrix(),
@@ -77,7 +77,7 @@ class TestBasis(unittest.TestCase):
         )
 
         np.testing.assert_array_almost_equal(
-            basis.inner_product_matrix(Monomial(n_basis=4)),
+            basis.inner_product_matrix(MonomialBasis(n_basis=4)),
             [
                 [1, 1 / 2, 1 / 3, 1 / 4],
                 [1 / 2, 1 / 3, 1 / 4, 1 / 5],
@@ -89,7 +89,7 @@ class TestBasis(unittest.TestCase):
 
     def test_basis_gram_matrix_monomial(self) -> None:
         """Test the Gram matrix with monomial basis."""
-        basis = Monomial(n_basis=3)
+        basis = MonomialBasis(n_basis=3)
         gram_matrix = basis.gram_matrix()
         gram_matrix_numerical = basis._gram_matrix_numerical()  # noqa: WPS437
         gram_matrix_res = np.array([
@@ -109,7 +109,7 @@ class TestBasis(unittest.TestCase):
 
     def test_basis_gram_matrix_fourier(self) -> None:
         """Test the Gram matrix with fourier basis."""
-        basis = Fourier(n_basis=3)
+        basis = FourierBasis(n_basis=3)
         gram_matrix = basis.gram_matrix()
         gram_matrix_numerical = basis._gram_matrix_numerical()  # noqa: WPS437
         gram_matrix_res = np.identity(3)
@@ -127,7 +127,7 @@ class TestBasis(unittest.TestCase):
 
     def test_basis_gram_matrix_bspline(self) -> None:
         """Test the Gram matrix with B-spline basis."""
-        basis = BSpline(n_basis=6)
+        basis = BSplineBasis(n_basis=6)
         gram_matrix = basis.gram_matrix()
         gram_matrix_numerical = basis._gram_matrix_numerical()  # noqa: WPS437
         gram_matrix_res = np.array([
@@ -158,8 +158,8 @@ class TestBasis(unittest.TestCase):
 
     def test_basis_basis_inprod(self) -> None:
         """Test inner product between different basis."""
-        monomial = Monomial(n_basis=4)
-        bspline = BSpline(n_basis=5, order=4)
+        monomial = MonomialBasis(n_basis=4)
+        bspline = BSplineBasis(n_basis=5, order=4)
         np.testing.assert_allclose(
             monomial.inner_product_matrix(bspline),
             np.array([
@@ -177,8 +177,8 @@ class TestBasis(unittest.TestCase):
 
     def test_basis_fdatabasis_inprod(self) -> None:
         """Test inner product between different basis expansions."""
-        monomial = Monomial(n_basis=4)
-        bspline = BSpline(n_basis=5, order=3)
+        monomial = MonomialBasis(n_basis=4)
+        bspline = BSplineBasis(n_basis=5, order=3)
         bsplinefd = FDataBasis(bspline, np.arange(0, 15).reshape(3, 5))
 
         np.testing.assert_allclose(
@@ -194,7 +194,7 @@ class TestBasis(unittest.TestCase):
 
     def test_fdatabasis_fdatabasis_inprod(self) -> None:
         """Test inner product between FDataBasis objects."""
-        monomial = Monomial(n_basis=4)
+        monomial = MonomialBasis(n_basis=4)
         monomialfd = FDataBasis(
             monomial,
             [
@@ -205,7 +205,7 @@ class TestBasis(unittest.TestCase):
                 [5, 6, 2, 0],
             ],
         )
-        bspline = BSpline(n_basis=5, order=3)
+        bspline = BSplineBasis(n_basis=5, order=3)
         bsplinefd = FDataBasis(bspline, np.arange(0, 15).reshape(3, 5))
 
         np.testing.assert_allclose(
@@ -222,8 +222,8 @@ class TestBasis(unittest.TestCase):
 
     def test_comutativity_inprod(self) -> None:
         """Test commutativity of the inner product."""
-        monomial = Monomial(n_basis=4)
-        bspline = BSpline(n_basis=5, order=3)
+        monomial = MonomialBasis(n_basis=4)
+        bspline = BSplineBasis(n_basis=5, order=3)
         bsplinefd = FDataBasis(bspline, np.arange(0, 15).reshape(3, 5))
 
         np.testing.assert_allclose(
@@ -235,8 +235,8 @@ class TestBasis(unittest.TestCase):
         """Test concatenation of two FDataBasis."""
         sample1 = np.arange(0, 10)
         sample2 = np.arange(10, 20)
-        fd1 = FDataGrid([sample1]).to_basis(Fourier(n_basis=5))
-        fd2 = FDataGrid([sample2]).to_basis(Fourier(n_basis=5))
+        fd1 = FDataGrid([sample1]).to_basis(FourierBasis(n_basis=5))
+        fd2 = FDataGrid([sample2]).to_basis(FourierBasis(n_basis=5))
 
         fd = concatenate([fd1, fd2])
 
@@ -254,13 +254,14 @@ class TestFDataBasisOperations(unittest.TestCase):
 
     def test_fdatabasis_add(self) -> None:
         """Test addition of FDataBasis."""
-        monomial1 = FDataBasis(Monomial(n_basis=3), [1, 2, 3])
-        monomial2 = FDataBasis(Monomial(n_basis=3), [[1, 2, 3], [3, 4, 5]])
+        monomial1 = FDataBasis(MonomialBasis(n_basis=3), [1, 2, 3])
+        monomial2 = FDataBasis(MonomialBasis(
+            n_basis=3), [[1, 2, 3], [3, 4, 5]])
 
         self.assertTrue(
             (monomial1 + monomial2).equals(
                 FDataBasis(
-                    Monomial(n_basis=3),
+                    MonomialBasis(n_basis=3),
                     [[2, 4, 6], [4, 6, 8]],
                 ),
             ),
@@ -268,19 +269,20 @@ class TestFDataBasisOperations(unittest.TestCase):
 
         with np.testing.assert_raises(TypeError):
             monomial2 + FDataBasis(  # noqa: WPS428
-                Fourier(n_basis=3),
+                FourierBasis(n_basis=3),
                 [[2, 2, 3], [5, 4, 5]],
             )
 
     def test_fdatabasis_sub(self) -> None:
         """Test subtraction of FDataBasis."""
-        monomial1 = FDataBasis(Monomial(n_basis=3), [1, 2, 3])
-        monomial2 = FDataBasis(Monomial(n_basis=3), [[1, 2, 3], [3, 4, 5]])
+        monomial1 = FDataBasis(MonomialBasis(n_basis=3), [1, 2, 3])
+        monomial2 = FDataBasis(MonomialBasis(
+            n_basis=3), [[1, 2, 3], [3, 4, 5]])
 
         self.assertTrue(
             (monomial1 - monomial2).equals(
                 FDataBasis(
-                    Monomial(n_basis=3),
+                    MonomialBasis(n_basis=3),
                     [[0, 0, 0], [-2, -2, -2]],
                 ),
             ),
@@ -288,13 +290,13 @@ class TestFDataBasisOperations(unittest.TestCase):
 
         with np.testing.assert_raises(TypeError):
             monomial2 - FDataBasis(  # noqa: WPS428
-                Fourier(n_basis=3),
+                FourierBasis(n_basis=3),
                 [[2, 2, 3], [5, 4, 5]],
             )
 
     def test_fdatabasis_mul(self) -> None:
         """Test multiplication of FDataBasis."""
-        basis = Monomial(n_basis=3)
+        basis = MonomialBasis(n_basis=3)
 
         monomial1 = FDataBasis(basis, [1, 2, 3])
         monomial2 = FDataBasis(basis, [[1, 2, 3], [3, 4, 5]])
@@ -343,7 +345,7 @@ class TestFDataBasisOperations(unittest.TestCase):
 
         with np.testing.assert_raises(TypeError):
             monomial2 * FDataBasis(  # noqa: WPS428
-                Fourier(n_basis=3),
+                FourierBasis(n_basis=3),
                 [[2, 2, 3], [5, 4, 5]],
             )
 
@@ -352,7 +354,7 @@ class TestFDataBasisOperations(unittest.TestCase):
 
     def test_fdatabasis_div(self) -> None:
         """Test division of FDataBasis."""
-        basis = Monomial(n_basis=3)
+        basis = MonomialBasis(n_basis=3)
 
         monomial1 = FDataBasis(basis, [1, 2, 3])
         monomial2 = FDataBasis(basis, [[1, 2, 3], [3, 4, 5]])
@@ -389,14 +391,14 @@ class TestFDataBasisDerivatives(unittest.TestCase):
     def test_fdatabasis_derivative_constant(self) -> None:
         """Test derivatives with a constant basis."""
         constant = FDataBasis(
-            Constant(),
+            ConstantBasis(),
             [[1], [2], [3], [4]],
         )
 
         self.assertTrue(
             constant.derivative().equals(
                 FDataBasis(
-                    Constant(),
+                    ConstantBasis(),
                     [[0], [0], [0], [0]],
                 ),
             ),
@@ -405,7 +407,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         self.assertTrue(
             constant.derivative(order=0).equals(
                 FDataBasis(
-                    Constant(),
+                    ConstantBasis(),
                     [[1], [2], [3], [4]],
                 ),
             ),
@@ -414,12 +416,12 @@ class TestFDataBasisDerivatives(unittest.TestCase):
     def test_fdatabasis_derivative_monomial(self) -> None:
         """Test derivatives with a monomial basis."""
         monomial = FDataBasis(
-            Monomial(n_basis=8),
+            MonomialBasis(n_basis=8),
             [1, 5, 8, 9, 7, 8, 4, 5],
         )
 
         monomial2 = FDataBasis(
-            Monomial(n_basis=5),
+            MonomialBasis(n_basis=5),
             [
                 [4, 9, 7, 4, 3],
                 [1, 7, 9, 8, 5],
@@ -430,7 +432,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         self.assertTrue(
             monomial.derivative().equals(
                 FDataBasis(
-                    Monomial(n_basis=7),
+                    MonomialBasis(n_basis=7),
                     [5, 16, 27, 28, 40, 24, 35],
                 ),
             ),
@@ -443,7 +445,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         self.assertTrue(
             monomial.derivative(order=6).equals(
                 FDataBasis(
-                    Monomial(n_basis=2),
+                    MonomialBasis(n_basis=2),
                     [2880, 25200],
                 ),
             ),
@@ -452,7 +454,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         self.assertTrue(
             monomial2.derivative().equals(
                 FDataBasis(
-                    Monomial(n_basis=4),
+                    MonomialBasis(n_basis=4),
                     [
                         [9, 14, 12, 12],
                         [7, 18, 24, 20],
@@ -469,7 +471,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         self.assertTrue(
             monomial2.derivative(order=3).equals(
                 FDataBasis(
-                    Monomial(n_basis=2),
+                    MonomialBasis(n_basis=2),
                     [
                         [24, 72],
                         [48, 120],
@@ -482,12 +484,12 @@ class TestFDataBasisDerivatives(unittest.TestCase):
     def test_fdatabasis_derivative_fourier(self) -> None:
         """Test derivatives with a fourier basis."""
         fourier = FDataBasis(
-            Fourier(n_basis=7),
+            FourierBasis(n_basis=7),
             [1, 5, 8, 9, 8, 4, 5],
         )
 
         fourier2 = FDataBasis(
-            Fourier(n_basis=5),
+            FourierBasis(n_basis=5),
             [
                 [4, 9, 7, 4, 3],
                 [1, 7, 9, 8, 5],
@@ -550,11 +552,11 @@ class TestFDataBasisDerivatives(unittest.TestCase):
     def test_fdatabasis_derivative_bspline(self) -> None:
         """Test derivatives with a B-spline basis."""
         bspline = FDataBasis(
-            BSpline(n_basis=8),
+            BSplineBasis(n_basis=8),
             [1, 5, 8, 9, 7, 8, 4, 5],
         )
         bspline2 = FDataBasis(
-            BSpline(n_basis=5),
+            BSplineBasis(n_basis=5),
             [
                 [4, 9, 7, 4, 3],
                 [1, 7, 9, 8, 5],
@@ -565,7 +567,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         bs0 = bspline.derivative(order=0)
         bs1 = bspline.derivative()
         bs2 = bspline.derivative(order=2)
-        np.testing.assert_equal(bs1.basis, BSpline(n_basis=7, order=3))
+        np.testing.assert_equal(bs1.basis, BSplineBasis(n_basis=7, order=3))
 
         np.testing.assert_almost_equal(
             bs1.coefficients,
@@ -576,7 +578,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
 
         np.testing.assert_equal(
             bs2.basis,
-            BSpline(n_basis=6, order=2),
+            BSplineBasis(n_basis=6, order=2),
         )
 
         np.testing.assert_almost_equal(
@@ -588,7 +590,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
         bs1 = bspline2.derivative()
         bs2 = bspline2.derivative(order=2)
 
-        np.testing.assert_equal(bs1.basis, BSpline(n_basis=4, order=3))
+        np.testing.assert_equal(bs1.basis, BSplineBasis(n_basis=4, order=3))
 
         np.testing.assert_almost_equal(
             bs1.coefficients,
@@ -603,7 +605,7 @@ class TestFDataBasisDerivatives(unittest.TestCase):
 
         np.testing.assert_equal(
             bs2.basis,
-            BSpline(n_basis=3, order=2),
+            BSplineBasis(n_basis=3, order=2),
         )
 
         np.testing.assert_almost_equal(
@@ -623,11 +625,11 @@ class TestVectorValuedBasis(unittest.TestCase):
         """Test vector valued basis."""
         X, _ = fetch_weather(return_X_y=True)
 
-        basis_dim = skfda.representation.basis.Fourier(
+        basis_dim = skfda.representation.basis.FourierBasis(
             n_basis=7,
             domain_range=X.domain_range,
         )
-        basis = skfda.representation.basis.VectorValued(
+        basis = skfda.representation.basis.VectorValuedBasis(
             [basis_dim] * 2,
         )
 
@@ -661,11 +663,14 @@ class TestTensorBasis(unittest.TestCase):
 
         self.dims = (self.n_x, self.n_y, self.n_z)
 
-        self.basis_x = skfda.representation.basis.Monomial(n_basis=self.n_x)
-        self.basis_y = skfda.representation.basis.Fourier(n_basis=self.n_y)
-        self.basis_z = skfda.representation.basis.BSpline(n_basis=self.n_z)
+        self.basis_x = skfda.representation.basis.MonomialBasis(
+            n_basis=self.n_x)
+        self.basis_y = skfda.representation.basis.FourierBasis(
+            n_basis=self.n_y)
+        self.basis_z = skfda.representation.basis.BSplineBasis(
+            n_basis=self.n_z)
 
-        self.basis = skfda.representation.basis.Tensor([
+        self.basis = skfda.representation.basis.TensorBasis([
             self.basis_x,
             self.basis_y,
             self.basis_z,

--- a/skfda/tests/test_extrapolation.py
+++ b/skfda/tests/test_extrapolation.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from skfda import FDataBasis, FDataGrid
 from skfda.datasets import make_sinusoidal_process
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 from skfda.representation.extrapolation import (
     BoundaryExtrapolation,
     ExceptionExtrapolation,
@@ -21,13 +21,13 @@ class TestExtrapolation(unittest.TestCase):
     def setUp(self) -> None:
         """Create example data."""
         self.grid = make_sinusoidal_process(n_samples=2, random_state=0)
-        self.basis = self.grid.to_basis(Fourier())
+        self.basis = self.grid.to_basis(FourierBasis())
         self.dummy_data = [[1, 2, 3], [2, 3, 4]]
 
     def test_constructor_fdatabasis_setting(self) -> None:
         """Check argument normalization in constructor for FDataBasis."""
         coeff = self.dummy_data
-        basis = Fourier(n_basis=3)
+        basis = FourierBasis(n_basis=3)
 
         a = FDataBasis(basis, coeff)
         self.assertEqual(a.extrapolation, None)

--- a/skfda/tests/test_fdatabasis_evaluation.py
+++ b/skfda/tests/test_fdatabasis_evaluation.py
@@ -4,13 +4,13 @@ import unittest
 import numpy as np
 
 from skfda.representation.basis import (
-    BSpline,
-    Constant,
+    BSplineBasis,
+    ConstantBasis,
     FDataBasis,
-    Fourier,
-    Monomial,
-    Tensor,
-    VectorValued,
+    FourierBasis,
+    MonomialBasis,
+    TensorBasis,
+    VectorValuedBasis,
 )
 
 
@@ -24,7 +24,7 @@ class TestFDataBasisEvaluation(unittest.TestCase):
 
     def test_evaluation_single_point(self) -> None:
         """Test the evaluation of a single point FDataBasis."""
-        fourier = Fourier(
+        fourier = FourierBasis(
             domain_range=(0, 1),
             n_basis=3,
         )
@@ -54,7 +54,7 @@ class TestFDataBasisEvaluation(unittest.TestCase):
         Nothing should change as the domain dimension is 1.
 
         """
-        fourier = Fourier(
+        fourier = FourierBasis(
             domain_range=(0, 1),
             n_basis=3,
         )
@@ -93,7 +93,7 @@ class TestFDataBasisEvaluation(unittest.TestCase):
 
     def test_evaluation_unaligned(self) -> None:
         """Test the unaligned evaluation."""
-        fourier = Fourier(
+        fourier = FourierBasis(
             domain_range=(0, 1),
             n_basis=3,
         )
@@ -134,7 +134,7 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
     def test_simple_evaluation(self) -> None:
         """Compare Fourier evaluation with R package fda."""
-        fourier = Fourier(
+        fourier = FourierBasis(
             domain_range=(0, 2),
             n_basis=5,
         )
@@ -164,7 +164,7 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
     def test_evaluation_derivative(self) -> None:
         """Test the evaluation of the derivative of Fourier."""
-        fourier = Fourier(domain_range=(0, 1), n_basis=3)
+        fourier = FourierBasis(domain_range=(0, 1), n_basis=3)
 
         coefficients = np.array([
             [0.00078238, 0.48857741, 0.63971985],
@@ -193,7 +193,7 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
 
     def test_simple_evaluation(self) -> None:
         """Compare BSpline evaluation with R package fda."""
-        bspline = BSpline(
+        bspline = BSplineBasis(
             domain_range=(0, 2),
             n_basis=5,
         )
@@ -223,7 +223,7 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
 
     def test_evaluation_derivative(self) -> None:
         """Test the evaluation of the derivative of BSpline."""
-        bspline = BSpline(
+        bspline = BSplineBasis(
             domain_range=(0, 1),
             n_basis=5,
             order=3,
@@ -253,7 +253,7 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
 
     def test_evaluation_simple_monomial(self) -> None:
         """Compare Monomial evaluation with R package fda."""
-        monomial = Monomial(
+        monomial = MonomialBasis(
             domain_range=(0, 2),
             n_basis=5,
         )
@@ -283,7 +283,7 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
 
     def test_evaluation_derivative(self) -> None:
         """Test the evaluation of the derivative of Monomial."""
-        monomial = Monomial(
+        monomial = MonomialBasis(
             domain_range=(0, 1),
             n_basis=3,
         )
@@ -312,10 +312,10 @@ class TestBasisEvaluationVectorValued(unittest.TestCase):
 
     def test_constant(self) -> None:
         """Test vector-valued constant basis."""
-        basis_first = Constant()
-        basis_second = Constant()
+        basis_first = ConstantBasis()
+        basis_second = ConstantBasis()
 
-        basis = VectorValued([basis_first, basis_second])
+        basis = VectorValuedBasis([basis_first, basis_second])
 
         fd = FDataBasis(basis=basis, coefficients=[[1, 2], [3, 4]])
 
@@ -327,13 +327,13 @@ class TestBasisEvaluationVectorValued(unittest.TestCase):
 
     def test_monomial(self) -> None:
         """Test vector-valued monomial basis."""
-        basis_first = Constant(domain_range=(0, 5))
-        basis_second = Monomial(
+        basis_first = ConstantBasis(domain_range=(0, 5))
+        basis_second = MonomialBasis(
             n_basis=3,
             domain_range=(0, 5),
         )
 
-        basis = VectorValued([basis_first, basis_second])
+        basis = VectorValuedBasis([basis_first, basis_second])
 
         fd = FDataBasis(
             basis=basis,
@@ -360,9 +360,9 @@ class TestBasisEvaluationTensor(unittest.TestCase):
 
     def test_tensor_monomial_constant(self) -> None:
         """Test monomial ⊗ constant basis."""
-        basis = Tensor([
-            Monomial(n_basis=2),
-            Constant(),
+        basis = TensorBasis([
+            MonomialBasis(n_basis=2),
+            ConstantBasis(),
         ])
 
         fd = FDataBasis(

--- a/skfda/tests/test_fpca.py
+++ b/skfda/tests/test_fpca.py
@@ -9,7 +9,7 @@ from skfda.datasets import fetch_weather
 from skfda.misc.operators import LinearDifferentialOperator
 from skfda.misc.regularization import L2Regularization
 from skfda.preprocessing.dim_reduction import FPCA
-from skfda.representation.basis import Basis, BSpline, Fourier
+from skfda.representation.basis import Basis, BSplineBasis, FourierBasis
 
 
 class FPCATestCase(unittest.TestCase):
@@ -21,7 +21,7 @@ class FPCATestCase(unittest.TestCase):
         with self.assertRaises(AttributeError):
             fpca.fit(None)  # type: ignore[arg-type]
 
-        basis = Fourier(n_basis=1)
+        basis = FourierBasis(n_basis=1)
         # Check that if n_components is bigger than the number of samples then
         # an exception should be thrown
         fd = FDataBasis(basis, [[0.9]])
@@ -60,7 +60,7 @@ class FPCATestCase(unittest.TestCase):
         fd_data = fetch_weather()['data'].coordinates[0]
 
         # Initialize basis data
-        basis = Fourier(n_basis=n_basis, domain_range=(0, 365))
+        basis = FourierBasis(n_basis=n_basis, domain_range=(0, 365))
         fd_basis = fd_data.to_basis(basis)
 
         fpca = FPCA(
@@ -114,7 +114,7 @@ class FPCATestCase(unittest.TestCase):
         fd_data = fetch_weather()['data'].coordinates[0]
 
         # Initialize basis data
-        basis = Fourier(n_basis=n_basis, domain_range=(0, 365))
+        basis = FourierBasis(n_basis=n_basis, domain_range=(0, 365))
         fd_basis = fd_data.to_basis(basis)
 
         fpca = FPCA(
@@ -198,7 +198,7 @@ class FPCATestCase(unittest.TestCase):
         fd_data = fetch_weather()['data'].coordinates[0]
 
         # Initialize basis data
-        basis = Fourier(n_basis=n_basis, domain_range=(0, 365))
+        basis = FourierBasis(n_basis=n_basis, domain_range=(0, 365))
         fd_basis = fd_data.to_basis(basis)
 
         fpca = FPCA(n_components=n_components)
@@ -594,7 +594,7 @@ class FPCATestCase(unittest.TestCase):
         # Low dimensional case (n_samples>n_grid)
         n_samples = 1000
         n_grid = 100
-        bsp = BSpline(
+        bsp = BSplineBasis(
             domain_range=(0, 50),
             n_basis=100,
             order=3,
@@ -610,7 +610,7 @@ class FPCATestCase(unittest.TestCase):
         # (almost) High dimensional case (n_samples<n_grid)
         n_samples = 100
         n_grid = 1000
-        bsp = BSpline(
+        bsp = BSplineBasis(
             domain_range=(0, 50),
             n_basis=100,
             order=3,
@@ -662,7 +662,7 @@ class FPCATestCase(unittest.TestCase):
         # Low dimensional case: n_basis<<n_samples
         n_samples = 1000
         n_basis = 20
-        bsp = BSpline(
+        bsp = BSplineBasis(
             domain_range=(0, 50),
             n_basis=n_basis,
             order=3,
@@ -677,7 +677,7 @@ class FPCATestCase(unittest.TestCase):
         # Case n_samples<n_basis
         n_samples = 10
         n_basis = 20
-        bsp = BSpline(
+        bsp = BSplineBasis(
             domain_range=(0, 50),
             n_basis=n_basis,
             order=3,

--- a/skfda/tests/test_functional_transformers.py
+++ b/skfda/tests/test_functional_transformers.py
@@ -21,7 +21,7 @@ class TestUnconditionalExpectedValues(unittest.TestCase):
             np.log,
         )
         data_basis = unconditional_expected_value(
-            X[:5].to_basis(basis.BSpline(n_basis=7)),
+            X[:5].to_basis(basis.BSplineBasis(n_basis=7)),
             np.log,
         )
         np.testing.assert_allclose(data_basis, data_grid, rtol=1e-3)

--- a/skfda/tests/test_hotelling.py
+++ b/skfda/tests/test_hotelling.py
@@ -3,7 +3,7 @@ import unittest
 
 from skfda.inference.hotelling import hotelling_t2, hotelling_test_ind
 from skfda.representation import FDataGrid
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 
 class HotellingTests(unittest.TestCase):
@@ -14,9 +14,9 @@ class HotellingTests(unittest.TestCase):
         fd1 = FDataGrid([[1, 1, 1]])
 
         with self.assertRaises(TypeError):
-            hotelling_test_ind(fd1.to_basis(Fourier(n_basis=3)), fd1)
+            hotelling_test_ind(fd1.to_basis(FourierBasis(n_basis=3)), fd1)
         with self.assertRaises(TypeError):
-            hotelling_test_ind(fd1, fd1.to_basis(Fourier(n_basis=3)))
+            hotelling_test_ind(fd1, fd1.to_basis(FourierBasis(n_basis=3)))
         with self.assertRaises(ValueError):
             hotelling_test_ind(fd1, fd1, n_reps=0)
 
@@ -25,9 +25,9 @@ class HotellingTests(unittest.TestCase):
         fd1 = FDataGrid([[1, 1, 1]])
 
         with self.assertRaises(TypeError):
-            hotelling_t2(fd1.to_basis(Fourier(n_basis=3)), fd1)
+            hotelling_t2(fd1.to_basis(FourierBasis(n_basis=3)), fd1)
         with self.assertRaises(TypeError):
-            hotelling_t2(fd1, fd1.to_basis(Fourier(n_basis=3)))
+            hotelling_t2(fd1, fd1.to_basis(FourierBasis(n_basis=3)))
 
     def test_hotelling_t2(self) -> None:
         """Trivial checks for the statistic."""
@@ -36,8 +36,8 @@ class HotellingTests(unittest.TestCase):
         self.assertAlmostEqual(hotelling_t2(fd1, fd1), 0)
         self.assertAlmostEqual(hotelling_t2(fd1, fd2), 1)
 
-        fd1 = fd1.to_basis(Fourier(n_basis=3))
-        fd2 = fd2.to_basis(Fourier(n_basis=3))
+        fd1 = fd1.to_basis(FourierBasis(n_basis=3))
+        fd2 = fd2.to_basis(FourierBasis(n_basis=3))
         self.assertAlmostEqual(hotelling_t2(fd1, fd1), 0)
         self.assertAlmostEqual(hotelling_t2(fd1, fd2), 1)
 

--- a/skfda/tests/test_kernel_regression.py
+++ b/skfda/tests/test_kernel_regression.py
@@ -15,7 +15,7 @@ from skfda.misc.hat_matrix import (
 from skfda.misc.kernels import normal, uniform
 from skfda.misc.metrics import l2_distance
 from skfda.ml.regression import KernelRegression
-from skfda.representation.basis import FDataBasis, Fourier, Monomial
+from skfda.representation.basis import FDataBasis, FourierBasis, MonomialBasis
 from skfda.representation.grid import FDataGrid
 
 FloatArray = np.typing.NDArray[np.float_]
@@ -100,7 +100,7 @@ def _create_data_basis(
     fd = X.iloc[:, 0].values
     fat = y['fat'].values
 
-    basis = Fourier(
+    basis = FourierBasis(
         n_basis=10,
         domain_range=fd.domain_range,
     )
@@ -327,7 +327,7 @@ class TestNonOthonormalBasisLLR(unittest.TestCase):
         """Test LocalLinearRegression with monomial basis."""
         coef1 = [[1, 5, 8], [4, 6, 6], [9, 4, 1]]
         coef2 = [[6, 3, 5]]
-        basis = Monomial(n_basis=3, domain_range=(0, 3))
+        basis = MonomialBasis(n_basis=3, domain_range=(0, 3))
 
         X_train = FDataBasis(coefficients=coef1, basis=basis)
         X = FDataBasis(coefficients=coef2, basis=basis)

--- a/skfda/tests/test_linear_differential_operator.py
+++ b/skfda/tests/test_linear_differential_operator.py
@@ -6,7 +6,7 @@ from typing import Callable, Sequence, Union
 import numpy as np
 
 from skfda.misc.operators import LinearDifferentialOperator
-from skfda.representation.basis import Constant, FDataBasis, Monomial
+from skfda.representation.basis import ConstantBasis, FDataBasis, MonomialBasis
 
 WeightCallable = Callable[[np.ndarray], np.ndarray]
 
@@ -85,7 +85,7 @@ class TestLinearDifferentialOperator(unittest.TestCase):
         n_basis = 4
         n_weights = 6
 
-        monomial = Monomial(domain_range=(0, 1), n_basis=n_basis)
+        monomial = MonomialBasis(domain_range=(0, 1), n_basis=n_basis)
 
         weights = np.arange(n_basis * n_weights).reshape((n_weights, n_basis))
 
@@ -101,7 +101,7 @@ class TestLinearDifferentialOperator(unittest.TestCase):
         )
 
         # Check failure if intervals do not match
-        constant = Constant(domain_range=(0, 2))
+        constant = ConstantBasis(domain_range=(0, 2))
         fdlist.append(FDataBasis(constant, 1))
         with np.testing.assert_raises(ValueError):
             LinearDifferentialOperator(weights=fdlist)
@@ -113,7 +113,7 @@ class TestLinearDifferentialOperator(unittest.TestCase):
             LinearDifferentialOperator(1, weights=[1, 1])
 
         # Check invalid domain range
-        monomial = Monomial(domain_range=(0, 1), n_basis=3)
+        monomial = MonomialBasis(domain_range=(0, 1), n_basis=3)
         fdlist = [FDataBasis(monomial, [1, 2, 3])]
 
         with np.testing.assert_raises(ValueError):

--- a/skfda/tests/test_math.py
+++ b/skfda/tests/test_math.py
@@ -8,7 +8,11 @@ import skfda
 from skfda._utils import _pairwise_symmetric
 from skfda.datasets import make_gaussian_process
 from skfda.misc.covariances import Gaussian
-from skfda.representation.basis import MonomialBasis, TensorBasis, VectorValuedBasis
+from skfda.representation.basis import (
+    MonomialBasis,
+    TensorBasis,
+    VectorValuedBasis,
+)
 
 
 def _ndm(

--- a/skfda/tests/test_math.py
+++ b/skfda/tests/test_math.py
@@ -8,7 +8,7 @@ import skfda
 from skfda._utils import _pairwise_symmetric
 from skfda.datasets import make_gaussian_process
 from skfda.misc.covariances import Gaussian
-from skfda.representation.basis import Monomial, Tensor, VectorValued
+from skfda.representation.basis import MonomialBasis, TensorBasis, VectorValuedBasis
 
 
 def _ndm(
@@ -45,10 +45,10 @@ class InnerProductTest(unittest.TestCase):
             grid_points=grid_points,
         )
 
-        basis = Tensor([
-            Monomial(n_basis=5, domain_range=(0, 1)),
-            Monomial(n_basis=5, domain_range=(0, 2)),
-            Monomial(n_basis=5, domain_range=(0, 3)),
+        basis = TensorBasis([
+            MonomialBasis(n_basis=5, domain_range=(0, 1)),
+            MonomialBasis(n_basis=5, domain_range=(0, 2)),
+            MonomialBasis(n_basis=5, domain_range=(0, 3)),
         ])
 
         fd_basis = fd.to_basis(basis)
@@ -89,9 +89,9 @@ class InnerProductTest(unittest.TestCase):
             grid_points=grid_points,
         )
 
-        basis = VectorValued([
-            Monomial(n_basis=5),
-            Monomial(n_basis=5),
+        basis = VectorValuedBasis([
+            MonomialBasis(n_basis=5),
+            MonomialBasis(n_basis=5),
         ])
 
         fd_basis = fd.to_basis(basis)
@@ -111,7 +111,7 @@ class InnerProductTest(unittest.TestCase):
 
     def test_matrix(self) -> None:
         """Test inner_product_matrix function."""
-        basis = skfda.representation.basis.BSpline(n_basis=12)
+        basis = skfda.representation.basis.BSplineBasis(n_basis=12)
 
         X = make_gaussian_process(
             n_samples=10,

--- a/skfda/tests/test_metrics.py
+++ b/skfda/tests/test_metrics.py
@@ -13,7 +13,7 @@ from skfda.misc.metrics import (
     linf_norm,
     lp_norm,
 )
-from skfda.representation.basis import Monomial
+from skfda.representation.basis import MonomialBasis
 
 
 class TestLp(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestLp(unittest.TestCase):
             ],
             grid_points=grid_points,
         )
-        basis = Monomial(n_basis=3, domain_range=(1, 5))
+        basis = MonomialBasis(n_basis=3, domain_range=(1, 5))
         self.fd_basis = FDataBasis(basis, [[1, 1, 0], [0, 0, 1]])
         self.fd_vector_valued = self.fd.concatenate(
             self.fd,

--- a/skfda/tests/test_neighbors.py
+++ b/skfda/tests/test_neighbors.py
@@ -17,7 +17,7 @@ from skfda.ml.classification import (
 from skfda.ml.clustering import NearestNeighbors
 from skfda.ml.regression import KNeighborsRegressor, RadiusNeighborsRegressor
 from skfda.representation import FDataBasis, FDataGrid
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 
 class TestNeighbors(unittest.TestCase):
@@ -250,7 +250,8 @@ class TestNeighbors(unittest.TestCase):
             FDataGrid,
             FDataGrid,
         ](weights=self._weights, n_neighbors=5)
-        response = self.X.to_basis(Fourier(domain_range=(-1, 1), n_basis=10))
+        response = self.X.to_basis(FourierBasis(
+            domain_range=(-1, 1), n_basis=10))
         knnr.fit(self.X, response)
 
         res = knnr.predict(self.X)
@@ -287,7 +288,8 @@ class TestNeighbors(unittest.TestCase):
             FDataGrid,
             FDataBasis,
         ](weights='distance', n_neighbors=5)
-        response = self.X.to_basis(Fourier(domain_range=(-1, 1), n_basis=10))
+        response = self.X.to_basis(FourierBasis(
+            domain_range=(-1, 1), n_basis=10))
         knnr.fit(self.X, response)
 
         res = knnr.predict(self.X)
@@ -360,7 +362,7 @@ class TestNeighbors(unittest.TestCase):
         np.testing.assert_almost_equal(r, 0.65599399478951)
 
         # Weighted case and basis form
-        y = y.to_basis(Fourier(domain_range=y.domain_range[0], n_basis=5))
+        y = y.to_basis(FourierBasis(domain_range=y.domain_range[0], n_basis=5))
         neigh.fit(self.X, y)
 
         r = neigh.score(

--- a/skfda/tests/test_oneway_anova.py
+++ b/skfda/tests/test_oneway_anova.py
@@ -10,7 +10,7 @@ from skfda.inference.anova import (
     v_sample_stat,
 )
 from skfda.representation import FDataGrid
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 
 class OnewayAnovaTests(unittest.TestCase):
@@ -43,7 +43,7 @@ class OnewayAnovaTests(unittest.TestCase):
         self.assertEqual(v_sample_stat(fd, weights), 7.0)
         self.assertAlmostEqual(
             v_sample_stat(
-                fd.to_basis(Fourier(n_basis=5)),
+                fd.to_basis(FourierBasis(n_basis=5)),
                 weights,
             ),
             7.0,
@@ -56,7 +56,7 @@ class OnewayAnovaTests(unittest.TestCase):
         self.assertAlmostEqual(v_asymptotic_stat(fd, weights=weights), res)
         self.assertAlmostEqual(
             v_asymptotic_stat(
-                fd.to_basis(Fourier(n_basis=5)),
+                fd.to_basis(FourierBasis(n_basis=5)),
                 weights=weights,
             ),
             res,
@@ -86,7 +86,7 @@ class OnewayAnovaTests(unittest.TestCase):
         big_sim = oneway_anova(fd1, fd2, fd3, n_reps=2000, random_state=100)[1]
         self.assertAlmostEqual(little_sim, big_sim, delta=0.05)
 
-        fd = fd.to_basis(Fourier(n_basis=5))
+        fd = fd.to_basis(FourierBasis(n_basis=5))
         fd1 = fd[:5]
         fd2 = fd[5:10]
 

--- a/skfda/tests/test_pandas.py
+++ b/skfda/tests/test_pandas.py
@@ -18,7 +18,7 @@ class TestPandas(unittest.TestCase):
             ],
         )
         self.fd_basis = self.fd.to_basis(
-            skfda.representation.basis.BSpline(
+            skfda.representation.basis.BSplineBasis(
                 n_basis=5,
             ),
         )

--- a/skfda/tests/test_pandas_fdatabasis.py
+++ b/skfda/tests/test_pandas_fdatabasis.py
@@ -10,11 +10,11 @@ from pandas.tests.extension import base
 
 from skfda.representation.basis import (
     Basis,
-    BSpline,
+    BSplineBasis,
     FDataBasis,
     FDataBasisDType,
-    Fourier,
-    Monomial,
+    FourierBasis,
+    MonomialBasis,
 )
 
 
@@ -22,9 +22,9 @@ from skfda.representation.basis import (
 # Fixtures
 ##############################################################################
 @pytest.fixture(params=[
-    Monomial(n_basis=5),
-    Fourier(n_basis=5),
-    BSpline(n_basis=5),
+    MonomialBasis(n_basis=5),
+    FourierBasis(n_basis=5),
+    BSplineBasis(n_basis=5),
 ])
 def basis(request: Any) -> Any:
     """A fixture providing the ExtensionDtype to validate."""

--- a/skfda/tests/test_registration.py
+++ b/skfda/tests/test_registration.py
@@ -25,7 +25,7 @@ from skfda.preprocessing.registration.validation import (
     PairwiseCorrelation,
     SobolevLeastSquares,
 )
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 from skfda.representation.interpolation import SplineInterpolation
 
 
@@ -268,7 +268,7 @@ class TestLeastSquaresShiftRegistration(unittest.TestCase):
         np.testing.assert_array_almost_equal(deltas, [-0.022, 0.03])
 
         # Test with Basis
-        fd = self.fd.to_basis(Fourier())
+        fd = self.fd.to_basis(FourierBasis())
         reg.fit_transform(fd)
         deltas = reg.deltas_.round(3)
         np.testing.assert_array_almost_equal(deltas, [-0.022, 0.03])
@@ -439,7 +439,7 @@ class TestRegistrationValidation(unittest.TestCase):
     def test_amplitude_phase_score_with_basis(self) -> None:
         """Test the AmplitudePhaseDecomposition with FDataBasis."""
         scorer = AmplitudePhaseDecomposition()
-        X = self.X.to_basis(Fourier())
+        X = self.X.to_basis(FourierBasis())
         score = scorer(self.shift_registration, X)
         np.testing.assert_allclose(score, 0.995086, rtol=1e-6)
 

--- a/skfda/tests/test_regression.py
+++ b/skfda/tests/test_regression.py
@@ -13,11 +13,11 @@ from skfda.misc.operators import LinearDifferentialOperator
 from skfda.misc.regularization import L2Regularization
 from skfda.ml.regression import HistoricalLinearRegression, LinearRegression
 from skfda.representation.basis import (
-    BSpline,
-    Constant,
+    BSplineBasis,
+    ConstantBasis,
     FDataBasis,
-    Fourier,
-    Monomial,
+    FourierBasis,
+    MonomialBasis,
 )
 from skfda.representation.grid import FDataGrid
 
@@ -26,10 +26,10 @@ class TestScalarLinearRegression(unittest.TestCase):
 
     def test_regression_single_explanatory(self) -> None:
 
-        x_basis = Monomial(n_basis=7)
+        x_basis = MonomialBasis(n_basis=7)
         x_fd = FDataBasis(x_basis, np.identity(7))
 
-        beta_basis = Fourier(n_basis=5)
+        beta_basis = FourierBasis(n_basis=5)
         beta_fd = FDataBasis(beta_basis, [1, 1, 1, 1, 1])
         y = np.array([
             0.9999999999999993,
@@ -77,9 +77,9 @@ class TestScalarLinearRegression(unittest.TestCase):
     def test_regression_multiple_explanatory(self) -> None:
         y = np.array([1, 2, 3, 4, 5, 6, 7])
 
-        X = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        X = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
 
-        beta1 = BSpline(domain_range=(0, 1), n_basis=5)
+        beta1 = BSplineBasis(domain_range=(0, 1), n_basis=5)
 
         scalar = LinearRegression(coef_basis=[beta1])
 
@@ -119,7 +119,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         ] = [
             multivariate,
             FDataBasis(
-                Monomial(n_basis=3),
+                MonomialBasis(n_basis=3),
                 [
                     [1, 0, 0], [0, 1, 0], [0, 0, 1],
                     [1, 0, 1], [1, 0, 0], [0, 1, 0],
@@ -131,7 +131,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         intercept = 2
         coefs_multivariate = np.array([3, 1])
         coefs_functions = FDataBasis(
-            Monomial(n_basis=3),
+            MonomialBasis(n_basis=3),
             [[3, 0, 0]],
         )
         y_integral = np.array([3, 3 / 2, 1, 4, 3, 3 / 2, 1])
@@ -173,7 +173,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         multivariate2 = np.asarray([7, 3, 2, 1, 1, 5])
         multivariate = [[1, 7], [2, 3], [4, 2], [1, 1], [3, 1], [2, 5]]
 
-        x_basis = Monomial(n_basis=2)
+        x_basis = MonomialBasis(n_basis=2)
         x_fd = FDataBasis(
             x_basis,
             [[0, 2], [0, 4], [1, 0], [2, 0], [1, 2], [2, 2]],
@@ -181,10 +181,10 @@ class TestScalarLinearRegression(unittest.TestCase):
 
         y = [11, 10, 12, 6, 10, 13]
 
-        linear = LinearRegression(coef_basis=[None, Constant()])
+        linear = LinearRegression(coef_basis=[None, ConstantBasis()])
         linear.fit([multivariate, x_fd], y)
 
-        linear2 = LinearRegression(coef_basis=[None, None, Constant()])
+        linear2 = LinearRegression(coef_basis=[None, None, ConstantBasis()])
         linear2.fit([multivariate1, multivariate2, x_fd], y)
 
         np.testing.assert_equal(
@@ -208,7 +208,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         multivariate2 = [0, 7, 7, 9, 16, 14, 5]
         multivariate = [list(obs) for obs in zip(multivariate1, multivariate2)]
 
-        x_basis = Monomial(n_basis=3)
+        x_basis = MonomialBasis(n_basis=3)
         x_fd = FDataBasis(x_basis, [[1, 0, 0], [0, 1, 0], [0, 0, 1],
                                     [1, 0, 1], [1, 0, 0], [0, 1, 0],
                                     [0, 0, 1]])
@@ -221,7 +221,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         intercept = 2
         coefs_multivariate = np.array([3, 1])
         coefs_functions = FDataBasis(
-            Monomial(n_basis=3), [[3, 0, 0]],
+            MonomialBasis(n_basis=3), [[3, 0, 0]],
         )
         y_integral = np.array([3, 3 / 2, 1, 4, 3, 3 / 2, 1])
         y_sum = multivariate @ coefs_multivariate
@@ -263,7 +263,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         ] = [
             multivariate,
             FDataBasis(
-                Monomial(n_basis=3),
+                MonomialBasis(n_basis=3),
                 [
                     [1, 0, 0], [0, 1, 0], [0, 0, 1],
                     [1, 0, 1], [1, 0, 0], [0, 1, 0],
@@ -318,10 +318,10 @@ class TestScalarLinearRegression(unittest.TestCase):
 
     def test_regression_regularization(self) -> None:
 
-        x_basis = Monomial(n_basis=7)
+        x_basis = MonomialBasis(n_basis=7)
         x_fd = FDataBasis(x_basis, np.identity(7))
 
-        beta_basis = Fourier(n_basis=5)
+        beta_basis = FourierBasis(n_basis=5)
         beta_fd = FDataBasis(
             beta_basis,
             [1.0403, 0, 0, 0, 0],
@@ -368,7 +368,7 @@ class TestScalarLinearRegression(unittest.TestCase):
         y_pred = scalar.predict(x_fd)
         np.testing.assert_allclose(y_pred, y_pred_compare, atol=1e-4)
 
-        x_basis = Monomial(n_basis=3)
+        x_basis = MonomialBasis(n_basis=3)
         x_fd = FDataBasis(
             x_basis,
             [
@@ -424,17 +424,17 @@ class TestScalarLinearRegression(unittest.TestCase):
         x_fd = np.identity(7)
         y = np.zeros(7)
 
-        scalar = LinearRegression(coef_basis=[Fourier(n_basis=5)])
+        scalar = LinearRegression(coef_basis=[FourierBasis(n_basis=5)])
 
         with np.testing.assert_warns(UserWarning):
             scalar.fit([x_fd], y)
 
     def test_error_y_is_FData(self) -> None:
         """Tests that none of the explained variables is an FData object."""
-        x_fd = FDataBasis(Monomial(n_basis=7), np.identity(7))
-        y = list(FDataBasis(Monomial(n_basis=7), np.identity(7)))
+        x_fd = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
+        y = list(FDataBasis(MonomialBasis(n_basis=7), np.identity(7)))
 
-        scalar = LinearRegression(coef_basis=[Fourier(n_basis=5)])
+        scalar = LinearRegression(coef_basis=[FourierBasis(n_basis=5)])
 
         with np.testing.assert_raises(ValueError):
             scalar.fit([x_fd], y)  # type: ignore[arg-type]
@@ -442,9 +442,9 @@ class TestScalarLinearRegression(unittest.TestCase):
     def test_error_X_beta_len_distinct(self) -> None:
         """Test that the number of beta bases and explanatory variables
         are not different """
-        x_fd = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        x_fd = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
         y = np.array([1 for _ in range(7)])
-        beta = Fourier(n_basis=5)
+        beta = FourierBasis(n_basis=5)
 
         scalar = LinearRegression(coef_basis=[beta])
         with np.testing.assert_raises(ValueError):
@@ -458,17 +458,17 @@ class TestScalarLinearRegression(unittest.TestCase):
         """Test that the number of response samples and explanatory samples
         are not different """
 
-        x_fd = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        x_fd = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
         y = np.array([1 for _ in range(8)])
-        beta = Fourier(n_basis=5)
+        beta = FourierBasis(n_basis=5)
 
         scalar = LinearRegression(coef_basis=[beta])
         with np.testing.assert_raises(ValueError):
             scalar.fit([x_fd], y)
 
-        x_fd = FDataBasis(Monomial(n_basis=8), np.identity(8))
+        x_fd = FDataBasis(MonomialBasis(n_basis=8), np.identity(8))
         y = np.array([1 for _ in range(7)])
-        beta = Fourier(n_basis=5)
+        beta = FourierBasis(n_basis=5)
 
         scalar = LinearRegression(coef_basis=[beta])
         with np.testing.assert_raises(ValueError):
@@ -476,9 +476,9 @@ class TestScalarLinearRegression(unittest.TestCase):
 
     def test_error_beta_not_basis(self) -> None:
         """Test that all beta are Basis objects. """
-        x_fd = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        x_fd = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
         y = np.array([1 for _ in range(7)])
-        beta = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        beta = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
 
         scalar = LinearRegression(coef_basis=[beta])
         with np.testing.assert_raises(TypeError):
@@ -486,10 +486,10 @@ class TestScalarLinearRegression(unittest.TestCase):
 
     def test_error_weights_lenght(self) -> None:
         """Test that the number of weights is equal to n_samples."""
-        x_fd = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        x_fd = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
         y = np.array([1 for _ in range(7)])
         weights = np.array([1 for _ in range(8)])
-        beta = Monomial(n_basis=7)
+        beta = MonomialBasis(n_basis=7)
 
         scalar = LinearRegression(coef_basis=[beta])
         with np.testing.assert_raises(ValueError):
@@ -497,10 +497,10 @@ class TestScalarLinearRegression(unittest.TestCase):
 
     def test_error_weights_negative(self) -> None:
         """Test that none of the weights are negative."""
-        x_fd = FDataBasis(Monomial(n_basis=7), np.identity(7))
+        x_fd = FDataBasis(MonomialBasis(n_basis=7), np.identity(7))
         y = np.array([1 for _ in range(7)])
         weights = np.array([-1 for _ in range(7)])
-        beta = Monomial(n_basis=7)
+        beta = MonomialBasis(n_basis=7)
 
         scalar = LinearRegression(coef_basis=[beta])
         with np.testing.assert_raises(ValueError):

--- a/skfda/tests/test_regularization.py
+++ b/skfda/tests/test_regularization.py
@@ -24,10 +24,10 @@ from skfda.misc.regularization import L2Regularization
 from skfda.ml.regression import LinearRegression
 from skfda.representation.basis import (
     Basis,
-    BSpline,
-    Constant,
-    Fourier,
-    Monomial,
+    BSplineBasis,
+    ConstantBasis,
+    FourierBasis,
+    MonomialBasis,
 )
 
 LinearDifferentialOperatorInput = Union[
@@ -76,7 +76,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
 
     def test_constant_penalty(self) -> None:
         """Test penalty for Constant basis."""
-        basis = Constant(domain_range=(0, 3))
+        basis = ConstantBasis(domain_range=(0, 3))
 
         res = np.array([[12]])
 
@@ -86,7 +86,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
         """Test directly the penalty for Monomial basis."""
         n_basis = 5
 
-        basis = Monomial(n_basis=n_basis)
+        basis = MonomialBasis(n_basis=n_basis)
 
         linear_diff_op = [3]
         res = np.array([
@@ -141,7 +141,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
 
     def test_monomial_penalty(self) -> None:
         """Test penalty for Monomial basis."""
-        basis = Monomial(n_basis=5, domain_range=(0, 3))
+        basis = MonomialBasis(n_basis=5, domain_range=(0, 3))
 
         # Theorethical result
         res = np.array([
@@ -154,7 +154,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
 
         self._test_penalty(basis, linear_diff_op=2, result=res)
 
-        basis = Monomial(n_basis=8, domain_range=(1, 5))
+        basis = MonomialBasis(n_basis=8, domain_range=(1, 5))
 
         self._test_penalty(basis, linear_diff_op=[1, 2, 3])
         self._test_penalty(basis, linear_diff_op=7)
@@ -164,7 +164,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
 
     def test_fourier_penalty(self) -> None:
         """Test penalty for Fourier basis."""
-        basis = Fourier(n_basis=5)
+        basis = FourierBasis(n_basis=5)
 
         res = np.array([
             [0, 0, 0, 0, 0],
@@ -177,7 +177,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
         # Those comparisons require atol as there are zeros involved
         self._test_penalty(basis, linear_diff_op=2, atol=0.01, result=res)
 
-        basis = Fourier(n_basis=9, domain_range=(1, 5))
+        basis = FourierBasis(n_basis=9, domain_range=(1, 5))
         self._test_penalty(basis, linear_diff_op=[1, 2, 3], atol=1e-7)
         self._test_penalty(basis, linear_diff_op=[2, 3, 0.1, 1], atol=1e-7)
         self._test_penalty(basis, linear_diff_op=0, atol=1e-7)
@@ -186,7 +186,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
 
     def test_bspline_penalty(self) -> None:
         """Test penalty for BSpline basis."""
-        basis = BSpline(n_basis=5)
+        basis = BSplineBasis(n_basis=5)
 
         res = np.array([
             [96, -132, 24, 12, 0],
@@ -198,7 +198,7 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
 
         self._test_penalty(basis, linear_diff_op=2, result=res)
 
-        basis = BSpline(n_basis=9, domain_range=(1, 5))
+        basis = BSplineBasis(n_basis=9, domain_range=(1, 5))
         self._test_penalty(basis, linear_diff_op=[1, 2, 3])
         self._test_penalty(basis, linear_diff_op=[2, 3, 0.1, 1])
         self._test_penalty(basis, linear_diff_op=0)
@@ -206,12 +206,12 @@ class TestLinearDifferentialOperatorRegularization(unittest.TestCase):
         self._test_penalty(basis, linear_diff_op=3)
         self._test_penalty(basis, linear_diff_op=4)
 
-        basis = BSpline(n_basis=16, order=8)
+        basis = BSplineBasis(n_basis=16, order=8)
         self._test_penalty(basis, linear_diff_op=0, atol=1e-7)
 
     def test_bspline_penalty_special_case(self) -> None:
         """Test for behavior like in issue #185."""
-        basis = BSpline(n_basis=5)
+        basis = BSplineBasis(n_basis=5)
 
         res = np.array([
             [1152, -2016, 1152, -288, 0],
@@ -246,7 +246,7 @@ class TestDefaultL2Regularization(unittest.TestCase):
         fd = skfda.FDataGrid(data_matrix.T)
 
         smoother = skfda.preprocessing.smoothing.BasisSmoother(
-            basis=skfda.representation.basis.BSpline(
+            basis=skfda.representation.basis.BSplineBasis(
                 n_basis=10,
                 domain_range=fd.domain_range,
             ),
@@ -254,7 +254,7 @@ class TestDefaultL2Regularization(unittest.TestCase):
         )
 
         smoother2 = skfda.preprocessing.smoothing.BasisSmoother(
-            basis=skfda.representation.basis.BSpline(
+            basis=skfda.representation.basis.BSplineBasis(
                 n_basis=10,
                 domain_range=fd.domain_range,
             ),
@@ -282,7 +282,7 @@ class TestEndpointsDifferenceRegularization(unittest.TestCase):
         fd = skfda.FDataGrid(data_matrix.T)
 
         smoother = skfda.preprocessing.smoothing.BasisSmoother(
-            basis=skfda.representation.basis.BSpline(
+            basis=skfda.representation.basis.BSplineBasis(
                 n_basis=10,
                 domain_range=fd.domain_range,
             ),

--- a/skfda/tests/test_scoring.py
+++ b/skfda/tests/test_scoring.py
@@ -16,7 +16,7 @@ from skfda.misc.scoring import (
     mean_squared_log_error,
     r2_score,
 )
-from skfda.representation.basis import BSpline, Fourier, Monomial
+from skfda.representation.basis import BSplineBasis, FourierBasis, MonomialBasis
 from skfda.typing._numpy import NDArrayFloat
 
 score_functions: Sequence[ScoreFunction] = (
@@ -36,14 +36,14 @@ def _create_data_basis() -> Tuple[FDataBasis, FDataBasis]:
     # y_true: 1) 1 + 2x + 3x^2
     #         2) 4 + 5x + 6x^2
     y_true = FDataBasis(
-        basis=Monomial(domain_range=((0, 3),), n_basis=3),
+        basis=MonomialBasis(domain_range=((0, 3),), n_basis=3),
         coefficients=coef_true,
     )
 
     # y_pred: 1) 1 + 2x + 3x^2
     #         2) 4 + 6x + 5x^2
     y_pred = FDataBasis(
-        basis=Monomial(domain_range=((0, 3),), n_basis=3),
+        basis=MonomialBasis(domain_range=((0, 3),), n_basis=3),
         coefficients=coef_pred,
     )
 
@@ -124,8 +124,8 @@ class TestScoreFunctionGridBasis(unittest.TestCase):
     ) -> None:
         y_true_grid, y_pred_grid = _create_data_grid()
 
-        y_true_basis = y_true_grid.to_basis(basis=BSpline(n_basis=10))
-        y_pred_basis = y_pred_grid.to_basis(basis=BSpline(n_basis=10))
+        y_true_basis = y_true_grid.to_basis(basis=BSplineBasis(n_basis=10))
+        y_pred_basis = y_pred_grid.to_basis(basis=BSplineBasis(n_basis=10))
 
         # The results should be close but not equal as the two representations
         # do not give same functions.
@@ -241,12 +241,12 @@ class TestScoreZeroDenominator(unittest.TestCase):
         # y_true and y_pred are 2 sets of 3 straight lines
         # for all f, f(1) = 1
         y_true_basis = FDataBasis(
-            basis=Monomial(domain_range=((0, 2),), n_basis=2),
+            basis=MonomialBasis(domain_range=((0, 2),), n_basis=2),
             coefficients=basis_coef_true,
         )
 
         y_pred_basis = FDataBasis(
-            basis=Monomial(domain_range=((0, 2),), n_basis=2),
+            basis=MonomialBasis(domain_range=((0, 2),), n_basis=2),
             coefficients=basis_coef_pred,
         )
 
@@ -280,7 +280,7 @@ class TestScoreZeroDenominator(unittest.TestCase):
         # for all f in y_pred, f(1) = 2
         basis_coef_pred = [[2, 0], [3, -1], [4, -2]]
         y_pred_basis = FDataBasis(
-            basis=Monomial(domain_range=((0, 2),), n_basis=2),
+            basis=MonomialBasis(domain_range=((0, 2),), n_basis=2),
             coefficients=basis_coef_pred,
         )
 
@@ -315,12 +315,12 @@ class TestScoreZeroDenominator(unittest.TestCase):
         # for all f, f(1) = 1
         # var(y_true(1)) = 0 and var(y_true(1) - y_pred(1)) = 0
         y_true_basis = FDataBasis(
-            basis=Monomial(domain_range=((0, 2),), n_basis=2),
+            basis=MonomialBasis(domain_range=((0, 2),), n_basis=2),
             coefficients=basis_coef_true,
         )
 
         y_pred_basis = FDataBasis(
-            basis=Monomial(domain_range=((0, 2),), n_basis=2),
+            basis=MonomialBasis(domain_range=((0, 2),), n_basis=2),
             coefficients=basis_coef_pred,
         )
 
@@ -352,7 +352,7 @@ class TestScoreZeroDenominator(unittest.TestCase):
         # Case when numerator is non-zero and denominator is zero (in t = 1)
         basis_coef_pred = [[2, 0], [2, -1], [2, -2]]
         y_pred_basis = FDataBasis(
-            basis=Monomial(domain_range=((0, 2),), n_basis=2),
+            basis=MonomialBasis(domain_range=((0, 2),), n_basis=2),
             coefficients=basis_coef_pred,
         )
         y_pred_grid = y_pred_basis.to_grid(grid_points=grid_points)
@@ -391,12 +391,12 @@ class TestScoreZeroDenominator(unittest.TestCase):
         # The second function in y_true should be zero at t = 0.5 and t = 1.5
 
         y_true_basis = FDataBasis(
-            basis=Fourier(domain_range=((0, 2),), n_basis=5),
+            basis=FourierBasis(domain_range=((0, 2),), n_basis=5),
             coefficients=basis_coef_true,
         )
 
         y_pred_basis = FDataBasis(
-            basis=Fourier(domain_range=((0, 2),), n_basis=5),
+            basis=FourierBasis(domain_range=((0, 2),), n_basis=5),
             coefficients=basis_coef_pred,
         )
 
@@ -430,12 +430,12 @@ class TestScoreZeroDenominator(unittest.TestCase):
         # All functions in y_pred should be always positive
 
         y_true_basis = FDataBasis(
-            basis=Fourier(domain_range=((0, 2),), n_basis=3),
+            basis=FourierBasis(domain_range=((0, 2),), n_basis=3),
             coefficients=basis_coef_true,
         )
 
         y_pred_basis = FDataBasis(
-            basis=Fourier(domain_range=((0, 2),), n_basis=3),
+            basis=FourierBasis(domain_range=((0, 2),), n_basis=3),
             coefficients=basis_coef_pred,
         )
 

--- a/skfda/tests/test_scoring.py
+++ b/skfda/tests/test_scoring.py
@@ -16,7 +16,11 @@ from skfda.misc.scoring import (
     mean_squared_log_error,
     r2_score,
 )
-from skfda.representation.basis import BSplineBasis, FourierBasis, MonomialBasis
+from skfda.representation.basis import (
+    BSplineBasis,
+    FourierBasis,
+    MonomialBasis,
+)
 from skfda.typing._numpy import NDArrayFloat
 
 score_functions: Sequence[ScoreFunction] = (

--- a/skfda/tests/test_smoothing.py
+++ b/skfda/tests/test_smoothing.py
@@ -20,7 +20,7 @@ from skfda.misc.hat_matrix import (
 from skfda.misc.operators import LinearDifferentialOperator
 from skfda.misc.regularization import L2Regularization
 from skfda.preprocessing.smoothing import KernelSmoother
-from skfda.representation.basis import BSpline, Monomial
+from skfda.representation.basis import BSplineBasis, MonomialBasis
 from skfda.representation.grid import FDataGrid
 
 
@@ -180,7 +180,7 @@ class TestBasisSmoother(unittest.TestCase):
         """Test Basis Smoother using BSpline basis and Cholesky method."""
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
-        basis = BSpline((0, 1), n_basis=5)
+        basis = BSplineBasis((0, 1), n_basis=5)
 
         fd = FDataGrid(data_matrix=x, grid_points=t)
 
@@ -205,7 +205,7 @@ class TestBasisSmoother(unittest.TestCase):
         """Test Basis Smoother using BSpline basis and QR method."""
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
-        basis = BSpline((0, 1), n_basis=5)
+        basis = BSplineBasis((0, 1), n_basis=5)
 
         fd = FDataGrid(data_matrix=x, grid_points=t)
 
@@ -232,7 +232,7 @@ class TestBasisSmoother(unittest.TestCase):
         # where the fit is very good but its just for testing purposes
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
-        basis = Monomial(n_basis=4)
+        basis = MonomialBasis(n_basis=4)
 
         fd = FDataGrid(data_matrix=x, grid_points=t)
 
@@ -257,11 +257,11 @@ class TestBasisSmoother(unittest.TestCase):
         """Test Basis Smoother for vector values functions."""
         X, _ = fetch_weather(return_X_y=True)
 
-        basis_dim = skfda.representation.basis.Fourier(
+        basis_dim = skfda.representation.basis.FourierBasis(
             n_basis=7, domain_range=X.domain_range,
         )
 
-        basis = skfda.representation.basis.VectorValued(
+        basis = skfda.representation.basis.VectorValuedBasis(
             [basis_dim] * 2,
         )
 

--- a/skfda/tests/test_ufunc_numpy.py
+++ b/skfda/tests/test_ufunc_numpy.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from skfda import FDataGrid
-from skfda.representation.basis import Fourier
+from skfda.representation.basis import FourierBasis
 
 T = TypeVar("T", "np.typing.NDArray[Any]", FDataGrid)
 
@@ -93,7 +93,7 @@ class TestOperators(unittest.TestCase):
         """Test that operations with numpy arrays for basis commute."""
         X = FDataGrid([[1, 2, 3], [4, 5, 6]])
         arr = np.array([1, 2])
-        basis = Fourier(n_basis=5)
+        basis = FourierBasis(n_basis=5)
 
         X_basis = X.to_basis(basis)
 

--- a/tutorial/plot_basis_representation.py
+++ b/tutorial/plot_basis_representation.py
@@ -132,7 +132,7 @@ plt.show()
 # .. math::
 #     x(t) = 3 + 2t - 4t^2 + t^3
 
-basis = skfda.representation.basis.Monomial(
+basis = skfda.representation.basis.MonomialBasis(
     n_basis=4,
     domain_range=(-10, 10),
 )
@@ -182,7 +182,7 @@ X.plot()
 fig, axes = plt.subplots(nrows=3, ncols=3)
 
 for n_basis in range(1, max_basis + 1):
-    basis = skfda.representation.basis.Monomial(n_basis=n_basis)
+    basis = skfda.representation.basis.MonomialBasis(n_basis=n_basis)
     X_basis = X.to_basis(basis)
 
     ax = axes.ravel()[n_basis - 1]
@@ -243,7 +243,7 @@ plt.show()
 ##############################################################################
 # Here we show the first five elements of the monomial basis.
 
-basis = skfda.representation.basis.Monomial(n_basis=5)
+basis = skfda.representation.basis.MonomialBasis(n_basis=5)
 basis.plot()
 plt.show()
 
@@ -278,7 +278,7 @@ plt.show()
 ##############################################################################
 # Here we show the first five elements of a Fourier basis.
 
-basis = skfda.representation.basis.Fourier(n_basis=5)
+basis = skfda.representation.basis.FourierBasis(n_basis=5)
 basis.plot()
 plt.show()
 
@@ -314,7 +314,7 @@ plt.show()
 ##############################################################################
 # Here we show the first five elements of a B-spline basis.
 
-basis = skfda.representation.basis.BSpline(n_basis=5)
+basis = skfda.representation.basis.BSplineBasis(n_basis=5)
 basis.plot()
 plt.show()
 
@@ -365,12 +365,12 @@ X = X.reshape(-1, 8, 8)
 
 fd = skfda.FDataGrid(X)
 
-basis = skfda.representation.basis.Tensor([
-    skfda.representation.basis.Fourier(  # X axis
+basis = skfda.representation.basis.TensorBasis([
+    skfda.representation.basis.FourierBasis(  # X axis
         n_basis=5,
         domain_range=fd.domain_range[0],
     ),
-    skfda.representation.basis.BSpline(  # Y axis
+    skfda.representation.basis.BSplineBasis(  # Y axis
         n_basis=6,
         domain_range=fd.domain_range[1],
     ),
@@ -435,7 +435,7 @@ plt.show()
 ##############################################################################
 # We now represent the digits dataset in this basis.
 
-basis = skfda.representation.basis.FiniteElement(
+basis = skfda.representation.basis.FiniteElementBasis(
     vertices=vertices,
     cells=cells,
 )
@@ -475,12 +475,12 @@ plt.show()
 # are now expressed in a Fourier basis, while we express precipitations as
 # B-splines.
 
-basis = skfda.representation.basis.VectorValued([
-    skfda.representation.basis.Fourier(  # First coordinate function
+basis = skfda.representation.basis.VectorValuedBasis([
+    skfda.representation.basis.FourierBasis(  # First coordinate function
         n_basis=5,
         domain_range=X.domain_range,
     ),
-    skfda.representation.basis.BSpline(  # Second coordinate function
+    skfda.representation.basis.BSplineBasis(  # Second coordinate function
         n_basis=10,
         domain_range=X.domain_range,
     ),


### PR DESCRIPTION
Closes #488 by renaming the current basis to add "Basis" as a suffix.
Additionally, the current basis classes are marked as deprecated and implemented as subclasses of the renamed one.