### PR TITLE
Explicit arguments for simpson

### DIFF
--- a/skfda/preprocessing/dim_reduction/_fpca.py
+++ b/skfda/preprocessing/dim_reduction/_fpca.py
@@ -349,7 +349,7 @@ class FPCA(  # noqa: WPS230 (too many public attributes)
             # grid_points is a list with one array in the 1D case
             identity = np.eye(len(X.grid_points[0]))
             self._weights = scipy.integrate.simpson(
-                identity,
+                y=identity,
                 x=X.grid_points[0],
             )
         elif callable(self._weights):


### PR DESCRIPTION
<!--
Thanks for your contribution! Please ensure you have taken a look at
the contribution guidelines:
https://github.com/GAA-UAM/scikit-fda/blob/develop/CONTRIBUTING.md
-->

## References to issues or other PRs
<!--
Include links to the relevant issues and PRs, using the relevant Github
keywords (e.g., Fixes) for closing automatically the issues resolved
on merge (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
If there is no current issue discussing the addition of this functionality, it
is recommended to create one and discuss the feature there.
Otherwise, it is possible for this functionality to be rejected, or to require
considerable changes.
Example: Fixes #42. See also #123.
-->


## Describe the proposed changes
`self._weights = scipy.integrate.simpson(y=identity, x=X.grid_points[0])`

should replace

`self._weights = scipy.integrate.simpson(identity, X.grid_points[0])`

in FPCA._fit_grid (currently line 351 in "Functional Principal Component Analysis Module.")

By not specifying x and y, simpson() returns the error:

`TypeError: simpson() takes 1 positional argument but 2 were given`

## Additional information


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
