### PR TITLE
Support SciPy 1.14.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 	"rdata",
 	"scikit-datasets[cran]>=0.2.2",
 	"scikit-learn>=0.20",
-	"scipy>=1.6.0, <1.14",
+	"scipy>=1.6.0",
 	"typing-extensions",
 ]
 
@@ -64,6 +64,7 @@ test = [
   "pytest",
   "pytest-env",
   "pytest-subtests",
+  "scipy>=1.14", # Changes in sparse array representation.
 ]
 
 [project.urls]

--- a/skfda/_utils/_neighbors_base.py
+++ b/skfda/_utils/_neighbors_base.py
@@ -313,9 +313,12 @@ class KNeighborsMixin(NeighborsBase[Input, Target]):
 
             >>> graph = neigh.kneighbors_graph(X[0])
             >>> print(graph)
-                (0, 0)    1.0
-                (0, 8)    1.0
-                (0, 1)    1.0
+            <Compressed Sparse Row sparse matrix of dtype 'float64'
+               with 3 stored elements and shape (1, 30)>
+              Coords    Values
+              (0, 0)    1.0
+              (0, 8)    1.0
+              (0, 1)    1.0
 
         Notes:
             This method wraps the corresponding sklearn routine in the

--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -627,7 +627,7 @@ class FDataIrregular(FData):  # noqa: WPS214
         values_list = np.split(data.values, data.start_indices[1:])
         points_list = np.split(data.points, data.start_indices[1:])
         return np.array([
-            scipy.integrate.simpson(y, x, axis=0)
+            scipy.integrate.simpson(y, x=x, axis=0)
             for y, x in zip(values_list, points_list)
         ])
 


### PR DESCRIPTION
## Describe the proposed changes

Fixed the code that was failing in the tests for Scipy 1.14:
- Calls to simpson with more than one positional parameters are invalid (https://github.com/scipy/scipy/pull/20554).
- Representation of SciPy sparse matrix in doctests has changed (https://github.com/scipy/scipy/pull/20649).
  - As this change makes tests fail for previous SciPy versions, the minimum version of SciPy used for tests has been set to 1.14.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
