### PR TITLE
RKHS inner product

### DIFF
--- a/skfda/misc/covariances.py
+++ b/skfda/misc/covariances.py
@@ -804,6 +804,8 @@ class Empirical(Covariance):
         Returns:
             Covariance function evaluated at the grid formed by x and y.
         """
+        x = _transform_to_2d(x)
+        y = _transform_to_2d(y)
         return self.cov_fdata([x, y], grid=True)[0, ..., 0]
 
 

--- a/skfda/misc/rkhs_product.py
+++ b/skfda/misc/rkhs_product.py
@@ -139,13 +139,6 @@ def rkhs_inner_product(
             )[0],
         ).T[..., np.newaxis]
 
-        # NOTE: Numpy alternative.
-        # inv_fd2_matrix = np.linalg.lstsq(
-        #     cov_matrix_1_2.T,
-        #     data_matrix_2[..., 0].T,
-        #     rcond=None,
-        # )[0].T[..., np.newaxis]
-
     products = (
         np.transpose(data_matrix_1, axes=(0, 2, 1))
         @ inv_fd2_matrix

--- a/skfda/misc/rkhs_product.py
+++ b/skfda/misc/rkhs_product.py
@@ -1,0 +1,223 @@
+"""RKHS inner product of two FData objects."""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import multimethod
+import numpy as np
+import scipy.linalg
+
+from ..misc.covariances import EmpiricalBasis
+from ..representation import FData, FDataBasis, FDataGrid
+from ..representation.basis import Basis, TensorBasis
+from ..typing._numpy import NDArrayFloat
+from ._math import inner_product
+from .validation import check_fdata_dimensions
+
+
+def _check_compatible_fdata(
+    fdata1: FData,
+    fdata2: FData,
+) -> None:
+    """Check terms of the inner product are compatible.
+
+    Args:
+        fdata1: First functional data object.
+        fdata2: Second functional data object.
+
+    Raises:
+        ValueError: If the data is not univariate or if the number of samples
+            is not the same.
+    """
+    check_fdata_dimensions(fdata1, dim_domain=1, dim_codomain=1)
+    check_fdata_dimensions(fdata2, dim_domain=1, dim_codomain=1)
+    if fdata1.n_samples != fdata2.n_samples:
+        raise ValueError(
+            "Invalid number of samples for functional data objects:"
+            f"{fdata1.n_samples} != {fdata2.n_samples}.",
+        )
+
+
+def _get_coeff_matrix(
+    cov_function: Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
+    basis1: Basis,
+    basis2: Basis,
+) -> NDArrayFloat:
+    """Return the matrix of coefficients of a function in a tensor basis.
+
+    Args:
+        cov_function: Covariance function as a callable. It is expected to
+            receive two arrays, s and t, and return the corresponding
+            covariance matrix.
+        basis1: First basis.
+        basis2: Second basis.
+
+    Returns:
+        Matrix of coefficients of the covariance function in the tensor
+        basis formed by the two given bases.
+    """
+    # In order to use inner_product, the callable must follow the
+    # same convention as the evaluation on FDataGrids, that is, it
+    # is expected to receive a single bidimensional point as input
+    def cov_function_pointwise(  # noqa: WPS430
+        x: NDArrayFloat,
+    ) -> NDArrayFloat:
+        t = np.array([x[0]])
+        s = np.array([x[1]])
+        return cov_function(t, s)[..., np.newaxis]
+
+    tensor_basis = TensorBasis([basis1, basis2])
+
+    # Solving the system yields the coefficients of the covariance
+    # as a vector that is reshaped to form a matrix
+    return np.linalg.solve(
+        tensor_basis.gram_matrix(),
+        inner_product(
+            cov_function_pointwise,
+            tensor_basis,
+            _domain_range=tensor_basis.domain_range,
+        ).T,
+    ).reshape(basis1.n_basis, basis2.n_basis)
+
+
+@multimethod.multidispatch
+def rkhs_inner_product(
+    fdata1: FDataGrid,
+    fdata2: FDataGrid,
+    *,
+    cov_function: Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
+    cond: Optional[float] = None,
+) -> NDArrayFloat:
+    r"""RKHS inner product of two univariate FDataGrid objects.
+
+    This is the most general method for calculating the RKHS inner product
+    using a discretization of the domain. The RKHS inner product is calculated
+    as the inner product between the square root inverse of the covariance
+    operator applied to the functions.
+    Assuming the existence of such inverse, using the self-adjointness of the
+    covariance operator, the RKHS inner product can be calculated as:
+        \langle f, \mathcal{K}^{-1} g \rangle
+    When discretizing a common domain, this is equivalent to doing the matrix
+    product between the discretized functions and the inverse of the
+    covariance matrix.
+    In case of having different discretization grids, the left inverse of the
+    transposed covariace matrix is used instead.
+
+    Args:
+        fdata1: First FDataGrid object.
+        fdata2: Second FDataGrid object.
+        cov_function: Covariance function as a callable. It is expected to
+            receive two arrays, s and t, and return the corresponding
+            covariance matrix.
+        cond: Cutoff for small singular values of the covariance matrix.
+            Default uses scipy default.
+
+    Returns:
+        Matrix of the RKHS inner product between paired samples of
+        fdata1 and fdata2.
+    """
+    _check_compatible_fdata(fdata1, fdata2)
+
+    data_matrix_1 = fdata1.data_matrix
+    data_matrix_2 = fdata2.data_matrix
+    grid_points_1 = fdata1.grid_points[0]
+    grid_points_2 = fdata2.grid_points[0]
+    cov_matrix_1_2 = cov_function(grid_points_1, grid_points_2)
+
+    # Calculate the inverse operator applied to fdata2
+    if np.array_equal(grid_points_1, grid_points_2):
+        inv_fd2_matrix = np.linalg.solve(
+            cov_matrix_1_2,
+            data_matrix_2,
+        )
+    else:
+        inv_fd2_matrix = np.asarray(
+            scipy.linalg.lstsq(
+                cov_matrix_1_2.T,
+                data_matrix_2[..., 0].T,
+                cond=cond,
+            )[0],
+        ).T[..., np.newaxis]
+
+        # NOTE: Numpy alternative.
+        # inv_fd2_matrix = np.linalg.lstsq(
+        #     cov_matrix_1_2.T,
+        #     data_matrix_2[..., 0].T,
+        #     rcond=None,
+        # )[0].T[..., np.newaxis]
+
+    products = (
+        np.transpose(data_matrix_1, axes=(0, 2, 1))
+        @ inv_fd2_matrix
+    )
+    # Remove redundant dimensions
+    return products.reshape(products.shape[0])
+
+
+@rkhs_inner_product.register(FDataBasis, FDataBasis)
+def rkhs_inner_product_fdatabasis(
+    fdata1: FDataBasis,
+    fdata2: FDataBasis,
+    *,
+    cov_function: Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
+) -> NDArrayFloat:
+    """RKHS inner product of two FDataBasis objects.
+
+    In case of using a basis expression, the RKHS inner product can be
+    computed obtaining first a basis representation of the covariance
+    function in the tensor basis. Then, the inverse operator applied to
+    the second term is calculated.
+    In case of using a common basis, that step is done by solving the
+    system given by the inverse of the matrix of coefficients of the
+    covariance function in the tensor basis formed by the two given bases.
+    In case of using different bases, the left inverse of the transposed
+    matrix of coefficients of the covariance function is used instead.
+    Finally, the inner product between each pair of samples is calculated.
+
+    In case of knowing the matrix of coefficients of the covariance function
+    in the tensor basis formed by the two given bases, it can be passed as
+    an argument to avoid the calculation of it.
+
+    Args:
+        fdata1: First FDataBasis object.
+        fdata2: Second FDataBasis object.
+        cov_function: Covariance function as a callable. It is expected to
+            receive two arrays, s and t, and return the corresponding
+            covariance matrix.
+
+    Returns:
+        Matrix of the RKHS inner product between paired samples of
+        fdata1 and fdata2.
+    """
+    _check_compatible_fdata(fdata1, fdata2)
+
+    if isinstance(cov_function, EmpiricalBasis):
+        cov_coeff_matrix = cov_function.coeff_matrix
+    else:
+        # Express the covariance function in the tensor basis
+        # NOTE: The alternative is to convert to FDatagrid the two FDataBasis
+        cov_coeff_matrix = _get_coeff_matrix(
+            cov_function,
+            fdata1.basis,
+            fdata2.basis,
+        )
+
+    if fdata1.basis == fdata2.basis:
+        inv_fd2_coefs = np.linalg.solve(
+            cov_coeff_matrix,
+            fdata2.coefficients.T,
+        )
+    else:
+        inv_fd2_coefs = np.linalg.lstsq(
+            cov_coeff_matrix.T,
+            fdata2.coefficients.T,
+            rcond=None,
+        )[0]
+
+    # Following einsum is equivalent to doing the matrix multiplication
+    # and then taking the diagonal of the result
+    return np.einsum(  # type: ignore[no-any-return]
+        "ij,ji->i",
+        fdata1.coefficients,
+        inv_fd2_coefs,
+    )

--- a/skfda/tests/test_rkhs_inner_product.py
+++ b/skfda/tests/test_rkhs_inner_product.py
@@ -1,0 +1,232 @@
+"""Test the RKHS inner product method."""
+from typing import Any
+
+import numpy as np
+import pytest
+
+from skfda._utils import constants
+from skfda.misc.rkhs_product import rkhs_inner_product
+from skfda.representation import FDataBasis, FDataGrid
+from skfda.representation.basis import (
+    Basis,
+    BSplineBasis,
+    FourierBasis,
+    TensorBasis,
+)
+from skfda.typing._numpy import NDArrayFloat
+
+N_BASIS = 5
+DOMAIN_RANGE = (0, 1)
+
+
+@pytest.fixture(
+    params=[
+        FourierBasis,
+        BSplineBasis,
+    ],
+    ids=[
+        "FourierBasis",
+        "BSplineBasis",
+    ],
+)
+def basis_2(
+    request: Any,
+) -> Any:
+    """Fixture for classes to test."""
+    return request.param(
+        n_basis=N_BASIS,
+        domain_range=DOMAIN_RANGE,
+    )
+
+
+def test_rkhs_inner_product_grid() -> None:
+    """Test the RKHS product for specific FDataGrid.
+
+    The tested functions are:
+        x(t) = t
+        y(t) = t/3 + 1/2
+        K(t,s) = t*s + 1
+
+    The expected result of the RKHS product is:
+        <x,y>_K = 1/3
+    """
+    grid_points = np.linspace(
+        *DOMAIN_RANGE,
+        constants.N_POINTS_FINE_MESH,
+    )
+    x = FDataGrid(
+        [grid_points],
+        grid_points,
+    )
+    y = (x / 3) + (1 / 2)
+
+    def cov_function(  # noqa: WPS430
+        t: NDArrayFloat,
+        s: NDArrayFloat,
+    ) -> NDArrayFloat:
+        return np.outer(t, s) + 1
+
+    result = rkhs_inner_product(
+        fdata1=x,
+        fdata2=y,
+        cov_function=cov_function,
+    )
+    expected_result = [1 / 3]
+    np.testing.assert_allclose(
+        result,
+        expected_result,
+        rtol=1e-13,
+    )
+
+    # Test the product is symmetric
+    result = rkhs_inner_product(
+        fdata1=y,
+        fdata2=x,
+        cov_function=cov_function,
+    )
+    np.testing.assert_allclose(
+        result,
+        expected_result,
+        rtol=1e-13,
+    )
+
+
+def test_rkhs_inner_product_basis(
+    basis_2: Basis,
+) -> None:
+    """Test the RKHS product for specific FDataBasis.
+
+    The tested functions are:
+        x(t) = sin(2*pi*t)
+        y(t) = phi_0(t) + phi_2(t)
+        K(t,s) = Phi(t)^T B Phi(s)
+    Where Phi = {phi_0, phi_1, phi_2} is the Fourier basis and B is a
+    specific symmetric definite-positive matrix.
+    The inverse of the operator applied to y is phi_2(t).
+
+    The expected result of the RKHS product is:
+        <x,y>_K = 0
+    """
+    grid_points = np.linspace(
+        *DOMAIN_RANGE,
+        constants.N_POINTS_FINE_MESH,
+    )
+    x = FDataGrid(
+        [np.sin(2 * np.pi * grid_points)],
+        grid_points,
+    )
+
+    # Define y and cov_function in term of basis_1
+    basis_1 = FourierBasis(
+        n_basis=3,
+        domain_range=DOMAIN_RANGE,
+    )
+    y = FDataBasis(
+        basis=basis_1,
+        coefficients=[[1, 0, 1]],
+    )
+    kernel = FDataBasis(
+        basis=TensorBasis([basis_1, basis_1]),
+        coefficients=np.array([
+            [3, 1, 1],
+            [1, 2, 0],
+            [1, 0, 1],
+        ]).flatten(),
+    )
+
+    def cov_function(  # noqa: WPS430
+        t: NDArrayFloat,
+        s: NDArrayFloat,
+    ) -> NDArrayFloat:
+        return kernel([s, t], grid=True)[0, ..., 0]
+
+    x_basis = x.to_basis(basis_1)
+    y_basis = y.to_basis(basis_2)
+
+    result = rkhs_inner_product(
+        fdata1=x_basis,
+        fdata2=y_basis,
+        cov_function=cov_function,
+    )
+    expected_result = [0]
+    np.testing.assert_allclose(
+        result,
+        expected_result,
+        atol=1e-4,
+    )
+
+    # Test the product is symmetric
+    result = rkhs_inner_product(
+        fdata1=y_basis,
+        fdata2=x_basis,
+        cov_function=cov_function,
+    )
+    np.testing.assert_allclose(
+        result,
+        expected_result,
+        atol=1e-4,
+    )
+
+
+def test_rkhs_inner_product_brownian_bridge() -> None:
+    r"""Test the RKHS product for specific FDataGrid.
+
+    The tested functions are:
+        x(t) = 1-(2t-1)^2
+        y(t) = sin(pi*t)
+        K(t,s) = sigma^2 * (min(t,s) - t*s)
+    Where sigma is a constant.
+
+    The precise formula is:
+        <f,g>_K = 1/sigma^2 * \int_0^1 f'(t)g'(t)dt
+    Assuming that the domain is [0,1] and the functions
+    are in the RKHS of the Brownian bridge.
+    See ramos___2020_gaussian.pdf for more details.
+
+    The expected result of the RKHS product is:
+        <x,y>_K = 16/pi
+        for sigma = 1
+    """
+    grid_points = np.linspace(
+        *DOMAIN_RANGE,
+        constants.N_POINTS_FINE_MESH,
+    )
+    # Remove axis 0 to avoid singular matrix
+    grid_points = grid_points[1:-1]
+    x = FDataGrid(
+        [1 - (2 * grid_points - 1)**2],
+        grid_points,
+    )
+    y = FDataGrid(
+        [np.sin(np.pi * grid_points)],
+        grid_points,
+    )
+    sigma = 1
+
+    def cov_function(  # noqa: WPS430
+        t: NDArrayFloat,
+        s: NDArrayFloat,
+    ) -> NDArrayFloat:
+        # Matrix with the minimum of each pair of values
+        min_values = np.amin(
+            np.transpose(
+                np.meshgrid(t, s),
+                (2, 1, 0),
+            ),
+            axis=2,
+        )
+        return sigma**2 * (  # type: ignore[no-any-return]
+            min_values - np.outer(t, s)
+        )
+
+    result = rkhs_inner_product(
+        fdata1=x,
+        fdata2=y,
+        cov_function=cov_function,
+    )
+    expected_result = [16 / np.pi]
+    np.testing.assert_allclose(
+        result,
+        expected_result,
+        rtol=1e-5,
+    )


### PR DESCRIPTION
This PR adds the RKHS inner product.

Cases regarding the product between `FDataBasis` objects with different basis or with the covariance function not already expressed in the tensor basis, might be better to not consider them.