### PR TITLE
Change `ddof` argument to `correction` in var and cov functions

### DIFF
--- a/skfda/exploratory/stats/_stats.py
+++ b/skfda/exploratory/stats/_stats.py
@@ -41,22 +41,22 @@ def mean(
     return (X * weight).sum()
 
 
-def var(X: FData, ddof: int = 1) -> FDataGrid:
+def var(X: FData, correction: int = 1) -> FDataGrid:
     """
     Compute the variance of a set of samples in a FData object.
 
     Args:
         X: Object containing all the set of samples whose variance is desired.
-        ddof: "Delta Degrees of Freedom": the divisor used in the calculation
-            is `N - ddof`, where `N` represents the number of elements. By
-            default `ddof` is 1.
+        correction: degrees of freedom adjustment. The divisor used in the
+            calculation is `N - correction`, where `N` represents the number of
+            elements. Default: `1`.
 
     Returns:
         Variance of all the samples in the original object, as a
         :term:`functional data object` with just one sample.
 
     """
-    return X.var(ddof=ddof)  # type: ignore[no-any-return]
+    return X.var(correction=correction)  # type: ignore[no-any-return]
 
 
 def gmean(X: FDataGrid) -> FDataGrid:
@@ -76,7 +76,7 @@ def gmean(X: FDataGrid) -> FDataGrid:
 
 def cov(
     X: FData,
-    ddof: int = 1
+    correction: int = 1,
 ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
     """
     Compute the covariance.
@@ -86,9 +86,9 @@ def cov(
 
     Args:
         X: Object containing different samples of a functional variable.
-        ddof: "Delta Degrees of Freedom": the divisor used in the calculation
-            is `N - ddof`, where `N` represents the number of elements. By
-            default `ddof` is 1.
+        correction: degrees of freedom adjustment. The divisor used in the
+            calculation is `N - correction`, where `N` represents the number of
+            elements. Default: `1`.
 
 
     Returns:
@@ -96,7 +96,7 @@ def cov(
         callable.
 
     """
-    return X.cov(ddof=ddof)
+    return X.cov(correction=correction)
 
 
 def modified_epigraph_index(X: FDataGrid) -> NDArrayFloat:

--- a/skfda/misc/covariances.py
+++ b/skfda/misc/covariances.py
@@ -768,27 +768,27 @@ class Empirical(Covariance):
 
     The sample covariance function is defined as
     . math::
-        K(t, s) = \frac{1}{N-\text{ddof}}\sum_{n=1}^N\left(x_n(t) -
+        K(t, s) = \frac{1}{N-\text{correction}}\sum_{n=1}^N\left(x_n(t) -
         \bar{x}(t)\right) \left(x_n(s) - \bar{x}(s)\right)
 
     where :math:`x_n(t)` is the n-th sample and :math:`\bar{x}(t)` is the
     mean of the samples. :math:`N` is the number of samples,
-    :math:`\text{ddof}` means "Delta Degrees of Freedom" and is such that
-    :math:`N-\text{ddof}` is the divisor used in the calculation of the
-    covariance function.
+    :math:`\text{correction}` is the degrees of freedom adjustment and is such
+    that :math:`N-\text{correction}` is the divisor used in the calculation of
+    the covariance function.
 
     """
 
     _latex_formula = (
-        r"K(t, s) = \frac{1}{N-\text{ddof}}\sum_{n=1}^N(x_n(t) - \bar{x}(t))"
-        r"(x_n(s) - \bar{x}(s))"
+        r"K(t, s) = \frac{1}{N-\text{correction}}\sum_{n=1}^N"
+        r"(x_n(t) - \bar{x}(t))(x_n(s) - \bar{x}(s))"
     )
     _parameters_str = [
         ("data", "data"),
     ]
 
     cov_fdata: FData
-    ddof: int
+    correction: int
 
     @abc.abstractmethod
     def __init__(self, data: FData) -> None:
@@ -815,17 +815,17 @@ class EmpiricalGrid(Empirical):
     """Sample covariance function for FDataGrid."""
 
     cov_fdata: FDataGrid
-    ddof: int
+    correction: int
 
-    def __init__(self, data: FDataGrid, ddof: int = 1) -> None:
+    def __init__(self, data: FDataGrid, correction: int = 1) -> None:
         super().__init__(data=data)
 
-        self.ddof = ddof
+        self.correction = correction
         self.cov_fdata = data.copy(
             data_matrix=np.cov(
                 data.data_matrix[..., 0],
                 rowvar=False,
-                ddof=ddof,
+                ddof=correction,
             )[np.newaxis, ...],
             grid_points=[
                 data.grid_points[0],
@@ -851,16 +851,16 @@ class EmpiricalBasis(Empirical):
 
     cov_fdata: FDataBasis
     coeff_matrix: NDArrayFloat
-    ddof: int
+    correction: int
 
-    def __init__(self, data: FDataBasis, ddof: int = 1) -> None:
+    def __init__(self, data: FDataBasis, correction: int = 1) -> None:
         super().__init__(data=data)
 
-        self.ddof = ddof
+        self.correction = correction
         self.coeff_matrix = np.cov(
             data.coefficients,
             rowvar=False,
-            ddof=ddof,
+            ddof=correction,
         )
         self.cov_fdata = FDataBasis(
             basis=TensorBasis([data.basis, data.basis]),

--- a/skfda/misc/scoring.py
+++ b/skfda/misc/scoring.py
@@ -74,7 +74,7 @@ def _var(
     from ..exploratory.stats import mean, var
 
     if weights is None:
-        return var(x, ddof=0)
+        return var(x, correction=0)
 
     return mean(  # type: ignore[no-any-return]
         np.power(x - mean(x, weights=weights), 2),

--- a/skfda/ml/clustering/_kmeans.py
+++ b/skfda/ml/clustering/_kmeans.py
@@ -147,7 +147,7 @@ class BaseKMeans(
         return fdata
 
     def _tolerance(self, fdata: Input) -> float:
-        variance = fdata.var(ddof=0)
+        variance = fdata.var(correction=0)
         mean_variance = np.mean(variance[0].data_matrix)
 
         return float(mean_variance * self.tol)

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -826,7 +826,7 @@ class FData(  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> NDArrayFloat:
         pass
 
@@ -834,7 +834,7 @@ class FData(  # noqa: WPS214
     def cov(  # noqa: WPS451
         self: T,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -844,7 +844,7 @@ class FData(  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -864,9 +864,9 @@ class FData(  # noqa: WPS214
         Args:
             s_points: Points where the covariance function is evaluated.
             t_points: Points where the covariance function is evaluated.
-            ddof: "Delta Degrees of Freedom": the divisor used in the
-                calculation is `N - ddof`, where `N` represents the number
-                of elements. By default `ddof` is 1.
+            correction: degrees of freedom adjustment. The divisor used in the
+                calculation is `N - correction`, where `N` represents the
+                number of elements. Default: `1`.
 
         Returns:
             Covariance function.

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -445,7 +445,7 @@ class FDataBasis(FData):  # noqa: WPS214
     def var(
         self: T,
         eval_points: Optional[NDArrayFloat] = None,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> T:
         """Compute the variance of the functional data object.
 
@@ -460,15 +460,16 @@ class FDataBasis(FData):  # noqa: WPS214
                 numpy.linspace with bounds equal to the ones defined in
                 self.domain_range and the number of points the maximum
                 between 501 and 10 times the number of basis.
-            ddof: "Delta Degrees of Freedom": the divisor used in the
-                calculation is `N - ddof`, where `N` represents the number of
-                elements. By default `ddof` is 1.
+            correction: degrees of freedom adjustment. The divisor used in the
+                calculation is `N - correction`, where `N` represents the 
+                number of elements. Default: `1`.
 
         Returns:
             Variance of the original object.
 
         """
-        return self.to_grid(eval_points).var(ddof=ddof).to_basis(self.basis)
+        return self.to_grid(
+            eval_points).var(correction=correction).to_basis(self.basis)
 
     @overload
     def cov(  # noqa: WPS451
@@ -476,7 +477,7 @@ class FDataBasis(FData):  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> NDArrayFloat:
         pass
 
@@ -484,7 +485,7 @@ class FDataBasis(FData):  # noqa: WPS214
     def cov(    # noqa: WPS451
         self: T,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -493,7 +494,7 @@ class FDataBasis(FData):  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -515,9 +516,9 @@ class FDataBasis(FData):  # noqa: WPS214
         Args:
             s_points: Points where the covariance function is evaluated.
             t_points: Points where the covariance function is evaluated.
-            ddof: "Delta Degrees of Freedom": the divisor used in the
-                calculation is `N - ddof`, where `N` represents the number
-                of elements. By default `ddof` is 1.
+            correction: degrees of freedom adjustment. The divisor used in the
+                calculation is `N - correction`, where `N` represents the
+                number of elements. Default: `1`.
 
         Returns:
             Covariance function.
@@ -525,7 +526,7 @@ class FDataBasis(FData):  # noqa: WPS214
         """
         # To avoid circular imports
         from ...misc.covariances import EmpiricalBasis
-        cov_function = EmpiricalBasis(self, ddof=ddof)
+        cov_function = EmpiricalBasis(self, correction=correction)
         if s_points is None or t_points is None:
             return cov_function
         return cov_function(s_points, t_points)

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -461,7 +461,7 @@ class FDataBasis(FData):  # noqa: WPS214
                 self.domain_range and the number of points the maximum
                 between 501 and 10 times the number of basis.
             correction: degrees of freedom adjustment. The divisor used in the
-                calculation is `N - correction`, where `N` represents the 
+                calculation is `N - correction`, where `N` represents the
                 number of elements. Default: `1`.
 
         Returns:
@@ -469,7 +469,8 @@ class FDataBasis(FData):  # noqa: WPS214
 
         """
         return self.to_grid(
-            eval_points).var(correction=correction).to_basis(self.basis)
+            eval_points,
+        ).var(correction=correction).to_basis(self.basis)
 
     @overload
     def cov(  # noqa: WPS451

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -582,13 +582,13 @@ class FDataGrid(FData):  # noqa: WPS214
             sample_names=(None,),
         )
 
-    def var(self: T, ddof: int = 1) -> T:
+    def var(self: T, correction: int = 1) -> T:
         """Compute the variance of a set of samples in a FDataGrid object.
 
         Args:
-            ddof: "Delta Degrees of Freedom": the divisor used in the
-                calculation is `N - ddof`, where `N` represents the number of
-                elements. By default `ddof` is 1.
+            correction: "Delta Degrees of Freedom": the divisor used in the
+                calculation is `N - correction`, where `N` represents the number of
+                elements. By default `correction` is 1.
 
         Returns:
             A FDataGrid object with just one sample representing the
@@ -599,7 +599,7 @@ class FDataGrid(FData):  # noqa: WPS214
             data_matrix=np.array([np.var(
                 self.data_matrix,
                 axis=0,
-                ddof=ddof,
+                ddof=correction,
             )]),
             sample_names=("variance",),
         )
@@ -610,7 +610,7 @@ class FDataGrid(FData):  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> NDArrayFloat:
         pass
 
@@ -618,7 +618,7 @@ class FDataGrid(FData):  # noqa: WPS214
     def cov(  # noqa: WPS451
         self: T,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -627,7 +627,7 @@ class FDataGrid(FData):  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
-        ddof: int = 1,
+        correction: int = 1,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -643,9 +643,9 @@ class FDataGrid(FData):  # noqa: WPS214
         Args:
             s_points: Grid points where the covariance function is evaluated.
             t_points: Grid points where the covariance function is evaluated.
-            ddof: "Delta Degrees of Freedom": the divisor used in the
-                calculation is `N - ddof`, where `N` represents the number
-                of elements. By default `ddof` is 1.
+            correction: degrees of freedom adjustment. The divisor used in the
+                calculation is `N - correction`, where `N` represents the
+                number of elements. Default: `1`.
 
         Returns:
             Covariance function.
@@ -653,7 +653,7 @@ class FDataGrid(FData):  # noqa: WPS214
         """
         # To avoid circular imports
         from ..misc.covariances import EmpiricalGrid
-        cov_function = EmpiricalGrid(self, ddof=ddof)
+        cov_function = EmpiricalGrid(self, correction=correction)
         if s_points is None or t_points is None:
             return cov_function
         return cov_function(s_points, t_points)


### PR DESCRIPTION
Change `ddof` argument name to `correction` to match the Python array API standard.

Closes #576 