### PR TITLE
Set `correction=0` by default

### DIFF
--- a/skfda/exploratory/stats/_stats.py
+++ b/skfda/exploratory/stats/_stats.py
@@ -43,7 +43,7 @@ def mean(
     return (X * weight).sum()
 
 
-def var(X: FData, correction: int = 1) -> FDataGrid:
+def var(X: FData, correction: int = 0) -> FDataGrid:
     """
     Compute the variance of a set of samples in a FData object.
 
@@ -51,7 +51,7 @@ def var(X: FData, correction: int = 1) -> FDataGrid:
         X: Object containing all the set of samples whose variance is desired.
         correction: degrees of freedom adjustment. The divisor used in the
             calculation is `N - correction`, where `N` represents the number of
-            elements. Default: `1`.
+            elements. Default: `0`.
 
     Returns:
         Variance of all the samples in the original object, as a
@@ -78,7 +78,7 @@ def gmean(X: FDataGrid) -> FDataGrid:
 
 def cov(
     X: FData,
-    correction: int = 1,
+    correction: int = 0,
 ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
     """
     Compute the covariance.
@@ -90,7 +90,7 @@ def cov(
         X: Object containing different samples of a functional variable.
         correction: degrees of freedom adjustment. The divisor used in the
             calculation is `N - correction`, where `N` represents the number of
-            elements. Default: `1`.
+            elements. Default: `0`.
 
 
     Returns:

--- a/skfda/inference/anova/_anova_oneway.py
+++ b/skfda/inference/anova/_anova_oneway.py
@@ -220,6 +220,7 @@ def _anova_bootstrap(
         cov_est = concatenate(fd_grouped).cov(
             grid_points,
             grid_points,
+            correction=1,
         )
         k_est = [cov_est] * len(fd_grouped)
     else:
@@ -228,6 +229,7 @@ def _anova_bootstrap(
             fdg.cov(
                 grid_points,
                 grid_points,
+                correction=1,
             )
             for fdg in fd_grouped
         ]

--- a/skfda/inference/hotelling/_hotelling.py
+++ b/skfda/inference/hotelling/_hotelling.py
@@ -103,10 +103,12 @@ def hotelling_t2(
         k1 = fd1.cov(
             fd1.grid_points[0],
             fd1.grid_points[0],
+            correction=1,
         )
         k2 = fd2.cov(
             fd2.grid_points[0],
             fd2.grid_points[0],
+            correction=1,
         )
 
     m = m.reshape((-1, 1))  # Reshaping the mean for a proper matrix product

--- a/skfda/misc/covariances.py
+++ b/skfda/misc/covariances.py
@@ -817,7 +817,7 @@ class EmpiricalGrid(Empirical):
     cov_fdata: FDataGrid
     correction: int
 
-    def __init__(self, data: FDataGrid, correction: int = 1) -> None:
+    def __init__(self, data: FDataGrid, correction: int = 0) -> None:
         super().__init__(data=data)
 
         self.correction = correction
@@ -853,7 +853,7 @@ class EmpiricalBasis(Empirical):
     coeff_matrix: NDArrayFloat
     correction: int
 
-    def __init__(self, data: FDataBasis, correction: int = 1) -> None:
+    def __init__(self, data: FDataBasis, correction: int = 0) -> None:
         super().__init__(data=data)
 
         self.correction = correction

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -826,7 +826,7 @@ class FData(  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> NDArrayFloat:
         pass
 
@@ -834,7 +834,7 @@ class FData(  # noqa: WPS214
     def cov(  # noqa: WPS451
         self: T,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -844,7 +844,7 @@ class FData(  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -866,7 +866,7 @@ class FData(  # noqa: WPS214
             t_points: Points where the covariance function is evaluated.
             correction: degrees of freedom adjustment. The divisor used in the
                 calculation is `N - correction`, where `N` represents the
-                number of elements. Default: `1`.
+                number of elements. Default: `0`.
 
         Returns:
             Covariance function.

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -445,7 +445,7 @@ class FDataBasis(FData):  # noqa: WPS214
     def var(
         self: T,
         eval_points: Optional[NDArrayFloat] = None,
-        correction: int = 1,
+        correction: int = 0,
     ) -> T:
         """Compute the variance of the functional data object.
 
@@ -462,7 +462,7 @@ class FDataBasis(FData):  # noqa: WPS214
                 between 501 and 10 times the number of basis.
             correction: degrees of freedom adjustment. The divisor used in the
                 calculation is `N - correction`, where `N` represents the
-                number of elements. Default: `1`.
+                number of elements. Default: `0`.
 
         Returns:
             Variance of the original object.
@@ -478,7 +478,7 @@ class FDataBasis(FData):  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> NDArrayFloat:
         pass
 
@@ -486,7 +486,7 @@ class FDataBasis(FData):  # noqa: WPS214
     def cov(    # noqa: WPS451
         self: T,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -495,7 +495,7 @@ class FDataBasis(FData):  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -519,7 +519,7 @@ class FDataBasis(FData):  # noqa: WPS214
             t_points: Points where the covariance function is evaluated.
             correction: degrees of freedom adjustment. The divisor used in the
                 calculation is `N - correction`, where `N` represents the
-                number of elements. Default: `1`.
+                number of elements. Default: `0`.
 
         Returns:
             Covariance function.

--- a/skfda/representation/grid.py
+++ b/skfda/representation/grid.py
@@ -582,13 +582,13 @@ class FDataGrid(FData):  # noqa: WPS214
             sample_names=(None,),
         )
 
-    def var(self: T, correction: int = 1) -> T:
+    def var(self: T, correction: int = 0) -> T:
         """Compute the variance of a set of samples in a FDataGrid object.
 
         Args:
-            correction: "Delta Degrees of Freedom": the divisor used in the
-                calculation is `N - correction`, where `N` represents the number of
-                elements. By default `correction` is 1.
+            correction: degrees of freedom adjustment. The divisor used in the
+                calculation is `N - correction`, where `N` represents the
+                number of elements. Default: `0`.
 
         Returns:
             A FDataGrid object with just one sample representing the
@@ -610,7 +610,7 @@ class FDataGrid(FData):  # noqa: WPS214
         s_points: NDArrayFloat,
         t_points: NDArrayFloat,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> NDArrayFloat:
         pass
 
@@ -618,7 +618,7 @@ class FDataGrid(FData):  # noqa: WPS214
     def cov(  # noqa: WPS451
         self: T,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat]:
         pass
 
@@ -627,7 +627,7 @@ class FDataGrid(FData):  # noqa: WPS214
         s_points: Optional[NDArrayFloat] = None,
         t_points: Optional[NDArrayFloat] = None,
         /,
-        correction: int = 1,
+        correction: int = 0,
     ) -> Union[
         Callable[[NDArrayFloat, NDArrayFloat], NDArrayFloat],
         NDArrayFloat,
@@ -645,7 +645,7 @@ class FDataGrid(FData):  # noqa: WPS214
             t_points: Grid points where the covariance function is evaluated.
             correction: degrees of freedom adjustment. The divisor used in the
                 calculation is `N - correction`, where `N` represents the
-                number of elements. Default: `1`.
+                number of elements. Default: `0`.
 
         Returns:
             Covariance function.


### PR DESCRIPTION
(and explicitly set the correction value where it was not set, to avoid changing the previous behavior of the modules).

Closes #581 