### PR TITLE
Deprecate 3 as the default number of components in FPCA

### DIFF
--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Callable, Optional, TypeVar, Union
+from typing import Callable, TypeVar
 
 import numpy as np
 import scipy.integrate
@@ -34,10 +34,13 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
 
     Parameters:
         n_components: Number of principal components to keep from
-            functional principal component analysis. In future versions, it
-            will default to the maximum number of components that can
-            be extracted. Currently, it still defaults to 3 but do not
-            assume this behavior as it will change.
+            functional principal component analysis.
+
+            .. versionchanged:: 0.9
+               In future versions, it will default to the maximum number
+               of components that can be extracted.
+               Currently, it still defaults to 3 but do not assume this
+               behavior as it will change.
         centering: Set to ``False`` when the functional data is already known
             to be centered and there is no need to center it. Otherwise,
             the mean of the functional data object is calculated and the data
@@ -89,12 +92,12 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
 
     def __init__(
         self,
-        n_components: Optional[int] = None,
+        n_components: int | None = None,
         *,
         centering: bool = True,
-        regularization: Optional[L2Regularization[FData]] = None,
-        components_basis: Optional[Basis] = None,
-        _weights: Optional[Union[ArrayLike, WeightsCallable]] = None,
+        regularization: L2Regularization[FData] | None = None,
+        components_basis: Basis | None = None,
+        _weights: ArrayLike | WeightsCallable | None = None,
     ) -> None:
 
         if n_components is None:

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -1,7 +1,7 @@
 """Functional Principal Component Analysis Module."""
-
 from __future__ import annotations
 
+import warnings
 from typing import Callable, Optional, TypeVar, Union
 
 import numpy as np
@@ -34,7 +34,10 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
 
     Parameters:
         n_components: Number of principal components to keep from
-            functional principal component analysis. Defaults to 3.
+            functional principal component analysis. In future versions, it
+            will default to the maximum number of components that can
+            be extracted. Currently, it still defaults to 3 but do not
+            assume this behavior as it will change.
         centering: Set to ``False`` when the functional data is already known
             to be centered and there is no need to center it. Otherwise,
             the mean of the functional data object is calculated and the data
@@ -86,13 +89,23 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
 
     def __init__(
         self,
-        n_components: int = 3,
+        n_components: Optional[int] = None,
         *,
         centering: bool = True,
         regularization: Optional[L2Regularization[FData]] = None,
         components_basis: Optional[Basis] = None,
         _weights: Optional[Union[ArrayLike, WeightsCallable]] = None,
     ) -> None:
+
+        if n_components is None:
+            warnings.warn(
+                "The default value of n_components will change in a future "
+                "version to the maximum number of components that can be "
+                "extracted. Update your code to specify explicitly the "
+                "number of components to avoid this warning.",
+                DeprecationWarning,
+            )
+            n_components = 3
         self.n_components = n_components
         self.centering = centering
         self.regularization = regularization

--- a/skfda/tests/test_fpca.py
+++ b/skfda/tests/test_fpca.py
@@ -17,7 +17,7 @@ class FPCATestCase(unittest.TestCase):
 
     def test_basis_fpca_fit_exceptions(self) -> None:
         """Check that invalid arguments in fit raise exception for basis."""
-        fpca = FPCA()
+        fpca = FPCA(n_components=3)
         with self.assertRaises(AttributeError):
             fpca.fit(None)  # type: ignore[arg-type]
 
@@ -36,7 +36,7 @@ class FPCATestCase(unittest.TestCase):
 
     def test_discretized_fpca_fit_exceptions(self) -> None:
         """Check that invalid arguments in fit raise exception for grid."""
-        fpca = FPCA()
+        fpca = FPCA(n_components=3)
         with self.assertRaises(AttributeError):
             fpca.fit(None)  # type: ignore[arg-type]
 


### PR DESCRIPTION
As outlined in #507, when the number of components is not specified, all components should be extracted. A deprecation warning has been added to alert the users that were relying on the default value of components being 3. The documentation has also been updated accordingly.