### PR TITLE
BSplineBasis initialization incorrect error message

### DIFF
--- a/skfda/representation/basis/_bspline_basis.py
+++ b/skfda/representation/basis/_bspline_basis.py
@@ -129,11 +129,10 @@ class BSplineBasis(Basis):
                 )
             n_basis = len(knots) + order - 2
 
-        if (n_basis - order + 2) < 2:
+        if n_basis < order:
             raise ValueError(
-                f"The number of basis ({n_basis}) minus the "
-                f"order of the bspline ({order}) should be "
-                f"greater than 3.",
+                f"The number of basis ({n_basis}) should not be smaller "
+                f"than the order of the bspline ({order}).",
             )
 
         self._order = order


### PR DESCRIPTION
Fix message and condition (n_basis < order) in the initialization of a BSplineBasis.

Current condition is equivalent to previous one. The message has been corrected to match the condition.

Closes #575 