### PR TITLE
Clustering example error fixed

### DIFF
--- a/examples/plot_clustering.py
+++ b/examples/plot_clustering.py
@@ -103,7 +103,7 @@ fuzzy_kmeans.fit(fd)
 print(fuzzy_kmeans.predict_proba(fd))
 
 ##############################################################################
-# To see the information in a graphic way, the method
+# To see the information in a graphic way, the class
 # :class:`~skfda.exploratory.visualization.clustering.ClusterPlot` can
 # be used. It assigns each sample to the cluster whose membership value is the
 # greatest.

--- a/examples/plot_clustering.py
+++ b/examples/plot_clustering.py
@@ -75,9 +75,8 @@ kmeans.fit(fd)
 print(kmeans.predict(fd))
 
 ##############################################################################
-# To see the information in a graphic way, the method
-# :func:`~skfda.exploratory.visualization.clustering_plots.plot_clusters` can
-# be used.
+# To see the information in a graphic way, we can use the class
+# :class:`~skfda.exploratory.visualization.clustering.ClusterPlot`.
 
 # Customization of cluster colors and labels in order to match the first image
 # of raw data.
@@ -105,7 +104,7 @@ print(fuzzy_kmeans.predict_proba(fd))
 
 ##############################################################################
 # To see the information in a graphic way, the method
-# :func:`~skfda.exploratory.visualization.clustering_plots.plot_clusters` can
+# :class:`~skfda.exploratory.visualization.clustering.ClusterPlot` can
 # be used. It assigns each sample to the cluster whose membership value is the
 # greatest.
 
@@ -115,7 +114,7 @@ ClusterPlot(fuzzy_kmeans, fd, cluster_colors=cluster_colors,
 ##############################################################################
 # Another plot implemented to show the results in the class
 # :class:`~skfda.ml.clustering.FuzzyCMeans` is
-# :func:`~skfda.exploratory.visualization.clustering_plots.plot_cluster_lines`
+# :class:`~skfda.exploratory.visualization.clustering.ClusterMembershipLinesPlot`.
 # which is similar to parallel coordinates. It is recommended to assign colors
 # to each of the samples in order to identify them. In this example, the
 # colors are the ones of the first plot, dividing the samples by climate.
@@ -126,8 +125,9 @@ ClusterMembershipLinesPlot(fuzzy_kmeans, fd, cluster_labels=cluster_labels,
                            sample_colors=colors_by_climate).plot()
 
 ##############################################################################
-# Finally, the function
-# :func:`~skfda.exploratory.visualization.clustering_plots.plot_cluster_bars`
+# Finally, the class
+# :class:`~skfda.exploratory.visualization.clustering.ClusterMembershipPlot`
+# has a plot method which
 # returns a barplot. Each sample is designated with a bar which is filled
 # proportionally to the membership values with the color of each cluster.
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please ensure you have taken a look at
the contribution guidelines:
https://github.com/GAA-UAM/scikit-fda/blob/develop/CONTRIBUTING.md
-->

## References to issues or other PRs
<!--
Include links to the relevant issues and PRs, using the relevant Github
keywords (e.g., Fixes) for closing automatically the issues resolved
on merge (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
If there is no current issue discussing the addition of this functionality, it
is recommended to create one and discuss the feature there.
Otherwise, it is possible for this functionality to be rejected, or to require
considerable changes.
Example: Fixes #42. See also #123.
-->
No issue was reported regarding the error in the clustering example.

## Describe the proposed changes
In the clustering example, a couple of the explanations of the code did not match the code itself. For instance you could read:

> To see the information in a graphic way, the method plot_clusters() can be used.

However, instead of using `plot_clusters()`, the following class was used:

>ClusterPlot(kmeans, fd, cluster_colors=cluster_colors, cluster_labels=cluster_labels).plot()


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
