### PR TITLE
Issue/classifier_classes/kneighbours

### DIFF
--- a/skfda/tests/test_classifier_classes.py
+++ b/skfda/tests/test_classifier_classes.py
@@ -11,7 +11,6 @@ from skfda._utils._sklearn_adapter import ClassifierMixin
 from skfda.datasets import make_gaussian_process
 from skfda.ml.classification import (
     KNeighborsClassifier,
-    LogisticRegression,
     RadiusNeighborsClassifier,
 )
 from skfda.representation import FData
@@ -21,7 +20,6 @@ from ..typing._numpy import NDArrayAny
 
 @pytest.fixture(
     params=[
-        LogisticRegression(),
         KNeighborsClassifier(),
         RadiusNeighborsClassifier(),
     ],
@@ -53,5 +51,7 @@ def test_classes(
     y = np.resize(classes, n_samples)
     X = make_gaussian_process(n_samples=n_samples)
     classifier.fit(X, y)
+    resulting_classes = np.unique(classifier.predict(X))
 
     np.testing.assert_array_equal(classifier.classes_, classes)
+    np.testing.assert_array_equal(classifier.classes_, resulting_classes)

--- a/skfda/tests/test_classifier_classes.py
+++ b/skfda/tests/test_classifier_classes.py
@@ -9,7 +9,11 @@ import pytest
 
 from skfda._utils._sklearn_adapter import ClassifierMixin
 from skfda.datasets import make_gaussian_process
-from skfda.ml.classification import LogisticRegression
+from skfda.ml.classification import (
+    KNeighborsClassifier,
+    LogisticRegression,
+    RadiusNeighborsClassifier,
+)
 from skfda.representation import FData
 
 from ..typing._numpy import NDArrayAny
@@ -18,6 +22,8 @@ from ..typing._numpy import NDArrayAny
 @pytest.fixture(
     params=[
         LogisticRegression(),
+        KNeighborsClassifier(),
+        RadiusNeighborsClassifier(),
     ],
     ids=lambda clf: type(clf).__name__,
 )


### PR DESCRIPTION
Solution of issue #480 for `KNeighborsClassifier` and `RadiusNeighborsClassifier`.

The `fit` method from their parent classifier class has been updated to include the initialization of the `classes_`attribute. To be able to use the corresponding functionality from `_utils`, the Target generic has been modified to a TargetClassification type var bounded to NDArrayInt and NDArrayStr, to be able to work with both string and integer class types.
