### PR TITLE
Integrate `FDataIrregular` using `scipy.integrate.simpson` on each curve separately 

### DIFF
--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -11,7 +11,6 @@ import itertools
 import numbers
 from typing import (
     Any,
-    Callable,
     Optional,
     Sequence,
     Tuple,
@@ -23,6 +22,7 @@ from typing import (
 import numpy as np
 import pandas.api.extensions
 from matplotlib.figure import Figure
+import scipy
 
 from .._utils import _cartesian_product, _check_array_key, _to_grid_points
 from ..typing._base import (
@@ -34,7 +34,6 @@ from ..typing._base import (
 )
 from ..typing._numpy import (
     ArrayLike,
-    DTypeLike,
     NDArrayBool,
     NDArrayFloat,
     NDArrayInt,
@@ -600,9 +599,15 @@ class FDataIrregular(FData):  # noqa: WPS214
 
     def integrate(
         self: T,
+        *,
         domain: Optional[DomainRange] = None,
     ) -> NDArrayFloat:
         """Integrate the FDataIrregular object.
+
+        The integration can only be performed over 1 dimensional domains.
+
+        For a vector valued function the vector of integrals will be
+        returned.
 
         Args:
             domain (Optional[DomainRange]): tuple with
@@ -610,9 +615,35 @@ class FDataIrregular(FData):  # noqa: WPS214
                 of the domain
 
         Returns:
-            FDataIrregular with the integral.
+            NumPy array of size (``n_samples``, ``dim_codomain``)
+            with the integrated data.
+
+        Examples:
+            >>> fdata = FDataIrregular(
+            ...     values=[[2, -1], [2, 3], [5, -2], [1, -1], [1, -1]],
+            ...     points=[[4], [5], [6], [0], [2]],
+            ...     start_indices=[0, 3],
+            ... )
+            >>> fdata.integrate()
+            array([[ 5.,  3.],
+                   [ 2., -2.]])
         """
-        raise NotImplementedError()
+        if self.dim_domain != 1:
+            raise NotImplementedError(
+                "Integration only implemented for 1D domains."
+            )
+
+        if domain is not None:
+            data = self.restrict(domain)
+        else:
+            data = self
+
+        values_list = np.split(data.values, data.start_indices[1:])
+        points_list = np.split(data.points, data.start_indices[1:])
+        return np.array([
+            scipy.integrate.simpson(y, x, axis=0)
+            for y, x in zip(values_list, points_list)
+        ])
 
     def check_same_dimensions(self: T, other: T) -> None:
         """Ensure that other FDataIrregular object has compatible dimensions.

--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -610,9 +610,8 @@ class FDataIrregular(FData):  # noqa: WPS214
         returned.
 
         Args:
-            domain (Optional[DomainRange]): tuple with
-                the domain ranges for each dimension
-                of the domain
+            domain: tuple with the domain ranges for each dimension of the
+                domain. If None, the domain range of the object will be used.
 
         Returns:
             NumPy array of size (``n_samples``, ``dim_codomain``)

--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -9,20 +9,12 @@ from __future__ import annotations
 
 import itertools
 import numbers
-from typing import (
-    Any,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 import numpy as np
 import pandas.api.extensions
-from matplotlib.figure import Figure
 import scipy
+from matplotlib.figure import Figure
 
 from .._utils import _cartesian_product, _check_array_key, _to_grid_points
 from ..typing._base import (
@@ -32,12 +24,7 @@ from ..typing._base import (
     GridPointsLike,
     LabelTupleLike,
 )
-from ..typing._numpy import (
-    ArrayLike,
-    NDArrayBool,
-    NDArrayFloat,
-    NDArrayInt,
-)
+from ..typing._numpy import ArrayLike, NDArrayBool, NDArrayFloat, NDArrayInt
 from ._functional_data import FData
 from .basis import Basis, FDataBasis
 from .evaluator import Evaluator

--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -629,7 +629,7 @@ class FDataIrregular(FData):  # noqa: WPS214
         """
         if self.dim_domain != 1:
             raise NotImplementedError(
-                "Integration only implemented for 1D domains."
+                "Integration only implemented for 1D domains.",
             )
 
         if domain is not None:


### PR DESCRIPTION
## Describe the proposed changes

Integration for irregular curves has been implemented using `scipy.integrate.simpson` to integrate irregular curves (of 1-dimensional domain) one by one.


## Additional information

We have not agreed on how integration of irregular data with higher dimensional domains should be defined, so it is not to be implemented yet.

This is a first implementation which may or may not be later improved by manually computing simpson's coefficients, multiply them against the curves' values and calling `skfda.representation.irregular._reduceat` to add the results.

