### PR TITLE
Feature/555 ddof parameter in fdatacov

### DIFF
--- a/skfda/exploratory/stats/_stats.py
+++ b/skfda/exploratory/stats/_stats.py
@@ -41,19 +41,22 @@ def mean(
     return (X * weight).sum()
 
 
-def var(X: FData) -> FDataGrid:
+def var(X: FData, ddof: int = 1) -> FDataGrid:
     """
     Compute the variance of a set of samples in a FData object.
 
     Args:
         X: Object containing all the set of samples whose variance is desired.
+        ddof: "Delta Degrees of Freedom": the divisor used in the calculation
+            is `N - ddof`, where `N` represents the number of elements. By
+            default `ddof` is 1.
 
     Returns:
         Variance of all the samples in the original object, as a
         :term:`functional data object` with just one sample.
 
     """
-    return X.var()  # type: ignore[no-any-return]
+    return X.var(ddof=ddof)  # type: ignore[no-any-return]
 
 
 def gmean(X: FDataGrid) -> FDataGrid:

--- a/skfda/exploratory/stats/_stats.py
+++ b/skfda/exploratory/stats/_stats.py
@@ -71,7 +71,10 @@ def gmean(X: FDataGrid) -> FDataGrid:
     return X.gmean()
 
 
-def cov(X: FData) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
+def cov(
+    X: FData,
+    ddof: int = 1
+) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
     """
     Compute the covariance.
 
@@ -80,13 +83,17 @@ def cov(X: FData) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
 
     Args:
         X: Object containing different samples of a functional variable.
+        ddof: "Delta Degrees of Freedom": the divisor used in the calculation
+            is `N - ddof`, where `N` represents the number of elements. By
+            default `ddof` is 1.
+
 
     Returns:
         Covariance of all the samples in the original object, as a
         callable.
 
     """
-    return X.cov()
+    return X.cov(ddof=ddof)
 
 
 def modified_epigraph_index(X: FDataGrid) -> NDArrayFloat:

--- a/skfda/misc/covariances.py
+++ b/skfda/misc/covariances.py
@@ -768,16 +768,19 @@ class Empirical(Covariance):
 
     The sample covariance function is defined as
     . math::
-        K(t, s) = \frac{1}{n}\sum_{n=1}^N\left(x_n(t) - \bar{x}(t)\right)
-        \left(x_n(s) - \bar{x}(s)\right)
+        K(t, s) = \frac{1}{N-\text{ddof}}\sum_{n=1}^N\left(x_n(t) -
+        \bar{x}(t)\right) \left(x_n(s) - \bar{x}(s)\right)
 
     where :math:`x_n(t)` is the n-th sample and :math:`\bar{x}(t)` is the
-    mean of the samples.
+    mean of the samples. :math:`N` is the number of samples,
+    :math:`\text{ddof}` means "Delta Degrees of Freedom" and is such that
+    :math:`N-\text{ddof}` is the divisor used in the calculation of the
+    covariance function.
 
     """
 
     _latex_formula = (
-        r"K(t, s) = \frac{1}{n}\sum_{n=1}^N(x_n(t) - \bar{x}(t))"
+        r"K(t, s) = \frac{1}{N-\text{ddof}}\sum_{n=1}^N(x_n(t) - \bar{x}(t))"
         r"(x_n(s) - \bar{x}(s))"
     )
     _parameters_str = [
@@ -785,6 +788,7 @@ class Empirical(Covariance):
     ]
 
     cov_fdata: FData
+    ddof: int
 
     @abc.abstractmethod
     def __init__(self, data: FData) -> None:
@@ -811,14 +815,17 @@ class EmpiricalGrid(Empirical):
     """Sample covariance function for FDataGrid."""
 
     cov_fdata: FDataGrid
+    ddof: int
 
-    def __init__(self, data: FDataGrid) -> None:
+    def __init__(self, data: FDataGrid, ddof: int = 1) -> None:
         super().__init__(data=data)
 
+        self.ddof = ddof
         self.cov_fdata = data.copy(
             data_matrix=np.cov(
                 data.data_matrix[..., 0],
                 rowvar=False,
+                ddof=ddof,
             )[np.newaxis, ...],
             grid_points=[
                 data.grid_points[0],
@@ -844,11 +851,17 @@ class EmpiricalBasis(Empirical):
 
     cov_fdata: FDataBasis
     coeff_matrix: NDArrayFloat
+    ddof: int
 
-    def __init__(self, data: FDataBasis) -> None:
+    def __init__(self, data: FDataBasis, ddof: int = 1) -> None:
         super().__init__(data=data)
 
-        self.coeff_matrix = np.cov(data.coefficients, rowvar=False)
+        self.ddof = ddof
+        self.coeff_matrix = np.cov(
+            data.coefficients,
+            rowvar=False,
+            ddof=ddof,
+        )
         self.cov_fdata = FDataBasis(
             basis=TensorBasis([data.basis, data.basis]),
             coefficients=self.coeff_matrix.flatten(),

--- a/skfda/misc/scoring.py
+++ b/skfda/misc/scoring.py
@@ -74,7 +74,7 @@ def _var(
     from ..exploratory.stats import mean, var
 
     if weights is None:
-        return var(x)
+        return var(x, ddof=0)
 
     return mean(  # type: ignore[no-any-return]
         np.power(x - mean(x, weights=weights), 2),

--- a/skfda/ml/clustering/_kmeans.py
+++ b/skfda/ml/clustering/_kmeans.py
@@ -147,7 +147,7 @@ class BaseKMeans(
         return fdata
 
     def _tolerance(self, fdata: Input) -> float:
-        variance = fdata.var()
+        variance = fdata.var(ddof=0)
         mean_variance = np.mean(variance[0].data_matrix)
 
         return float(mean_variance * self.tol)

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -826,6 +826,7 @@ class FData(  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
+        ddof: int = 1,
     ) -> NDArrayFloat:
         pass
 
@@ -833,6 +834,7 @@ class FData(  # noqa: WPS214
     def cov(  # noqa: WPS451
         self: T,
         /,
+        ddof: int = 1,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -842,6 +844,7 @@ class FData(  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
+        ddof: int = 1,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -861,6 +864,9 @@ class FData(  # noqa: WPS214
         Args:
             s_points: Points where the covariance function is evaluated.
             t_points: Points where the covariance function is evaluated.
+            ddof: "Delta Degrees of Freedom": the divisor used in the
+                calculation is `N - ddof`, where `N` represents the number
+                of elements. By default `ddof` is 1.
 
         Returns:
             Covariance function.

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -469,6 +469,7 @@ class FDataBasis(FData):  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
+        ddof: int = 1,
     ) -> NDArrayFloat:
         pass
 
@@ -476,6 +477,7 @@ class FDataBasis(FData):  # noqa: WPS214
     def cov(    # noqa: WPS451
         self: T,
         /,
+        ddof: int = 1,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -484,6 +486,7 @@ class FDataBasis(FData):  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
+        ddof: int = 1,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -505,6 +508,9 @@ class FDataBasis(FData):  # noqa: WPS214
         Args:
             s_points: Points where the covariance function is evaluated.
             t_points: Points where the covariance function is evaluated.
+            ddof: "Delta Degrees of Freedom": the divisor used in the
+                calculation is `N - ddof`, where `N` represents the number
+                of elements. By default `ddof` is 1.
 
         Returns:
             Covariance function.
@@ -512,7 +518,7 @@ class FDataBasis(FData):  # noqa: WPS214
         """
         # To avoid circular imports
         from ...misc.covariances import EmpiricalBasis
-        cov_function = EmpiricalBasis(self)
+        cov_function = EmpiricalBasis(self, ddof=ddof)
         if s_points is None or t_points is None:
             return cov_function
         return cov_function(s_points, t_points)

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -442,7 +442,11 @@ class FDataBasis(FData):  # noqa: WPS214
             sample_names=(None,),
         )
 
-    def var(self: T, eval_points: Optional[NDArrayFloat] = None) -> T:
+    def var(
+        self: T,
+        eval_points: Optional[NDArrayFloat] = None,
+        ddof: int = 1,
+    ) -> T:
         """Compute the variance of the functional data object.
 
         A numerical approach its used. The object its transformed into its
@@ -456,12 +460,15 @@ class FDataBasis(FData):  # noqa: WPS214
                 numpy.linspace with bounds equal to the ones defined in
                 self.domain_range and the number of points the maximum
                 between 501 and 10 times the number of basis.
+            ddof: "Delta Degrees of Freedom": the divisor used in the
+                calculation is `N - ddof`, where `N` represents the number of
+                elements. By default `ddof` is 1.
 
         Returns:
             Variance of the original object.
 
         """
-        return self.to_grid(eval_points).var().to_basis(self.basis)
+        return self.to_grid(eval_points).var(ddof=ddof).to_basis(self.basis)
 
     @overload
     def cov(  # noqa: WPS451

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -601,6 +601,7 @@ class FDataGrid(FData):  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
+        ddof: int = 1,
     ) -> NDArrayFloat:
         pass
 
@@ -608,6 +609,7 @@ class FDataGrid(FData):  # noqa: WPS214
     def cov(  # noqa: WPS451
         self: T,
         /,
+        ddof: int = 1,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -616,6 +618,7 @@ class FDataGrid(FData):  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
+        ddof: int = 1,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -631,6 +634,9 @@ class FDataGrid(FData):  # noqa: WPS214
         Args:
             s_points: Grid points where the covariance function is evaluated.
             t_points: Grid points where the covariance function is evaluated.
+            ddof: "Delta Degrees of Freedom": the divisor used in the
+                calculation is `N - ddof`, where `N` represents the number
+                of elements. By default `ddof` is 1.
 
         Returns:
             Covariance function.
@@ -638,7 +644,7 @@ class FDataGrid(FData):  # noqa: WPS214
         """
         # To avoid circular imports
         from ..misc.covariances import EmpiricalGrid
-        cov_function = EmpiricalGrid(self)
+        cov_function = EmpiricalGrid(self, ddof=ddof)
         if s_points is None or t_points is None:
             return cov_function
         return cov_function(s_points, t_points)

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -582,8 +582,13 @@ class FDataGrid(FData):  # noqa: WPS214
             sample_names=(None,),
         )
 
-    def var(self: T) -> T:
+    def var(self: T, ddof: int = 1) -> T:
         """Compute the variance of a set of samples in a FDataGrid object.
+
+        Args:
+            ddof: "Delta Degrees of Freedom": the divisor used in the
+                calculation is `N - ddof`, where `N` represents the number of
+                elements. By default `ddof` is 1.
 
         Returns:
             A FDataGrid object with just one sample representing the
@@ -591,7 +596,11 @@ class FDataGrid(FData):  # noqa: WPS214
 
         """
         return self.copy(
-            data_matrix=np.array([np.var(self.data_matrix, 0)]),
+            data_matrix=np.array([np.var(
+                self.data_matrix,
+                axis=0,
+                ddof=ddof,
+            )]),
             sample_names=("variance",),
         )
 


### PR DESCRIPTION
Add parameter `ddof` to FData.cov, FData.var, stats.cov and stats.var.

As explained in #555, this `ddof` parameter has value 1 by default and means "Delta Degrees of Freedom". The divisor used in the calculation of the covariance is `N-ddof`.

This changes the previous default behavior of `var`, which used `ddof=0` by default. Therefore, changes have been applied to scikit-fda/skfda/misc/scoring.py (Line 77) and scikit-fda/skfda/ml/clustering/_kmeans.py (Line 150), in order to preserve the previous behaviour of those modules.

This pull request closes #555 .