### PR TITLE
fix IndexError in FPCAPlot

### DIFF
--- a/skfda/exploratory/visualization/fpca.py
+++ b/skfda/exploratory/visualization/fpca.py
@@ -84,9 +84,10 @@ class FPCAPlot(BasePlot):
             self.mean = self.mean.mean()
 
         for i, ax in enumerate(axes):
-            perturbations = self._get_component_perturbations(i)
-            GraphPlot(fdata=perturbations, axes=ax).plot()
-            ax.set_title(f"Principal component {i + 1}")
+            if i < self.n_subplots:
+                perturbations = self._get_component_perturbations(i)
+                GraphPlot(fdata=perturbations, axes=ax).plot()
+                ax.set_title(f"Principal component {i + 1}")
 
     def _get_component_perturbations(self, index: int = 0) -> FData:
         """


### PR DESCRIPTION
FPCAplot returns an IndexError when the number of components to plot is not equal to the number of created axes.

In the following, I plot 3 components, FPCAplot has created a 2*2 subplots and can not allocate a plot for the last axe and throws an IndexError 

```python
import matplotlib.pyplot as plt
from skfda.datasets import fetch_weather
from skfda.exploratory.visualization import FPCAPlot
from skfda.preprocessing.dim_reduction.feature_extraction import FPCA
from skfda.representation.grid import FDataGrid
from skfda.representation.basis import BSpline

# create a FDataGrid with temperature from CanadianWeather
dataset = fetch_weather()
data_temp = FDataGrid(data_matrix=dataset["data"].data_matrix[:, :, 0], grid_points=dataset["data"].grid_points)

# basis expansion
basis_10 = BSpline(domain_range=data_temp.domain_range, n_basis=10, order=4)
temp_fd  = data_temp.to_basis(basis_10)

# fpca
fpca = FPCA(n_components=3)
fpca.fit(temp_fd)

FPCAPlot(temp_fd.mean(), fpca.components_, factor=100).plot()
```

```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[38], line 1
----> 1 FPCAPlot(temp_smooth_10.mean(), fpca.components_, factor=100).plot()

File [~/.local/lib/python3.10/site-packages/skfda/exploratory/visualization/_baseplot.py:98](https://file+.vscode-resource.vscode-cdn.net/home/quentin/Documents/Pr%C3%A9sentation/fda/~/.local/lib/python3.10/site-packages/skfda/exploratory/visualization/_baseplot.py:98), in BasePlot.plot(self)
     95 if self.y_label is not None:
     96     axes[0].set_ylabel(self.y_label)
---> 98 self._plot(fig, axes)
    100 self._hover_event_id = fig.canvas.mpl_connect(
    101     'motion_notify_event',
    102     self.hover,
    103 )
    105 return fig

File [~/.local/lib/python3.10/site-packages/skfda/exploratory/visualization/fpca.py:87](https://file+.vscode-resource.vscode-cdn.net/home/quentin/Documents/Pr%C3%A9sentation/fda/~/.local/lib/python3.10/site-packages/skfda/exploratory/visualization/fpca.py:87), in FPCAPlot._plot(self, fig, axes)
     84     self.mean = self.mean.mean()
     86 for i, ax in enumerate(axes):
---> 87     perturbations = self._get_component_perturbations(i)
     88     GraphPlot(fdata=perturbations, axes=ax).plot()
     89     ax.set_title(f"Principal component {i + 1}")

File [~/.local/lib/python3.10/site-packages/skfda/exploratory/visualization/fpca.py:107](https://file+.vscode-resource.vscode-cdn.net/home/quentin/Documents/Pr%C3%A9sentation/fda/~/.local/lib/python3.10/site-packages/skfda/exploratory/visualization/fpca.py:107), in FPCAPlot._get_component_perturbations(self, index)
    104     raise AttributeError("X must be a FData object")
    105 perturbations = self.mean.copy()
...
--> 572         raise IndexError("index out of bounds")
    574     return slice(key, key + 1)
    576 return key

IndexError: index out of bounds
```

I add an if statement in the loop to compare the current enumerate value with the number of plots