### PR TITLE
Hotfix: Correct the order of the parameters for the FPCA in Mahalanobis

### DIFF
--- a/skfda/misc/metrics/_mahalanobis.py
+++ b/skfda/misc/metrics/_mahalanobis.py
@@ -107,7 +107,7 @@ class MahalanobisDistance(BaseEstimator):
                 n_components=self.n_components,
                 centering=self.centering,
                 regularization=self.regularization,
-                component_basis=self.components_basis,
+                components_basis=self.components_basis,
                 weights=self.weights,
             )
             fpca.fit(X)

--- a/skfda/misc/metrics/_mahalanobis.py
+++ b/skfda/misc/metrics/_mahalanobis.py
@@ -108,7 +108,7 @@ class MahalanobisDistance(BaseEstimator):
                 centering=self.centering,
                 regularization=self.regularization,
                 components_basis=self.components_basis,
-                weights=self.weights,
+                _weights=self.weights,
             )
             fpca.fit(X)
             self.eigenvalues_ = fpca.explained_variance_

--- a/skfda/misc/metrics/_mahalanobis.py
+++ b/skfda/misc/metrics/_mahalanobis.py
@@ -104,11 +104,11 @@ class MahalanobisDistance(BaseEstimator):
 
         if self.eigenvalues is None or self.eigenvectors is None:
             fpca = FPCA(
-                self.n_components,
-                self.centering,
-                self.regularization,
-                self.components_basis,
-                self.weights,
+                n_components=self.n_components,
+                centering=self.centering,
+                regularization=self.regularization,
+                component_basis=self.components_basis,
+                weights=self.weights,
             )
             fpca.fit(X)
             self.eigenvalues_ = fpca.explained_variance_

--- a/skfda/misc/metrics/_mahalanobis.py
+++ b/skfda/misc/metrics/_mahalanobis.py
@@ -107,8 +107,8 @@ class MahalanobisDistance(BaseEstimator):
                 self.n_components,
                 self.centering,
                 self.regularization,
-                self.weights,
                 self.components_basis,
+                self.weights,
             )
             fpca.fit(X)
             self.eigenvalues_ = fpca.explained_variance_

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -87,6 +87,7 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
     def __init__(
         self,
         n_components: int = 3,
+        *,
         centering: bool = True,
         regularization: Optional[L2Regularization[FData]] = None,
         components_basis: Optional[Basis] = None,


### PR DESCRIPTION
The constructor for `FPCA` receives parameters in a different order than the one used in `Mahalanobis`.

https://github.com/GAA-UAM/scikit-fda/blob/05a35df781d65918d8730195f61a93a72198f2e1/skfda/preprocessing/dim_reduction/_fpca.py#L87-L94

Thus, the last two parameters should be interchanged in the call to the constructor in `Mahalanobis`.