### PR TITLE
`FDataGrid.restrict` option `with_bounds`

### DIFF
--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -1113,7 +1113,7 @@ class FDataGrid(FData):  # noqa: WPS214
             ib = np.searchsorted(grid_points, b, 'right')
             slice_list.append(slice(ia, ib))
         grid_points = [g[s] for g, s in zip(self.grid_points, slice_list)]
-        data_matrix = self.data_matrix[slice(None), *slice_list]
+        data_matrix = self.data_matrix[(slice(None),) + tuple(slice_list)]
 
         # Ensure that boundaries are in grid_points.
         if with_bounds:
@@ -1122,10 +1122,10 @@ class FDataGrid(FData):  # noqa: WPS214
                 dim_points = grid_points[dim]
                 grid_points[dim] = []
                 add_low, add_high = False, False
-                if a < g:
+                if a < dim_points[0]:
                     add_low = True
                     grid_points[dim].append(a)
-                if b > gb:
+                if b > dim_points[-1]:
                     add_high = True
                     grid_points[dim].append(b)
                 if not (add_low or add_high):
@@ -1142,19 +1142,19 @@ class FDataGrid(FData):  # noqa: WPS214
                 if add_low:
                     if add_high:
                         data_matrix = np.concatenate(
-                            (edge_values.take(0, dim),
+                            (edge_values.take([0], axis=dim+1),
                              data_matrix,
-                             edge_values.take(1, dim)),
-                            axis=dim)
+                             edge_values.take([1], axis=dim+1)),
+                            axis=dim+1)
                         dim_points = np.concatenate(([a], dim_points, [b]))
                     else:
                         data_matrix = np.concatenate(
-                            (edge_values, data_matrix), axis=dim)
+                            (edge_values, data_matrix), axis=dim+1)
                         dim_points = np.concatenate(([a], dim_points))
                 else:
                     if add_high:
                         data_matrix = np.concatenate(
-                            (data_matrix, edge_values), axis=dim)
+                            (data_matrix, edge_values), axis=dim+1)
                         dim_points = np.concatenate((dim_points, [b]))
                 grid_points[dim] = dim_points
 

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -1108,7 +1108,7 @@ class FDataGrid(FData):  # noqa: WPS214
         # Eliminate points outside the new range.
         index_list = []
         slice_list = []
-        for (a, b), grid_points in zip(domain_range,self.grid_points):
+        for (a, b), grid_points in zip(domain_range, self.grid_points):
             ia = np.searchsorted(grid_points, a)
             ib = np.searchsorted(grid_points, b, 'right')
             slice_list.append(slice(ia, ib))

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -1101,30 +1101,19 @@ class FDataGrid(FData):  # noqa: WPS214
             for ((a, b), (c, d)) in zip(domain_range, self.domain_range)
         )
 
-        index_list = []
-        new_grid_points = []
-
         # Eliminate points outside the new range.
-        for dr, grid_points in zip(
-            domain_range,
-            self.grid_points,
-        ):
-            keep_index = (
-                (dr[0] <= grid_points)
-                & (grid_points <= dr[1])
-            )
-
-            index_list.append(keep_index)
-
-            new_grid_points.append(
-                grid_points[keep_index],
-            )
-
-        data_matrix = self.data_matrix[(slice(None),) + tuple(index_list)]
+        index_list = []
+        slice_list = []
+        for (a, b), grid_points in zip(domain_range,self.grid_points):
+            ia = np.searchsorted(grid_points, a)
+            ib = np.searchsorted(grid_points, b, 'right')
+            slice_list.append(slice(ia, ib))
+        grid_points = [g[s] for g, s in zip(self.grid_points, slice_list)]
+        data_matrix = self.data_matrix[slice(None), *slice_list]
 
         return self.copy(
             domain_range=domain_range,
-            grid_points=new_grid_points,
+            grid_points=grid_points,
             data_matrix=data_matrix,
         )
 

--- a/skfda/tests/test_grid.py
+++ b/skfda/tests/test_grid.py
@@ -341,7 +341,7 @@ class TestEvaluateFDataGrid(unittest.TestCase):
         """ Test FDataGrid.restrict with bounds. """
         # Test 1 sample function R^3 -> R^5.
         grid_points = ([0, 1], [0, 1, 2], [0, 1, 2, 3])
-        data_matrix = np.ones(1, 2, 3, 4, 5)
+        data_matrix = np.ones((1, 2, 3, 4, 5))
         fd = FDataGrid(data_matrix, grid_points)
         fd_restricted = fd.restrict(((0, 1), (.5, 1.5), (.5, 2)))
         res = fd_restricted.grid_points

--- a/skfda/tests/test_grid.py
+++ b/skfda/tests/test_grid.py
@@ -337,6 +337,18 @@ class TestEvaluateFDataGrid(unittest.TestCase):
 
         np.testing.assert_allclose(res, expected)
 
+    def test_restrict(self) -> None:
+        """ Test FDataGrid.restrict with bounds. """
+        # Test 1 sample function R^3 -> R^5.
+        grid_points = ([0, 1], [0, 1, 2], [0, 1, 2, 3])
+        data_matrix = np.ones(1, 2, 3, 4, 5)
+        fd = FDataGrid(data_matrix, grid_points)
+        fd_restricted = fd.restrict(((0, 1), (.5, 1.5), (.5, 2)))
+        res = fd_restricted.grid_points
+        expected = ([0, 1], [.5, 1, 1.5], [.5, 1, 2])
+        for r, e in zip(res, expected):
+            np.testing.assert_array_equal(r, e)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented proposed enhancement from #560.

A few notes to keep in mind when (or before) merging:
- `with_bounds` defaults to `True`,
- With high `dim_domain`, `domain`'s boundary potentially contains a lot of points, which might end up pretty slow. That said, I guess it has to happen when manipulating a functional object on a huge domain size,
- No 1D optimization was made. I don't know the general spirit of your implementation, but if you generally treat 1D differently with lighter/faster code, then this should also be done here.

Waiting for your feedback!

Cheers :)
Élie