### PR TITLE
Change type of axis in FData's mean method to accept zero.

### DIFF
--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -822,7 +822,7 @@ class FData(  # noqa: WPS214
     def mean(
         self: T,
         *,
-        axis: None = None,
+        axis: Optional[int] = None,
         dtype: None = None,
         out: None = None,
         keepdims: bool = False,

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -786,7 +786,7 @@ class FData(  # noqa: WPS214
     def sum(  # noqa: WPS125
         self: T,
         *,
-        axis: Optional[int] = None,
+        axis: int | None = None,
         out: None = None,
         keepdims: bool = False,
         skipna: bool = False,

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -822,7 +822,7 @@ class FData(  # noqa: WPS214
     def mean(
         self: T,
         *,
-        axis: Optional[int] = None,
+        axis: int | None = None,
         dtype: None = None,
         out: None = None,
         keepdims: bool = False,


### PR DESCRIPTION
As the documention specifies, axis can be either None or 0.
Currently, if 0 is given as the axis, a mypy error is raised since the function signature only accepts a None axis.