### PR TITLE
Fix FDataIrregular's __getitem__

### DIFF
--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -1409,14 +1409,15 @@ class FDataIrregular(FData):  # noqa: WPS214
             ],
         )
 
-        indices = np.cumsum(chunk_sizes) - chunk_sizes[0]
+        indices = np.concatenate([[0], np.cumsum(chunk_sizes)])[:-1]
 
         return self.copy(
             start_indices=indices.astype(int),
             points=arguments,
             values=values,
-            sample_names=self.sample_names[key],
+            sample_names=list(np.array(self.sample_names)[key]),
         )
+
     #####################################################################
     # Numpy methods
     #####################################################################

--- a/skfda/tests/test_irregular.py
+++ b/skfda/tests/test_irregular.py
@@ -294,6 +294,11 @@ def test_fdatairregular_getitem(
     assert len(fdatairregular[:NUM_CURVES:2]) == NUM_CURVES / 2
     assert len(fdatairregular[:NUM_CURVES:2]) == NUM_CURVES / 2
 
+    idxs = np.array((2, 0, 6))
+    fd_subset = fdatairregular[idxs]
+    for i, idx in enumerate(idxs):
+        assert all(fd_subset[i] == fdatairregular[idx])
+
 
 def test_fdatairregular_coordinates(
     fdatairregular: FDataIrregular,


### PR DESCRIPTION
`FDataIrregular`'s `__getitem__` had incorrect computation of the `start_indices` of the new object.

This could perhaps be considered a hotfix.

Added test to check correction (previous version did not pass this test). The previous version was incorrect unless all samples in the new `FDataIrregular` object had the same number of measurements; this is why it has been hard to notice the mistake.
