### PR TITLE
Implement scores for `FDatairregular` objects as described in #609 

### DIFF
--- a/skfda/__init__.py
+++ b/skfda/__init__.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
         FData as FData,
         FDataBasis as FDataBasis,
         FDataGrid as FDataGrid,
+        FDataIrregular as FDataIrregular,
         concatenate as concatenate,
     )
 

--- a/skfda/misc/scoring.py
+++ b/skfda/misc/scoring.py
@@ -152,7 +152,12 @@ def _integral_average_fdatairregular(
 
     integrals = np.mean(score.integrate(), axis=1)
     lebesgue_measures = np.diff(score.sample_range, axis=-1).reshape(-1)
-    normalized_integrals = integrals / lebesgue_measures
+    normalized_integrals = np.divide(
+        integrals,
+        lebesgue_measures,
+        out=np.zeros_like(integrals),
+        where=lebesgue_measures != 0,
+    )
     return np.average(normalized_integrals, weights=weights)
 
 

--- a/skfda/misc/scoring.py
+++ b/skfda/misc/scoring.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import math
 import warnings
 from functools import singledispatch
-from typing import Callable, Optional, TypeVar, Union, overload
+from typing import Callable, TypeVar, overload
 
 import numpy as np
 import sklearn.metrics
@@ -269,9 +269,9 @@ def _explained_variance_score_fdatagrid(
     y_true: FDataGrid,
     y_pred: FDataGrid,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
-) -> Union[float, FDataGrid]:
+) -> float | FDataGrid:
 
     num = _var(y_true - y_pred, weights=sample_weight)
     den = _var(y_true, weights=sample_weight)
@@ -291,7 +291,7 @@ def _explained_variance_score_fdatabasis(
     y_true: FDataBasis,
     y_pred: FDataBasis,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
 
@@ -437,9 +437,9 @@ def _mean_absolute_error_fdatagrid(
     y_true: FDataGrid,
     y_pred: FDataGrid,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
-) -> Union[float, FDataGrid]:
+) -> float | FDataGrid:
     from ..exploratory.stats import mean
 
     error = mean(np.abs(y_true - y_pred), weights=sample_weight)
@@ -451,7 +451,7 @@ def _mean_absolute_error_fdatairregular(
     y_true: FDataIrregular,
     y_pred: FDataIrregular,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
     return _integral_average_fdatairregular(
@@ -465,7 +465,7 @@ def _mean_absolute_error_fdatabasis(
     y_true: FDataBasis,
     y_pred: FDataBasis,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
 
@@ -589,9 +589,9 @@ def _mean_absolute_percentage_error_fdatagrid(
     y_true: FDataGrid,
     y_pred: FDataGrid,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
-) -> Union[float, FDataGrid]:
+) -> float | FDataGrid:
     from ..exploratory.stats import mean
 
     epsilon = np.finfo(np.float64).eps
@@ -610,7 +610,7 @@ def _mean_absolute_percentage_error_fdatairregular(
     y_true: FDataIrregular,
     y_pred: FDataIrregular,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
     epsilon = np.finfo(np.float64).eps
@@ -627,7 +627,7 @@ def _mean_absolute_percentage_error_fdatabasis(
     y_true: FDataBasis,
     y_pred: FDataBasis,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
 
@@ -759,10 +759,10 @@ def _mean_squared_error_fdatagrid(
     y_true: FDataGrid,
     y_pred: FDataGrid,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
     squared: bool = True,
-) -> Union[float, FDataGrid]:
+) -> float | FDataGrid:
     from ..exploratory.stats import mean
 
     error: FDataGrid = mean(
@@ -778,7 +778,7 @@ def _mean_squared_error_fdatairregular(
     y_true: FDataIrregular,
     y_pred: FDataIrregular,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
     squared: bool = True,
 ) -> float:
@@ -794,7 +794,7 @@ def _mean_squared_error_fdatabasis(
     y_true: FDataBasis,
     y_pred: FDataBasis,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     squared: bool = True,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
@@ -930,10 +930,10 @@ def _mean_squared_log_error_fdatagrid(
     y_true: FDataGrid,
     y_pred: FDataGrid,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
     squared: bool = True,
-) -> Union[float, FDataGrid]:
+) -> float | FDataGrid:
 
     if np.any(y_true.data_matrix < 0) or np.any(y_pred.data_matrix < 0):
         raise ValueError(
@@ -955,7 +955,7 @@ def _mean_squared_log_error_fdatairregular(
     y_true: FDataIrregular,
     y_pred: FDataIrregular,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
     squared: bool = True,
 ) -> float:
@@ -979,7 +979,7 @@ def _mean_squared_log_error_fdatabasis(
     y_true: FDataBasis,
     y_pred: FDataBasis,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     squared: bool = True,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
@@ -1112,9 +1112,9 @@ def _r2_score_fdatagrid(
     y_true: FDataGrid,
     y_pred: FDataGrid,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
-) -> Union[float, FDataGrid]:
+) -> float | FDataGrid:
     from ..exploratory.stats import mean
 
     if y_pred.n_samples < 2:
@@ -1144,7 +1144,7 @@ def _r2_score_fdatabasis(
     y_true: FDataBasis,
     y_pred: FDataBasis,
     *,
-    sample_weight: Optional[NDArrayFloat] = None,
+    sample_weight: NDArrayFloat | None = None,
     multioutput: MultiOutputType = 'uniform_average',
 ) -> float:
 

--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -47,7 +47,7 @@ def _reduceat(
     dtype=None,
     out=None,
     *,
-    value_empty
+    value_empty,
 ):
     """
     Wrapped `np.ufunc.reduceat` to manage some edge cases.

--- a/skfda/tests/test_scoring.py
+++ b/skfda/tests/test_scoring.py
@@ -515,29 +515,6 @@ def y_pred_irregular() -> FDataIrregular:
     return _y_pred_irregular
 
 
-def _cmp_score_functions(
-    y_true_grid: FDataGrid,
-    y_pred_grid: FDataGrid,
-    y_true_irregular: FDataIrregular,
-    y_pred_irregular: FDataIrregular,
-    irregular_score_function: ScoreFunction,
-    **kwargs: Any,
-) -> None:
-    score_grid = irregular_score_function(
-        y_true_grid,
-        y_pred_grid,
-        **kwargs,
-    )
-    score_irregular = irregular_score_function(
-        y_true_irregular,
-        y_pred_irregular,
-        **kwargs,
-    )
-    np.testing.assert_allclose(
-        score_grid, score_irregular,
-    )
-
-
 def test_score_functions_irregular(
     y_true_grid: FDataGrid,
     y_pred_grid: FDataGrid,
@@ -546,24 +523,18 @@ def test_score_functions_irregular(
     irregular_score_function: ScoreFunction,
 ) -> None:
     """Test score functions with irregular data."""
-    weight = np.array([3, 1])
+    weight = np.array([3, 7])
 
-    try:
-        _cmp_score_functions(
-            y_true_grid,
-            y_pred_grid,
-            y_true_irregular,
-            y_pred_irregular,
-            irregular_score_function,
-            sample_weight=weight,
-        )
-    except TypeError:
-        pass
-
-    _cmp_score_functions(
+    score_grid = irregular_score_function(
         y_true_grid,
         y_pred_grid,
+        sample_weight=weight,
+    )
+    score_irregular = irregular_score_function(
         y_true_irregular,
         y_pred_irregular,
-        irregular_score_function,
+        sample_weight=weight,
+    )
+    np.testing.assert_allclose(
+        score_grid, score_irregular,
     )

--- a/skfda/tests/test_scoring.py
+++ b/skfda/tests/test_scoring.py
@@ -480,50 +480,14 @@ def irregular_score_function(request) -> ScoreFunction:
     return request.param
 
 
-_y_true_grid, _y_pred_grid = _create_data_grid()
-_y_true_irregular = FDataIrregular.from_fdatagrid(_y_true_grid)
-_y_pred_irregular = FDataIrregular.from_fdatagrid(_y_pred_grid)
-
-
-@pytest.fixture
-def y_true_grid() -> FDataGrid:
-    """Fixture with FDataGrid true representation."""
-    return _y_true_grid
-
-
-@pytest.fixture
-def y_pred_grid() -> FDataGrid:
-    """Fixture with FDataGrid prediction representation."""
-    return _y_pred_grid
-
-
-@pytest.fixture
-def y_true_irregular() -> FDataIrregular:
-    """Fixture with FDataIrregular true representation.
-
-    Same data as y_true_grid.
-    """
-    return _y_true_irregular
-
-
-@pytest.fixture
-def y_pred_irregular() -> FDataIrregular:
-    """Fixture with FDataIrregular true representation.
-
-    Same data as y_pred_grid.
-    """
-    return _y_pred_irregular
-
-
 def test_score_functions_irregular(
-    y_true_grid: FDataGrid,
-    y_pred_grid: FDataGrid,
-    y_true_irregular: FDataIrregular,
-    y_pred_irregular: FDataIrregular,
     irregular_score_function: ScoreFunction,
 ) -> None:
     """Test score functions with irregular data."""
     weight = np.array([3, 7])
+    y_true_grid, y_pred_grid = _create_data_grid()
+    y_true_irregular = FDataIrregular.from_fdatagrid(y_true_grid)
+    y_pred_irregular = FDataIrregular.from_fdatagrid(y_pred_grid)
 
     score_grid = irregular_score_function(
         y_true_grid,

--- a/skfda/tests/test_scoring.py
+++ b/skfda/tests/test_scoring.py
@@ -471,7 +471,7 @@ class TestScoreZeroDenominator(unittest.TestCase):
         )
 
 
-############### Test irregular data scoring ####################
+# ------------------ Test irregular data scoring ------------------
 
 
 @pytest.fixture(params=irregular_score_functions)


### PR DESCRIPTION
This pull request depends on #608 (integrating `FDataIrregular` objects is needed to implement the scores).

As explained in #609 , `mean_absolute_error`, `mean_absolute_percentage_error`, `mean_squared_error` and `mean_squared_log_error` have been implemented in the case when both `y_true` and `y_pred` are `FDataIrregular` objects.

Test cases have been included to ensure the same score is obtained if the `FDataIrregular` objects are obtained from `FDataGrid`'s.