### PR TITLE
Fix tests for scikit learn 1.3.0

### DIFF
--- a/skfda/preprocessing/smoothing/validation.py
+++ b/skfda/preprocessing/smoothing/validation.py
@@ -331,6 +331,7 @@ class SmoothingParameterSearch(
             return_train_score=False,
         )
         self.param_values = param_values
+        self.param_name = param_name
 
     def fit(  # noqa: D102
         self,


### PR DESCRIPTION
Add missing parameter to constructor so that tests pass with scikit-learn 1.3.0 (new version released today :) )