### PR TITLE
Make CustomBasis documentation accesible

### DIFF
--- a/docs/modules/representation.rst
+++ b/docs/modules/representation.rst
@@ -55,6 +55,7 @@ The following classes are used to define different basis for
    skfda.representation.basis.FourierBasis
    skfda.representation.basis.MonomialBasis
    skfda.representation.basis.ConstantBasis
+   skfda.representation.basis.CustomBasis
    
 The following classes, allow the construction of a basis for
 :math:`\mathbb{R}^n \to \mathbb{R}` functions.

--- a/skfda/representation/basis/_custom_basis.py
+++ b/skfda/representation/basis/_custom_basis.py
@@ -1,5 +1,3 @@
-"""Abstract base class for basis."""
-
 from __future__ import annotations
 
 from typing import Any, Tuple, TypeVar
@@ -19,7 +17,7 @@ T = TypeVar("T", bound="CustomBasis")
 class CustomBasis(Basis):
     """Basis composed of custom functions.
 
-    Defines a basis composed of the functions in the :class: `FData` object
+    Defines a basis composed of the functions in the :class:`FData` object
     passed as argument.
     The functions must be linearly independent, otherwise
     an exception is raised.


### PR DESCRIPTION
The CustomBasis documentation was added to `representation.rst`. Additionally, a left-over doc string and an incorrect whitespace were removed.