### PR TITLE
Update mypy workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,10 +12,8 @@ jobs:
     - uses: tsuyoshicho/action-mypy@v3
       with:
         github_token: ${{ secrets.github_token }}
-        # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
         reporter: github-pr-review
-        # Change reporter level if you need.
-        # GitHub Status Check won't become failure with warning.
+        # The action will output fail if there are mypy errors
         level: error
         setup_command: pip install -r requirements.txt pytest mypy
         mypy_flags: ''

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,5 +16,6 @@ jobs:
         reporter: github-pr-review
         # Change reporter level if you need.
         # GitHub Status Check won't become failure with warning.
-        level: warning
+        level: error
+        setup_command: pip install -r requirements.txt pytest mypy
         mypy_flags: ''


### PR DESCRIPTION
Currently, the `mypy` action does not find all errors and reports some false positives. 
For example, it consistently outputs:
```
Untyped decorator makes function "test_simple_regresion_dataset_functional" untyped [misc]
```
This is because the current action does not install the required Python packages for `mypy` to have all the typing information it needs. 

Additionally, I think the action should fail when there are `mypy` errors. The current configuration still marks it as a success in the pull request test summary. 

I tested these changes in the PLS pull request, and they work. 