### PR TITLE
Remove support for Python 3.9.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 	"numpy>=1.16",
 	"pandas>=1.0",
 	"rdata",
-	"scikit-datasets[cran]>=0.1.24",
+	"scikit-datasets[cran]>=0.2.2",
 	"scikit-learn>=0.20",
 	"scipy>=1.6.0",
 	"typing-extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 	"rdata",
 	"scikit-datasets[cran]>=0.1.24",
 	"scikit-learn>=0.20",
-	"scipy>=1.3.0",
+	"scipy>=1.6.0",
 	"typing-extensions",
 ]
 
@@ -64,7 +64,6 @@ test = [
   "pytest",
   "pytest-env",
   "pytest-subtests",
-  "scipy<1.11.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "scikit-fda"
 description = "Functional Data Analysis Python package."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE.txt"}
 keywords = [
 	"functional data",
@@ -20,7 +20,9 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/skfda/_utils/_neighbors_base.py
+++ b/skfda/_utils/_neighbors_base.py
@@ -245,11 +245,11 @@ class KNeighborsMixin(NeighborsBase[Input, Target]):
             Now we can query the k-nearest neighbors.
 
             >>> distances, index = neigh.kneighbors(X)
-            >>> index[0] # Index of k-neighbors of the first sample
-            array([0, 8, 1])
+            >>> index
+            array([[ 0, 8, 1], ...)
 
-            >>> distances[0].round(2) # Distances to k-neighbors
-            array([ 0.  ,  0.41,  0.58])
+            >>> distances.round(2)
+            array([[ 0.  ,  0.41,  0.58], ...])
 
         Notes:
             This method wraps the corresponding sklearn routine in the
@@ -408,9 +408,9 @@ class RadiusNeighborsMixin(NeighborsBase[Input, Target]):
 
             >>> distances, index = neigh.radius_neighbors(X)
             >>> index[0]
-            array([ 0,  1,  8, 18])
+            array([ 0,  1,  8, 18]...)
 
-            >>> distances[0].round(2) # Distances to neighbors
+            >>> distances[0].round(2)
             array([ 0.  ,  0.58,  0.41,  0.68])
 
 

--- a/skfda/_utils/_neighbors_base.py
+++ b/skfda/_utils/_neighbors_base.py
@@ -227,30 +227,29 @@ class KNeighborsMixin(NeighborsBase[Input, Target]):
                 Indices of the nearest points in the population matrix.
 
         Examples:
-            Firstly, we will create a toy dataset.
+            Firstly, we will create a toy dataset
 
-            >>> from skfda.datasets import make_sinusoidal_process
-            >>> fd1 = make_sinusoidal_process(phase_std=.25, random_state=0)
-            >>> fd2 = make_sinusoidal_process(phase_mean=1.8, error_std=0.,
-            ...                               phase_std=.25, random_state=0)
-            >>> fd = fd1.concatenate(fd2)
+            >>> from skfda.datasets import make_gaussian_process
+            >>> X = make_gaussian_process(
+            ...    n_samples=30,
+            ...    random_state=0,
+            ... )
 
             We will fit a Nearest Neighbors estimator
 
             >>> from skfda.ml.clustering import NearestNeighbors
-            >>> neigh = NearestNeighbors()
-            >>> neigh.fit(fd)
+            >>> neigh = NearestNeighbors(n_neighbors=3)
+            >>> neigh.fit(X)
             NearestNeighbors(...)
 
             Now we can query the k-nearest neighbors.
 
-            >>> distances, index = neigh.kneighbors(fd[:2])
-            >>> index # Index of k-neighbors of samples 0 and 1
-            array([[ 0,  7,  6, 11,  2],...)
+            >>> distances, index = neigh.kneighbors(X)
+            >>> index[0] # Index of k-neighbors of the first sample
+            array([0, 8, 1])
 
-            >>> distances.round(2) # Distances to k-neighbors
-            array([[ 0.  ,  0.28,  0.29,  0.29,  0.3 ],
-                   [ 0.  ,  0.27,  0.28,  0.29,  0.3 ]])
+            >>> distances[0].round(2) # Distances to k-neighbors
+            array([ 0.  ,  0.41,  0.58])
 
         Notes:
             This method wraps the corresponding sklearn routine in the
@@ -295,30 +294,28 @@ class KNeighborsMixin(NeighborsBase[Input, Target]):
             A[i, j] is assigned the weight of edge that connects i to j.
 
         Examples:
-            Firstly, we will create a toy dataset.
+            Firstly, we will create a toy dataset
 
-            >>> from skfda.datasets import make_sinusoidal_process
-            >>> fd1 = make_sinusoidal_process(phase_std=.25, random_state=0)
-            >>> fd2 = make_sinusoidal_process(phase_mean=1.8, error_std=0.,
-            ...                               phase_std=.25, random_state=0)
-            >>> fd = fd1.concatenate(fd2)
+            >>> from skfda.datasets import make_gaussian_process
+            >>> X = make_gaussian_process(
+            ...    n_samples=30,
+            ...    random_state=0,
+            ... )
 
             We will fit a Nearest Neighbors estimator.
 
             >>> from skfda.ml.clustering import NearestNeighbors
-            >>> neigh = NearestNeighbors()
-            >>> neigh.fit(fd)
+            >>> neigh = NearestNeighbors(n_neighbors=3)
+            >>> neigh.fit(X)
             NearestNeighbors(...)
 
             Now we can obtain the graph of k-neighbors of a sample.
 
-            >>> graph = neigh.kneighbors_graph(fd[0])
+            >>> graph = neigh.kneighbors_graph(X[0])
             >>> print(graph)
-              (0, 0)	1.0
-              (0, 7)	1.0
-              (0, 6)	1.0
-              (0, 11)	1.0
-              (0, 2)	1.0
+                (0, 0)    1.0
+                (0, 8)    1.0
+                (0, 1)    1.0
 
         Notes:
             This method wraps the corresponding sklearn routine in the
@@ -392,29 +389,29 @@ class RadiusNeighborsMixin(NeighborsBase[Input, Target]):
                 within a ball of size ``radius`` around the query points.
 
         Examples:
-            Firstly, we will create a toy dataset.
+            Firstly, we will create a toy dataset
 
-            >>> from skfda.datasets import make_sinusoidal_process
-            >>> fd1 = make_sinusoidal_process(phase_std=.25, random_state=0)
-            >>> fd2 = make_sinusoidal_process(phase_mean=1.8, error_std=0.,
-            ...                               phase_std=.25, random_state=0)
-            >>> fd = fd1.concatenate(fd2)
+            >>> from skfda.datasets import make_gaussian_process
+            >>> X = make_gaussian_process(
+            ...    n_samples=30,
+            ...    random_state=0,
+            ... )
 
             We will fit a Nearest Neighbors estimator.
 
             >>> from skfda.ml.clustering import NearestNeighbors
-            >>> neigh = NearestNeighbors(radius=.3)
-            >>> neigh.fit(fd)
-            NearestNeighbors(...radius=0.3...)
+            >>> neigh = NearestNeighbors(radius=0.7)
+            >>> neigh.fit(X)
+            NearestNeighbors(...)
 
-            Now we can query the neighbors in the radius.
+            Now we can query the neighbors in a given radius.
 
-            >>> distances, index = neigh.radius_neighbors(fd[:2])
-            >>> index[0] # Neighbors of sample 0
-            array([ 0,  2,  6,  7, 11]...)
+            >>> distances, index = neigh.radius_neighbors(X)
+            >>> index[0]
+            array([ 0,  1,  8, 18])
 
-            >>> distances[0].round(2) # Distances to neighbors of the sample 0
-            array([ 0.  ,  0.3 ,  0.29,  0.28,  0.29])
+            >>> distances[0].round(2) # Distances to neighbors
+            array([ 0.  ,  0.58,  0.41,  0.68])
 
 
         See also:

--- a/skfda/datasets/_real_datasets.py
+++ b/skfda/datasets/_real_datasets.py
@@ -5,24 +5,14 @@ from typing import Any, Mapping, Tuple, overload
 
 import numpy as np
 import pandas as pd
+import rdata
 from pandas import DataFrame, Series
+from skdatasets.repositories import cran, ucr
 from sklearn.utils import Bunch
 from typing_extensions import Literal
 
-import rdata
-
 from ..representation import FDataGrid
 from ..typing._numpy import NDArrayFloat, NDArrayInt
-
-
-def _get_skdatasets_repositories() -> Any:
-    import skdatasets
-
-    repositories = getattr(skdatasets, "repositories", None)
-    if repositories is None:
-        repositories = skdatasets
-
-    return repositories
 
 
 def fdata_constructor(
@@ -116,8 +106,6 @@ def fetch_cran(
         types.
 
     """
-    repositories = _get_skdatasets_repositories()
-
     if converter is None:
         converter = rdata.conversion.SimpleConverter({
             **rdata.conversion.DEFAULT_CLASS_MAP,
@@ -125,7 +113,7 @@ def fetch_cran(
             "functional": functional_constructor,
         })
 
-    return repositories.cran.fetch_dataset(
+    return cran.fetch_dataset(
         name,
         package_name,
         converter=converter,
@@ -198,9 +186,7 @@ def fetch_ucr(
         .. footbibliography::
 
     """
-    repositories = _get_skdatasets_repositories()
-
-    dataset = repositories.ucr.fetch(name, **kwargs)
+    dataset = ucr.fetch(name, **kwargs)
 
     dataset['data'] = _ucr_to_fdatagrid(
         name=dataset['name'],

--- a/skfda/datasets/_samples_generators.py
+++ b/skfda/datasets/_samples_generators.py
@@ -481,7 +481,7 @@ def make_random_warping(
     np.square(v, out=v)
 
     # Creation of FDataGrid in the corresponding domain
-    data_matrix = scipy.integrate.cumtrapz(
+    data_matrix = scipy.integrate.cumulative_trapezoid(
         v,
         dx=1 / n_features,
         initial=0,

--- a/skfda/exploratory/depth/_depth.py
+++ b/skfda/exploratory/depth/_depth.py
@@ -43,10 +43,10 @@ class IntegratedDepth(Depth[FDataGrid]):
         ...                [-1, -1, -0.5, 1, 1, 0.5],
         ...                [-0.5, -0.5, -0.5, -1, -1, -1]]
         >>> grid_points = [0, 2, 4, 6, 8, 10]
-        >>> fd = skfda.FDataGrid(data_matrix, grid_points)
+        >>> X = skfda.FDataGrid(data_matrix, grid_points)
         >>> depth = skfda.exploratory.depth.IntegratedDepth()
-        >>> depth(fd)
-        array([ 0.5  ,  0.75 ,  0.925,  0.875])
+        >>> depth(X).round(1)
+        array([ 0.5,  0.8,  0.9,  0.9])
 
     References:
         Fraiman, R., & Muniz, G. (2001). Trimmed means for functional
@@ -121,11 +121,11 @@ class ModifiedBandDepth(IntegratedDepth):
         ...                [-1, -1, -0.5, 1, 1, 0.5],
         ...                [-0.5, -0.5, -0.5, -1, -1, -1]]
         >>> grid_points = [0, 2, 4, 6, 8, 10]
-        >>> fd = skfda.FDataGrid(data_matrix, grid_points)
+        >>> X = skfda.FDataGrid(data_matrix, grid_points)
         >>> depth = skfda.exploratory.depth.ModifiedBandDepth()
-        >>> values = depth(fd)
-        >>> values.round(2)
-        array([ 0.5 ,  0.83,  0.73,  0.67])
+        >>> values = depth(X)
+        >>> values.round(1)
+        array([ 0.5,  0.8,  0.7,  0.7])
 
     References:
         López-Pintado, S., & Romo, J. (2009). On the Concept of
@@ -228,10 +228,10 @@ class DistanceBasedDepth(Depth[FDataGrid], BaseEstimator):
         ...                [-1, -1, -0.5, 1, 1, 0.5],
         ...                [-0.5, -0.5, -0.5, -1, -1, -1]]
         >>> grid_points = [0, 2, 4, 6, 8, 10]
-        >>> fd = skfda.FDataGrid(data_matrix, grid_points)
+        >>> X = skfda.FDataGrid(data_matrix, grid_points)
         >>> depth = DistanceBasedDepth(MahalanobisDistance(2))
-        >>> depth(fd)
-        array([ 0.41897777,  0.8058132 ,  0.31097392,  0.31723619])
+        >>> depth(X).round(1)
+        array([ 0.4,  0.8,  0.3,  0.3])
 
     References:
         .. footbibliography::

--- a/skfda/exploratory/outliers/_directional_outlyingness.py
+++ b/skfda/exploratory/outliers/_directional_outlyingness.py
@@ -107,50 +107,27 @@ def directional_outlyingness_stats(  # noqa: WPS218
 
     Example:
 
-        >>> data_matrix = [[1, 1, 2, 3, 2.5, 2],
-        ...                [0.5, 0.5, 1, 2, 1.5, 1],
-        ...                [-1, -1, -0.5, 1, 1, 0.5],
-        ...                [-0.5, -0.5, -0.5, -1, -1, -1]]
-        >>> grid_points = [0, 2, 4, 6, 8, 10]
-        >>> fd = FDataGrid(data_matrix, grid_points)
-        >>> stats = directional_outlyingness_stats(fd)
-        >>> stats.directional_outlyingness
-        array([[[ 1.33333333],
-                [ 1.33333333],
-                [ 2.33333333],
-                [ 1.5       ],
-                [ 1.66666667],
-                [ 1.66666667]],
-               [[ 0.        ],
-                [ 0.        ],
-                [ 0.        ],
-                [ 0.        ],
-                [ 0.        ],
-                [ 0.        ]],
-               [[-1.33333333],
-                [-1.33333333],
-                [-1.        ],
-                [-0.5       ],
-                [-0.33333333],
-                [-0.33333333]],
-               [[-0.66666667],
-                [-0.66666667],
-                [-1.        ],
-                [-2.5       ],
-                [-3.        ],
-                [-2.33333333]]])
+        >>> import skfda
+        >>> X = skfda.datasets.make_gaussian_process(
+        ...     n_samples=4,
+        ...     n_features=1000,
+        ...     random_state=1,
+        ... )
+        >>> stats = directional_outlyingness_stats(X)
+        >>> stats.directional_outlyingness.shape
+        (4, 1000, 1)
 
-    >>> stats.functional_directional_outlyingness
-    array([ 6.58864198,  6.4608642 ,  6.63753086,  7.40481481])
+    >>> stats.functional_directional_outlyingness.round()
+    array([ 11.,   8.,   6.,   9.])
 
-    >>> stats.mean_directional_outlyingness
-    array([[ 1.66666667],
-           [ 0.        ],
-           [-0.8       ],
-           [-1.74444444]])
+    >>> stats.mean_directional_outlyingness.round(1)
+    array([[-2. ],
+           [ 1.4],
+           [-0.1],
+           [ 0.1]])
 
-    >>> stats.variation_directional_outlyingness
-    array([ 0.12777778,  0.        ,  0.17666667,  0.94395062])
+    >>> stats.variation_directional_outlyingness.round()
+    array([ 5.,  2.,  0.,  3.])
 
     References:
         Dai, Wenlin, and Genton, Marc G. "Directional outlyingness for

--- a/skfda/exploratory/stats/_fisher_rao.py
+++ b/skfda/exploratory/stats/_fisher_rao.py
@@ -155,7 +155,7 @@ def _fisher_rao_warping_mean(
         mu = a * mu + b * vmean
 
     # Recover mean in original gamma space
-    warping_mean_ret = scipy.integrate.cumtrapz(
+    warping_mean_ret = scipy.integrate.cumulative_trapezoid(
         np.square(mu, out=mu)[0],
         x=eval_points,
         initial=0,
@@ -268,7 +268,7 @@ def fisher_rao_karcher_mean(
 
     distances = scipy.integrate.simpson(
         np.square(centered, out=centered),
-        eval_points_normalized,
+        x=eval_points_normalized,
         axis=1,
     )
 
@@ -306,14 +306,14 @@ def fisher_rao_karcher_mean(
         mu_norm = np.sqrt(
             scipy.integrate.simpson(
                 np.square(mu, out=mu_aux),
-                eval_points_normalized,
+                x=eval_points_normalized,
             ),
         )
 
         mu_diff = np.sqrt(
             scipy.integrate.simpson(
                 np.square(mu - mu_1, out=mu_aux),
-                eval_points_normalized,
+                x=eval_points_normalized,
             ),
         )
 

--- a/skfda/exploratory/visualization/_magnitude_shape_plot.py
+++ b/skfda/exploratory/visualization/_magnitude_shape_plot.py
@@ -98,10 +98,10 @@ class MagnitudeShapePlot(BasePlot):
         from skfda.misc.covariances import Exponential
         from skfda.exploratory.visualization import MagnitudeShapePlot
 
-        fd = make_gaussian_process(
+        X = make_gaussian_process(
                 n_samples=20, cov=Exponential(), random_state=1)
 
-        MagnitudeShapePlot(fd)
+        MagnitudeShapePlot(X)
 
     Example:
         >>> import skfda
@@ -110,51 +110,9 @@ class MagnitudeShapePlot(BasePlot):
         ...                [-1, -1, -0.5, 1, 1, 0.5],
         ...                [-0.5, -0.5, -0.5, -1, -1, -1]]
         >>> grid_points = [ 0., 2., 4., 6., 8., 10.]
-        >>> fd = skfda.FDataGrid(data_matrix, grid_points)
-        >>> MagnitudeShapePlot(fd)
-        MagnitudeShapePlot(
-            fdata=FDataGrid(
-                array([[[ 1. ],
-                        [ 1. ],
-                        [ 2. ],
-                        [ 3. ],
-                        [ 2.5],
-                        [ 2. ]],
-                       [[ 0.5],
-                        [ 0.5],
-                        [ 1. ],
-                        [ 2. ],
-                        [ 1.5],
-                        [ 1. ]],
-                       [[-1. ],
-                        [-1. ],
-                        [-0.5],
-                        [ 1. ],
-                        [ 1. ],
-                        [ 0.5]],
-                       [[-0.5],
-                        [-0.5],
-                        [-0.5],
-                        [-1. ],
-                        [-1. ],
-                        [-1. ]]]),
-                grid_points=(array([  0.,   2.,   4.,   6.,   8.,  10.]),),
-                domain_range=((0.0, 10.0),),
-                ...),
-            multivariate_depth=None,
-            pointwise_weights=None,
-            cutoff_factor=1,
-            points=array([[ 1.66666667,  0.12777778],
-                          [ 0.        ,  0.        ],
-                          [-0.8       ,  0.17666667],
-                          [-1.74444444,  0.94395062]]),
-            outliers=array([False, False, False, False]),
-            colormap=seismic,
-            color=0.2,
-            outliercol=0.8,
-            xlabel='MO',
-            ylabel='VO',
-            title='')
+        >>> X = skfda.FDataGrid(data_matrix, grid_points)
+        >>> MagnitudeShapePlot(X)
+        MagnitudeShapePlot(...)
 
     References:
         .. footbibliography::

--- a/skfda/inference/anova/_anova_oneway.py
+++ b/skfda/inference/anova/_anova_oneway.py
@@ -69,7 +69,7 @@ def v_sample_stat(fd: FData, weights: ArrayLike, p: int = 2) -> float:
         Finally the value of the statistic is calculated:
 
         >>> v_sample_stat(fd, weights)
-        0.01649...
+        0.0164...
 
     References:
         .. footbibliography::
@@ -176,7 +176,7 @@ def v_asymptotic_stat(
         Finally the value of the statistic is calculated:
 
         >>> v_asymptotic_stat(fd, weights=weights)
-        0.0018159320335885969
+        0.00181...
 
     References:
         .. footbibliography::
@@ -343,21 +343,24 @@ def oneway_anova(
         `return_dist` is `True`).
 
     Examples:
+        >>> import skfda
         >>> from skfda.inference.anova import oneway_anova
-        >>> from skfda.datasets import fetch_gait
-        >>> from numpy.random import RandomState
-        >>> from numpy import printoptions
 
-        >>> fd = fetch_gait()["data"].coordinates[1]
-        >>> fd1, fd2, fd3 = fd[:13], fd[13:26], fd[26:]
-        >>> oneway_anova(fd1, fd2, fd3, random_state=RandomState(42))
-        (179.52499999999998, 0.56)
-        >>> _, _, dist = oneway_anova(fd1, fd2, fd3, n_reps=3,
-        ...     random_state=RandomState(42),
+        >>> X = skfda.datasets.make_gaussian_process(
+        ...     n_samples=100,
+        ...     random_state=0,
+        ... )
+        >>> X1, X2, X3 = X[:33], X[33:66], X[66:]
+        >>> statistic, pvalue = oneway_anova(X1, X2, X3, random_state=1)
+        >>> round(statistic, 2)
+        6.26
+        >>> pvalue
+        0.121
+        >>> _, _, dist = oneway_anova(X1, X2, X3, n_reps=3,
+        ...     random_state=1,
         ...     return_dist=True)
-        >>> with printoptions(precision=4):
-        ...     print(dist)
-        [ 174.8663  202.1025  185.598 ]
+        >>> dist.round(1)
+        array([ 7.9,  0.7,  4.4])
 
     References:
         .. footbibliography::

--- a/skfda/misc/operators/_linear_differential_operator.py
+++ b/skfda/misc/operators/_linear_differential_operator.py
@@ -736,7 +736,7 @@ def gridbasis_penalty_matrix_optimized(
     # This is done to avoid computing it for each subinterval of integration.
     quadrature = scipy.integrate.simpson(
         np.identity(n_points),
-        basis.grid_points[0],
+        x=basis.grid_points[0],
     )
 
     product_matrix = np.zeros((basis.n_basis, basis.n_basis))

--- a/skfda/misc/operators/_srvf.py
+++ b/skfda/misc/operators/_srvf.py
@@ -232,7 +232,7 @@ class SRSF(
 
         data_matrix *= np.abs(data_matrix)
 
-        f_data_matrix = scipy.integrate.cumtrapz(
+        f_data_matrix = scipy.integrate.cumulative_trapezoid(
             data_matrix,
             x=output_points,
             axis=1,

--- a/skfda/ml/clustering/_neighbors_clustering.py
+++ b/skfda/ml/clustering/_neighbors_clustering.py
@@ -53,39 +53,38 @@ class NearestNeighbors(
             Doesn't affect :meth:`fit` method.
 
     Examples:
-        Firstly, we will create a toy dataset with 2 classes
+        Firstly, we will create a toy dataset
 
-        >>> from skfda.datasets import make_sinusoidal_process
-        >>> fd1 = make_sinusoidal_process(phase_std=.25, random_state=0)
-        >>> fd2 = make_sinusoidal_process(phase_mean=1.8, error_std=0.,
-        ...                               phase_std=.25, random_state=0)
-        >>> fd = fd1.concatenate(fd2)
+        >>> from skfda.datasets import make_gaussian_process
+        >>> X = make_gaussian_process(
+        ...    n_samples=30,
+        ...    random_state=0,
+        ... )
 
         We will fit a Nearest Neighbors estimator
 
         >>> from skfda.ml.clustering import NearestNeighbors
-        >>> neigh = NearestNeighbors(radius=.3)
-        >>> neigh.fit(fd)
-        NearestNeighbors(...radius=0.3...)
+        >>> neigh = NearestNeighbors(n_neighbors=3, radius=0.7)
+        >>> neigh.fit(X)
+        NearestNeighbors(...)
 
         Now we can query the k-nearest neighbors.
 
-        >>> distances, index = neigh.kneighbors(fd[:2])
-        >>> index # Index of k-neighbors of samples 0 and 1
-        array([[ 0,  7,  6, 11,  2],...)
+        >>> distances, index = neigh.kneighbors(X)
+        >>> index[0] # Index of k-neighbors of the first sample
+        array([0, 8, 1])
 
-        >>> distances.round(2) # Distances to k-neighbors
-        array([[ 0.  ,  0.28,  0.29,  0.29,  0.3 ],
-               [ 0.  ,  0.27,  0.28,  0.29,  0.3 ]])
+        >>> distances[0].round(2) # Distances to k-neighbors
+        array([ 0.  ,  0.41,  0.58])
 
         We can query the neighbors in a given radius too.
 
-        >>> distances, index = neigh.radius_neighbors(fd[:2])
+        >>> distances, index = neigh.radius_neighbors(X)
         >>> index[0]
-        array([ 0,  2,  6,  7, 11]...)
+        array([ 0,  1,  8, 18])
 
-        >>> distances[0].round(2) # Distances to neighbors of the sample 0
-        array([ 0.  ,  0.3 ,  0.29,  0.28,  0.29])
+        >>> distances[0].round(2) # Distances to neighbors
+        array([ 0.  ,  0.58,  0.41,  0.68])
 
     See also:
         :class:`~skfda.ml.classification.KNeighborsClassifier`

--- a/skfda/ml/clustering/_neighbors_clustering.py
+++ b/skfda/ml/clustering/_neighbors_clustering.py
@@ -71,19 +71,19 @@ class NearestNeighbors(
         Now we can query the k-nearest neighbors.
 
         >>> distances, index = neigh.kneighbors(X)
-        >>> index[0] # Index of k-neighbors of the first sample
-        array([0, 8, 1])
+        >>> index
+        array([[ 0, 8, 1], ...)
 
-        >>> distances[0].round(2) # Distances to k-neighbors
-        array([ 0.  ,  0.41,  0.58])
+        >>> distances.round(2)
+        array([[ 0.  ,  0.41,  0.58], ...])
 
         We can query the neighbors in a given radius too.
 
         >>> distances, index = neigh.radius_neighbors(X)
         >>> index[0]
-        array([ 0,  1,  8, 18])
+        array([ 0,  1,  8, 18]...)
 
-        >>> distances[0].round(2) # Distances to neighbors
+        >>> distances[0].round(2)
         array([ 0.  ,  0.58,  0.41,  0.68])
 
     See also:

--- a/skfda/ml/regression/_historical_linear_model.py
+++ b/skfda/ml/regression/_historical_linear_model.py
@@ -42,7 +42,7 @@ def _pairwise_fem_inner_product(
     eval_fd = fd(grid)
 
     prod = eval_fem * eval_fd
-    integral = scipy.integrate.simpson(prod, grid, axis=1)
+    integral = scipy.integrate.simpson(prod, x=grid, axis=1)
     return np.sum(integral, axis=-1)  # type: ignore[no-any-return]
 
 
@@ -277,7 +277,7 @@ class HistoricalLinearRegression(
         >>> intercept = random_state.choice(10, size=(1, 6))
         >>> intercept
         array([[2, 0, 0, 4, 5, 5]])
-        >>> y_data = scipy.integrate.cumtrapz(
+        >>> y_data = scipy.integrate.cumulative_trapezoid(
         ...              data_matrix,
         ...              initial=0,
         ...              axis=1,

--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -348,7 +348,10 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
         if self._weights is None:
             # grid_points is a list with one array in the 1D case
             identity = np.eye(len(X.grid_points[0]))
-            self._weights = scipy.integrate.simpson(identity, X.grid_points[0])
+            self._weights = scipy.integrate.simpson(
+                identity,
+                x=X.grid_points[0],
+            )
         elif callable(self._weights):
             self._weights = self._weights(X.grid_points[0])
             # if its a FDataGrid then we need to reduce the dimension to 1-D

--- a/skfda/preprocessing/dim_reduction/_fpls.py
+++ b/skfda/preprocessing/dim_reduction/_fpls.py
@@ -380,9 +380,9 @@ class _FPLSBlockGrid(_FPLSBlock[FDataGrid]):
         # By default, use Simpson's rule
         if integration_weights is None:
             identity = np.identity(self.data_matrix.shape[1])
-            integration_weights = scipy.integrate.simps(
+            integration_weights = scipy.integrate.simpson(
                 identity,
-                self.data.grid_points[0],
+                x=self.data.grid_points[0],
             )
         self.integration_weights = np.diag(integration_weights)
 

--- a/skfda/preprocessing/feature_construction/_function_transformers.py
+++ b/skfda/preprocessing/feature_construction/_function_transformers.py
@@ -59,20 +59,20 @@ class LocalAveragesTransformer(
         >>> local_averages = LocalAveragesTransformer(
         ...     domains=[(1, 3), (3, 10), (10, 18)],
         ... )
-        >>> np.round(local_averages.fit_transform(X), decimals=2)
-        array([[  91.37,  126.52,  179.02],
-               [  87.51,  120.71,  158.81],
-               [  86.36,  115.04,  156.37]])
+        >>> np.round(local_averages.fit_transform(X))
+        array([[  91.,  127.,  179.],
+               [  88.,  121.,  159.],
+               [  86.,  115.,  156.]])
 
         A different possibility is to decide how many intervals we want to
         consider.  For example, we could want to split the domain in 2
         intervals of the same length.
 
         >>> local_averages = LocalAveragesTransformer(domains=2)
-        >>> np.around(local_averages.fit_transform(X), decimals=2)
-        array([[ 116.94,  177.26],
-               [ 111.86,  157.62],
-               [ 107.29,  154.97]])
+        >>> np.round(local_averages.fit_transform(X))
+        array([[ 117.,  177.],
+               [ 112.,  158.],
+               [ 107.,  155.]])
     """
 
     def __init__(

--- a/skfda/preprocessing/feature_construction/_functions.py
+++ b/skfda/preprocessing/feature_construction/_functions.py
@@ -77,28 +77,28 @@ def local_averages(
         ...     X,
         ...     domains=[(1, 3), (3, 10), (10, 18)],
         ... )
-        >>> np.around(averages, decimals=2)
-        array([[[  91.37],
-                [ 126.52],
-                [ 179.02]],
-               [[  87.51],
-                [ 120.71],
-                [ 158.81]],
-               [[  86.36],
-                [ 115.04],
-                [ 156.37]]])
+        >>> np.round(averages)
+        array([[[  91.],
+                [ 127.],
+                [ 179.]],
+               [[  88.],
+                [ 121.],
+                [ 159.]],
+               [[  86.],
+                [ 115.],
+                [ 156.]]])
 
         A different possibility is to decide how many intervals we want to
         consider.  For example, we could want to split the domain in 2
         intervals of the same length.
 
-        >>> np.around(local_averages(X, domains=2), decimals=2)
-        array([[[ 116.94],
-                [ 177.26]],
-               [[ 111.86],
-                [ 157.62]],
-               [[ 107.29],
-                [ 154.97]]])
+        >>> np.round(local_averages(X, domains=2))
+        array([[[ 117.],
+                [ 177.]],
+               [[ 112.],
+                [ 158.]],
+               [[ 107.],
+                [ 155.]]])
     """
     if isinstance(domains, int):
         domains = [domains] * data.dim_domain

--- a/skfda/tests/test_clustering.py
+++ b/skfda/tests/test_clustering.py
@@ -3,6 +3,9 @@ import unittest
 
 import numpy as np
 
+import skfda
+from skfda.datasets import make_gaussian_process
+from skfda.misc.covariances import Brownian
 from skfda.ml.clustering import FuzzyCMeans, KMeans
 from skfda.representation.grid import FDataGrid
 
@@ -10,107 +13,111 @@ from skfda.representation.grid import FDataGrid
 class TestKMeans(unittest.TestCase):
     """Test the KMeans clustering method."""
 
-    def test_univariate(self) -> None:
-        """Test with univariate functional data."""
-        data_matrix = [
-            [1, 1, 2, 3, 2.5, 2],
-            [0.5, 0.5, 1, 2, 1.5, 1],
-            [-1, -1, -0.5, 1, 1, 0.5],  # noqa: WPS204
-            [-0.5, -0.5, -0.5, -1, -1, -1],
-        ]
-        grid_points = [0, 2, 4, 6, 8, 10]
-        fd = FDataGrid(data_matrix, grid_points)
-        init = np.array([[0, 0, 0, 0, 0, 0], [2, 1, -1, 0.5, 0, -0.5]])
-        init_fd = FDataGrid(init, grid_points)
-        kmeans = KMeans(init=init_fd)
-        distances_to_centers = kmeans.fit_transform(fd)
+    def test_distinct_clusters(self) -> None:
+        """
+        Test with two clearly distinct clusters.
+
+        We use two Brownian processes with different means (-1 and 1), so
+        clustering should be perfect.
+        """
+        n_features = 100
+        n_samples = 1000
+
+        cluster_0 = make_gaussian_process(
+            n_samples=n_samples,
+            n_features=n_features,
+            mean=-1,
+            cov=Brownian(variance=0.01),
+        )
+        cluster_1 = make_gaussian_process(
+            n_samples=n_samples,
+            n_features=n_features,
+            mean=1,
+            cov=Brownian(variance=0.01),
+        )
+
+        X = skfda.concatenate((cluster_0, cluster_1))
+
+        kmeans = KMeans[FDataGrid](random_state=0)
+        prediction = kmeans.fit_predict(X)
+
         np.testing.assert_allclose(
-            distances_to_centers,
-            np.array([
-                [2.98142397, 9.23534876],
-                [0.68718427, 6.50960828],
-                [3.31243449, 4.39222798],
-                [6.49679408, 0],
+            kmeans.cluster_centers_.data_matrix[..., 0],
+            [
+                -np.ones(n_features),
+                np.ones(n_features),
+            ],
+            rtol=1e-2,
+        )
+
+        np.testing.assert_equal(
+            prediction,
+            np.concatenate([
+                np.zeros(n_samples),
+                np.ones(n_samples),
             ]),
         )
-        np.testing.assert_array_equal(
-            kmeans.predict(fd),
-            np.array([0, 0, 0, 1]),
-        )
-        np.testing.assert_allclose(
-            kmeans.transform(fd),
-            np.array([
-                [2.98142397, 9.23534876],
-                [0.68718427, 6.50960828],
-                [3.31243449, 4.39222798],
-                [6.49679408, 0],
-            ]),
-        )
-        centers = FDataGrid(
-            data_matrix=np.array([
-                [  # noqa: WPS317
-                    0.16666667, 0.16666667, 0.83333333,
-                    2.0, 1.66666667, 1.16666667,
-                ],
-                [-0.5, -0.5, -0.5, -1.0, -1.0, -1.0],
-            ]),
-            grid_points=grid_points,
-        )
-        np.testing.assert_array_almost_equal(
-            kmeans.cluster_centers_.data_matrix,
-            centers.data_matrix,
-        )
-        np.testing.assert_allclose(kmeans.score(fd), np.array([-20.33333333]))
-        np.testing.assert_array_equal(kmeans.n_iter_, np.array([3.0]))
 
 
 class TestFuzzyCMeans(unittest.TestCase):
     """Test the FuzzyCMeans clustering method."""
 
-    def test_univariate(self) -> None:
-        """Test with univariate functional data."""
-        data_matrix = [
-            [1, 1, 2, 3, 2.5, 2],
-            [0.5, 0.5, 1, 2, 1.5, 1],
-            [-1, -1, -0.5, 1, 1, 0.5],  # noqa: WPS204
-            [-0.5, -0.5, -0.5, -1, -1, -1],
-        ]
-        grid_points = [0, 2, 4, 6, 8, 10]
-        fd = FDataGrid(data_matrix, grid_points)
-        fuzzy_kmeans = FuzzyCMeans[FDataGrid]()
-        fuzzy_kmeans.fit(fd)
-        np.testing.assert_array_equal(
-            fuzzy_kmeans.predict_proba(fd).round(3),
-            np.array([
-                [0.965, 0.035],
-                [0.94, 0.06],
-                [0.227, 0.773],
-                [0.049, 0.951],
+    def test_distinct_clusters(self) -> None:
+        """
+        Test with two clearly distinct clusters.
+
+        We use two Brownian processes with different means (-1 and 1), so
+        clustering should be perfect.
+        """
+        n_features = 100
+        n_samples = 1000
+
+        cluster_0 = make_gaussian_process(
+            n_samples=n_samples,
+            n_features=n_features,
+            mean=-1,
+            cov=Brownian(variance=0.01),
+        )
+        cluster_1 = make_gaussian_process(
+            n_samples=n_samples,
+            n_features=n_features,
+            mean=1,
+            cov=Brownian(variance=0.01),
+        )
+
+        X = skfda.concatenate((cluster_0, cluster_1))
+
+        fcmeans = FuzzyCMeans[FDataGrid](random_state=0)
+        prediction = fcmeans.fit_predict(X)
+
+        np.testing.assert_allclose(
+            fcmeans.cluster_centers_.data_matrix[..., 0],
+            [
+                -np.ones(n_features),
+                np.ones(n_features),
+            ],
+            rtol=1e-2,
+        )
+
+        np.testing.assert_equal(
+            prediction,
+            np.concatenate([
+                np.zeros(n_samples),
+                np.ones(n_samples),
             ]),
         )
+
+        predict_proba = fcmeans.predict_proba(X)
+        true_proba = np.zeros((n_samples * 2, 2))
+        true_proba[:n_samples, 0] = 1
+        true_proba[n_samples:, 1] = 1
+
+        # We need to use atol because we compare against 0.
         np.testing.assert_allclose(
-            fuzzy_kmeans.transform(fd).round(3),
-            np.array([
-                [1.492, 7.879],
-                [1.294, 5.127],
-                [4.856, 2.633],
-                [7.775, 1.759],
-            ]),
+            predict_proba,
+            true_proba,
+            atol=1e-1,
         )
-        centers = np.array([
-            [0.707, 0.707, 1.455, 2.467, 1.981, 1.482],
-            [-0.695, -0.695, -0.494, -0.197, -0.199, -0.398],
-        ])
-        np.testing.assert_allclose(
-            fuzzy_kmeans.cluster_centers_.data_matrix[..., 0],
-            centers,
-            atol=1e-3,
-        )
-        np.testing.assert_allclose(
-            fuzzy_kmeans.score(fd),
-            np.array([-12.025179]),
-        )
-        self.assertEqual(fuzzy_kmeans.n_iter_, 19)
 
 
 if __name__ == '__main__':

--- a/skfda/tests/test_elastic.py
+++ b/skfda/tests/test_elastic.py
@@ -84,7 +84,7 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
             ],
         ]
 
-        np.testing.assert_almost_equal(data_matrix, srsf.data_matrix)
+        np.testing.assert_allclose(data_matrix, srsf.data_matrix)
 
     def test_from_srsf(self) -> None:
         """Test from srsf."""
@@ -93,13 +93,17 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
 
         data_matrix = [
             [  # noqa: WPS317
-                [0.0], [-0.23449228], [-0.83464009],
-                [-1.38200046], [-1.55623723], [-1.38200046],
-                [-0.83464009], [-0.23449228], [0.0],
+                [0.0], [-0.234492], [-0.834640],
+                [-1.382000], [-1.556237], [-1.382000],
+                [-0.834640], [-0.234492], [0.0],
             ],
         ]
 
-        np.testing.assert_almost_equal(data_matrix, srsf.data_matrix)
+        np.testing.assert_allclose(
+            data_matrix,
+            srsf.data_matrix,
+            atol=1e-6,
+        )
 
     def test_from_srsf_with_output_points(self) -> None:
         """Test from srsf and explicit output points."""
@@ -112,13 +116,17 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
 
         data_matrix = [
             [  # noqa: WPS317
-                [0.0], [-0.23449228], [-0.83464009],
-                [-1.38200046], [-1.55623723], [-1.38200046],
-                [-0.83464009], [-0.23449228], [0.0],
+                [0.0], [-0.234492], [-0.834640],
+                [-1.382000], [-1.556237], [-1.382000],
+                [-0.834640], [-0.234492], [0.0],
             ],
         ]
 
-        np.testing.assert_almost_equal(data_matrix, srsf.data_matrix)
+        np.testing.assert_allclose(
+            data_matrix,
+            srsf.data_matrix,
+            atol=1e-6,
+        )
 
     def test_srsf_conversion(self) -> None:
         """Convert to srsf and pull back."""
@@ -236,7 +244,7 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
         reg = FisherRaoElasticRegistration()
         reg.fit(self.unimodal_samples)
         score = reg.score(self.unimodal_samples)
-        np.testing.assert_almost_equal(score, 0.999389)
+        np.testing.assert_allclose(score, 0.99938, rtol=1e-5)
 
     def test_warping_mean(self) -> None:
         """Test the warping_mean function."""
@@ -277,10 +285,10 @@ class TestElasticDistances(unittest.TestCase):
         f = np.square(sample)
         g = np.power(sample, 0.5)
 
-        distance = [[0.64, 1.984], [1.984, 0.64]]
+        distance = [[0.639, 1.984], [1.985, 0.638]]
         res = pairwise_fisher_rao(f, g)
 
-        np.testing.assert_almost_equal(res, distance, decimal=3)
+        np.testing.assert_allclose(res, distance, rtol=1e-2)
 
     def test_fisher_rao_invariance(self) -> None:
         """Test invariance of fisher rao metric: d(f,g)= d(foh, goh)."""
@@ -324,7 +332,7 @@ class TestElasticDistances(unittest.TestCase):
         amplitude_limit = fisher_rao_amplitude_distance(f, g, lam=1000)
         fr_distance = fisher_rao_distance(f, g)
 
-        np.testing.assert_almost_equal(amplitude_limit, fr_distance)
+        np.testing.assert_allclose(amplitude_limit, fr_distance)
 
     def test_fisher_rao_phase_distance_id(self) -> None:
         """Test of phase distance invariance."""

--- a/skfda/tests/test_fpls_regression.py
+++ b/skfda/tests/test_fpls_regression.py
@@ -167,7 +167,10 @@ class TestFPLSRegression(LatentVariablesModel):
         signs = np.array([1, -1, 1, -1, 1])
 
         w_mat = fplsr.fpls_.x_weights_ @ np.diag(signs)
-        np.testing.assert_allclose(w_mat, r_results, atol=6e-6, rtol=6e-4)
+
+        # We use a different quadrature, so the results cannot
+        # be the same
+        np.testing.assert_allclose(w_mat, r_results, atol=1e-2)
 
     def test_basis_vs_grid(self) -> None:
         """Test that the results are the same in basis and grid."""
@@ -194,7 +197,7 @@ class TestFPLSRegression(LatentVariablesModel):
 
         # Get the weights for the Simpson's rule
         identity = np.eye(len(X.grid_points[0]))
-        ss_weights = scipy.integrate.simps(identity, X.grid_points[0])
+        ss_weights = scipy.integrate.simpson(identity, x=X.grid_points[0])
 
         # Fit the model with weights
         fplsr = FPLSRegression(

--- a/skfda/tests/test_metrics.py
+++ b/skfda/tests/test_metrics.py
@@ -92,7 +92,8 @@ class TestLp(unittest.TestCase):
         """Test the integration of surfaces."""
         np.testing.assert_allclose(
             lp_norm(self.fd_surface, p=1),
-            [0.12566256, 0.12563755, 0.12566133],
+            [0.125663, 0.125637, 0.125661],
+            rtol=1e-5,
         )
 
     def test_lp_error_dimensions(self) -> None:

--- a/skfda/tests/test_neighbors.py
+++ b/skfda/tests/test_neighbors.py
@@ -128,7 +128,7 @@ class TestNeighbors(unittest.TestCase):
         neigh.fit(self.X, self.y)
         probs = neigh.predict_proba(self.X)
 
-        np.testing.assert_array_almost_equal(probs, self.probs)
+        np.testing.assert_allclose(probs, self.probs)
 
     def test_predict_regressor(self) -> None:
         """Test scalar regression, predicts mode location."""
@@ -148,11 +148,11 @@ class TestNeighbors(unittest.TestCase):
         knnr.fit(self.X, self.modes_location)
         rnnr.fit(self.X, self.modes_location)
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             knnr.predict(self.X),
             self.modes_location,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             rnnr.predict(self.X),
             self.modes_location,
         )
@@ -177,19 +177,15 @@ class TestNeighbors(unittest.TestCase):
             dist, links = neigh.kneighbors(self.X[:4])
 
             np.testing.assert_array_equal(
-                links,
-                [[0, 7, 21, 23, 15],
-                 [1, 12, 19, 18, 17],
-                 [2, 17, 22, 27, 26],
-                 [3, 4, 9, 5, 25],
-                 ],
+                links[0],
+                [0, 7, 21, 23, 15],
             )
 
             graph = neigh.kneighbors_graph(self.X[:4])
 
             dist_kneigh = l2_distance(self.X[0], self.X[7])
 
-            np.testing.assert_array_almost_equal(dist[0, 1], dist_kneigh)
+            np.testing.assert_allclose(dist[0, 1], dist_kneigh)
 
             for i in range(30):
                 self.assertEqual(graph[0, i] == 1, i in links[0])
@@ -221,7 +217,7 @@ class TestNeighbors(unittest.TestCase):
 
             dist_kneigh = l2_distance(self.X[0], self.X[7])
 
-            np.testing.assert_array_almost_equal(dist[0][1], dist_kneigh)
+            np.testing.assert_allclose(dist[0][1], dist_kneigh)
 
             graph = neigh.radius_neighbors_graph(self.X[:4])
 
@@ -236,46 +232,64 @@ class TestNeighbors(unittest.TestCase):
         knnr.fit(self.X, self.X)
 
         res = knnr.predict(self.X)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             res.data_matrix,
             self.X.data_matrix,
         )
 
     def test_knn_functional_response_precomputed(self) -> None:
         """Test that precomputed distances work for functional response."""
+        # Non-precomputed
         knnr = KNeighborsRegressor[
             np.typing.NDArray[np.float_],
             FDataGrid,
         ](
-            n_neighbors=4,
+            weights='distance',
+        )
+
+        knnr.fit(self.X, self.X)
+        res = knnr.predict(self.X)
+
+        # Precomputed
+        knnr_pre = KNeighborsRegressor[
+            np.typing.NDArray[np.float_],
+            FDataGrid,
+        ](
             weights='distance',
             metric='precomputed',
         )
         d = PairwiseMetric(l2_distance)
-        distances = d(self.X[:4], self.X[:4])
+        distances = d(self.X, self.X)
 
-        knnr.fit(distances, self.X[:4])
+        knnr_pre.fit(distances, self.X)
 
-        res = knnr.predict(distances)
-        np.testing.assert_array_almost_equal(
-            res.data_matrix, self.X[:4].data_matrix,
+        res_pre = knnr_pre.predict(distances)
+
+        # Results should be EXACTLY the same
+        np.testing.assert_equal(
+            res_pre.data_matrix,
+            res.data_matrix,
         )
 
-    def test_radius_functional_response(self) -> None:
-        """Test that radius regression work with functional response."""
-        knnr = RadiusNeighborsRegressor[
-            FDataGrid,
-            FDataGrid,
-        ](
+    def test_small_radius_functional_response(self) -> None:
+        """
+        Test functional response with a small radius.
+
+        In this case, only one function should be selected
+        and the response should be exact.
+        """
+        knnr = RadiusNeighborsRegressor[FDataGrid, FDataGrid](
             metric=l2_distance,
             weights='distance',
+            radius=1e-6,
         )
 
         knnr.fit(self.X, self.X)
 
         res = knnr.predict(self.X)
-        np.testing.assert_array_almost_equal(
-            res.data_matrix, self.X.data_matrix,
+        np.testing.assert_equal(
+            res.data_matrix,
+            self.X.data_matrix,
         )
 
     def test_functional_response_custom_weights(self) -> None:
@@ -313,24 +327,27 @@ class TestNeighbors(unittest.TestCase):
         weights /= weights.sum()
 
         response = (self.X[:10] * weights).sum()
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             res.data_matrix, response.data_matrix,
         )
 
-    def test_functional_response_basis(self) -> None:
-        """Test FDataBasis response."""
+    def test_knn_functional_response_basis(self) -> None:
+        """Test FDataBasis response with just one neighbor."""
         knnr = KNeighborsRegressor[
             FDataGrid,
             FDataBasis,
-        ](weights='distance', n_neighbors=5)
+        ](weights='distance', n_neighbors=1)
+
         response = self.X.to_basis(
             FourierBasis(domain_range=(-1, 1), n_basis=10),
         )
         knnr.fit(self.X, response)
 
         res = knnr.predict(self.X)
-        np.testing.assert_array_almost_equal(
-            res.coefficients, response.coefficients,
+
+        np.testing.assert_equal(
+            res.coefficients,
+            response.coefficients,
         )
 
     def test_radius_outlier_functional_response(self) -> None:
@@ -345,7 +362,7 @@ class TestNeighbors(unittest.TestCase):
         knnr.fit(self.X[:6], self.X[:6])
 
         res = knnr.predict(self.X[:7])
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             res[6].data_matrix, np.nan,
         )
 
@@ -369,7 +386,7 @@ class TestNeighbors(unittest.TestCase):
 
         _, neighbors = nn.kneighbors(distances)
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             neighbors,
             np.array([[0, 3], [1, 2], [2, 1], [3, 0]]),
         )
@@ -383,7 +400,7 @@ class TestNeighbors(unittest.TestCase):
 
         neigh.fit(self.X, self.modes_location)
         r = neigh.score(self.X, self.modes_location)
-        np.testing.assert_almost_equal(r, 0.9975889963743335)
+        np.testing.assert_allclose(r, 0.9975, rtol=1e-3)
 
     def test_score_functional_response(self) -> None:
         """Test functional score."""
@@ -395,7 +412,7 @@ class TestNeighbors(unittest.TestCase):
         y = 5 * self.X + 1
         neigh.fit(self.X, y)
         r = neigh.score(self.X, y)
-        np.testing.assert_almost_equal(r, 0.65599399478951)
+        np.testing.assert_allclose(r, 0.655, rtol=1e-2)
 
         # Weighted case and basis form
         y = y.to_basis(FourierBasis(domain_range=y.domain_range[0], n_basis=5))
@@ -406,7 +423,7 @@ class TestNeighbors(unittest.TestCase):
             y[:7],
             sample_weight=np.array(4 * [1.0 / 5] + 3 * [1.0 / 15]),
         )
-        np.testing.assert_almost_equal(r, 0.9802105817331564)
+        np.testing.assert_allclose(r, 0.98, rtol=1e-2)
 
     def test_score_functional_response_exceptions(self) -> None:
         """Test weights with invalid length."""
@@ -445,28 +462,25 @@ class TestNeighbors(unittest.TestCase):
 
         # Check values of negative outlier factor
         negative_lof = [  # noqa: WPS317
-            -7.1068, -1.5412, -0.9961,
-            -0.9854, -0.9896, -1.0993,
-            -1.065, -0.9871, -0.9821,
-            -0.9955, -1.0385, -1.0072,
-            -0.9832, -1.0134, -0.9939,
-            -1.0074, -0.992, -0.992,
-            -0.9883, -1.0012, -1.1149,
-            -1.002, -0.9994, -0.9869,
-            -0.9726, -0.9989, -0.9904,
+            -7.1067, -1.5412, -0.9961, -0.9854, -0.9896, -1.0993, -1.065,
+            - 0.9871, -0.9821, -0.9955, -1.0385, -1.0072, -0.9832, -1.0134,
+            - 0.9939, -1.0074, -0.992, -0.992, -0.9883, -1.0012, -1.1149,
+            - 1.002, -0.9994, -0.9869, -0.9726, -0.9989, -0.9904,
         ]
 
-        np.testing.assert_array_almost_equal(
-            lof.negative_outlier_factor_.round(4), negative_lof,
+        np.testing.assert_allclose(
+            lof.negative_outlier_factor_.round(4),
+            negative_lof,
+            rtol=1e-4,
         )
 
         # Check same negative outlier factor
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             lof.negative_outlier_factor_,
             lof2.negative_outlier_factor_,
         )
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             lof.negative_outlier_factor_,
             lof3.negative_outlier_factor_,
         )
@@ -478,14 +492,14 @@ class TestNeighbors(unittest.TestCase):
 
         score = lof.score_samples(self.fd_lof[:5])
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             score.round(4),
-            [-5.9726, -1.3445, -0.9853, -0.9817, -0.985],
-            err_msg='Error in LocalOutlierFactor.score_samples',
+            [-5.9725, -1.3445, -0.9853, -0.9817, -0.985],
+            rtol=1e-4,
         )
 
         # Test decision_function = score_function - offset
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             lof.decision_function(self.fd_lof[:5]),
             score - lof.offset_,
             err_msg='Error in LocalOutlierFactor.decision_function',

--- a/skfda/tests/test_registration.py
+++ b/skfda/tests/test_registration.py
@@ -436,7 +436,7 @@ class TestRegistrationValidation(unittest.TestCase):
         """Test basic usage of AmplitudePhaseDecomposition."""
         scorer = AmplitudePhaseDecomposition()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.971144, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.971145, rtol=1e-5)
 
     def test_amplitude_phase_score_with_basis(self) -> None:
         """Test the AmplitudePhaseDecomposition with FDataBasis."""
@@ -448,19 +448,19 @@ class TestRegistrationValidation(unittest.TestCase):
     def test_default_score(self) -> None:
         """Test default score of a registration transformer."""
         score = self.shift_registration.score(self.X)
-        np.testing.assert_allclose(score, 0.971144, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.971146, rtol=1e-5)
 
     def test_least_squares_score(self) -> None:
         """Test LeastSquares."""
         scorer = LeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.953355, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.953357, rtol=1e-5)
 
     def test_sobolev_least_squares_score(self) -> None:
         """Test SobolevLeastSquares."""
         scorer = SobolevLeastSquares()
         score = scorer(self.shift_registration, self.X)
-        np.testing.assert_allclose(score, 0.923962, rtol=1e-6)
+        np.testing.assert_allclose(score, 0.92396, rtol=1e-5)
 
     def test_pairwise_correlation(self) -> None:
         """Test PairwiseCorrelation."""
@@ -477,10 +477,10 @@ class TestRegistrationValidation(unittest.TestCase):
         fd_registered = fd.compose(warping)
         scorer = AmplitudePhaseDecomposition()
         ret = scorer.stats(fd, fd_registered)
-        np.testing.assert_allclose(ret.mse_amplitude, 0.0009465483)
-        np.testing.assert_allclose(ret.mse_phase, 0.1051769136)
-        np.testing.assert_allclose(ret.r_squared, 0.9910806875)
-        np.testing.assert_allclose(ret.c_r, 0.9593073773)
+        np.testing.assert_allclose(ret.mse_amplitude, 0.000947, rtol=1e-3)
+        np.testing.assert_allclose(ret.mse_phase, 0.105177, rtol=1e-5)
+        np.testing.assert_allclose(ret.r_squared, 0.991082, rtol=1e-5)
+        np.testing.assert_allclose(ret.c_r, 0.959302, rtol=1e-5)
 
     def test_raises_amplitude_phase(self) -> None:
         scorer = AmplitudePhaseDecomposition()

--- a/skfda/tests/test_regression.py
+++ b/skfda/tests/test_regression.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 import numpy as np
 import pandas as pd
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from sklearn.preprocessing import OneHotEncoder
 
 from skfda.datasets import fetch_weather, make_gaussian, make_gaussian_process
@@ -1008,7 +1008,7 @@ class TestHistoricalLinearRegression(unittest.TestCase):
             X.data_matrix[..., 0, np.newaxis]
             * coefficients.data_matrix[..., 0]
         )
-        integral_matrix = cumtrapz(
+        integral_matrix = cumulative_trapezoid(
             integral_body,
             x=X.grid_points[0],
             initial=0,


### PR DESCRIPTION
## Describe the proposed changes

- Remove support for Python 3.9 according to [SPEC 0](https://scientific-python.org/specs/spec-0000/).

- Fix test discrepancies with newer Scipy versions.

SciPy version 1.11 changes how Simpson quadrature is computed with an even number of points (https://github.com/scipy/scipy/pull/18209).

This caused some test to fail, as the values of the integrals and metrics used change, causing in some cases several discrepancies (https://github.com/GAA-UAM/scikit-fda/issues/551).

This has been fixed to make the tests compatible with both previous versions and versions after 1.11, in two main ways:
- By making some comparisons more lenient, allowing for higher relative or absolute tolerances.
- By rewriting some tests in order to be less sensitive to changes in quadrature by design.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
