### PR TITLE
Update mean an sum functions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -586,6 +586,15 @@
         "research",
         "doc"
       ]
+    },
+    {
+      "login": "luisheb",
+      "name": "Luis Hebrero",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24703335?v=4",
+      "profile": "https://github.com/luisheb",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-50-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-51-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 ## Contributors ✨
 
@@ -75,6 +75,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/psotom"><img src="https://avatars.githubusercontent.com/u/166627986?v=4?s=100" width="100px;" alt="psotom"/><br /><sub><b>psotom</b></sub></a><br /><a href="https://github.com/GAA-UAM/scikit-fda/commits?author=psotom" title="Code">💻</a> <a href="#example-psotom" title="Examples">💡</a> <a href="#ideas-psotom" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/GAA-UAM/scikit-fda/commits?author=psotom" title="Tests">⚠️</a> <a href="#research-psotom" title="Research">🔬</a> <a href="https://github.com/GAA-UAM/scikit-fda/commits?author=psotom" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/luisheb"><img src="https://avatars.githubusercontent.com/u/24703335?v=4?s=100" width="100px;" alt="Luis Hebrero"/><br /><sub><b>Luis Hebrero</b></sub></a><br /><a href="https://github.com/GAA-UAM/scikit-fda/commits?author=luisheb" title="Documentation">📖</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/skfda/representation/_functional_data.py
+++ b/skfda/representation/_functional_data.py
@@ -882,6 +882,7 @@ class FData(  # noqa: WPS214
         out: None = None,
         keepdims: bool = False,
         skipna: bool = False,
+        min_count: int = 0,
     ) -> T:
         """Compute the mean of all the samples.
 
@@ -891,6 +892,9 @@ class FData(  # noqa: WPS214
             out: Used for compatibility with numpy. Must be None.
             keepdims: Used for compatibility with numpy. Must be False.
             skipna: Wether the NaNs are ignored or not.
+            min_count: Number of valid (non NaN) data to have in order
+                for the a variable to not be NaN when `skipna` is
+                `True`.
 
         Returns:
             A FData object with just one sample representing
@@ -902,10 +906,7 @@ class FData(  # noqa: WPS214
                 "Not implemented for that parameter combination",
             )
 
-        return (
-            self.sum(axis=axis, out=out, keepdims=keepdims, skipna=skipna)
-            / self.n_samples
-        )
+        return self
 
     @abstractmethod
     def to_grid(

--- a/skfda/representation/basis/_fdatabasis.py
+++ b/skfda/representation/basis/_fdatabasis.py
@@ -427,19 +427,48 @@ class FDataBasis(FData):  # noqa: WPS214
         """
         super().sum(axis=axis, out=out, keepdims=keepdims, skipna=skipna)
 
-        coefs = (
-            np.nansum(self.coefficients, axis=0) if skipna
-            else np.sum(self.coefficients, axis=0)
-        )
-
-        if min_count > 0:
-            valid = ~np.isnan(self.coefficients)
-            n_valid = np.sum(valid, axis=0)
-            coefs[n_valid < min_count] = np.nan
+        valid_functions = ~self.isna()
+        valid_coefficients = self.coefficients[valid_functions]
+        
+        coefs = np.sum(valid_coefficients, axis=0)
 
         return self.copy(
             coefficients=coefs,
             sample_names=(None,),
+        )
+    
+    def mean(  # noqa: WPS125
+        self: T,
+        *,
+        axis: Optional[int] = None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: bool = False,
+        skipna: bool = False,
+        min_count: int = 0,
+    ) -> T:
+        """Compute the mean of all the samples.
+
+        Args:
+            axis: Used for compatibility with numpy. Must be None or 0.
+            dtype: Used for compatibility with numpy. Must be None.
+            out: Used for compatibility with numpy. Must be None.
+            keepdims: Used for compatibility with numpy. Must be False.
+            skipna: Wether the NaNs are ignored or not.
+            min_count: Number of valid (non NaN) data to have in order
+                for the a variable to not be NaN when `skipna` is
+                `True`.
+
+        Returns:
+            A FDataBasis object with just one sample representing
+            the mean of all the samples in the original object.
+        """
+        super().mean(axis=axis, dtype=dtype, out=out, keepdims=keepdims, 
+                     skipna=skipna)
+        
+        return (
+            self.sum(axis=axis, out=out, keepdims=keepdims, skipna=skipna)
+            / np.sum(~self.isna())
         )
 
     def var(
@@ -998,7 +1027,7 @@ class FDataBasis(FData):  # noqa: WPS214
         Returns:
             na_values (np.ndarray): Positions of NA.
         """
-        return np.all(  # type: ignore[no-any-return]
+        return np.any(  # type: ignore[no-any-return]
             np.isnan(self.coefficients),
             axis=1,
         )

--- a/skfda/representation/irregular.py
+++ b/skfda/representation/irregular.py
@@ -716,6 +716,60 @@ class FDataIrregular(FData):  # noqa: WPS214
             values=sum_values,
             sample_names=(None,),
         )
+    
+    def mean(  # noqa: WPS125
+        self: T,
+        *,
+        axis: Optional[int] = None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: bool = False,
+        skipna: bool = False,
+        min_count: int = 0,
+    ) -> T:
+        """Compute the mean of all the samples.
+
+        Args:
+            axis: Used for compatibility with numpy. Must be None or 0.
+            dtype: Used for compatibility with numpy. Must be None.
+            out: Used for compatibility with numpy. Must be None.
+            keepdims: Used for compatibility with numpy. Must be False.
+            skipna: Wether the NaNs are ignored or not.
+            min_count: Number of valid (non NaN) data to have in order
+                for the a variable to not be NaN when `skipna` is
+                `True`.
+
+        Returns:
+            An FDataIrregular object with just one sample representing
+            the mean of all the samples in the original object.
+        """
+        super().mean(axis=axis, dtype=dtype, out=out, keepdims=keepdims, 
+                     skipna=skipna)
+        
+        common_points, common_values = self._get_common_points_and_values()
+
+        if len(common_points) == 0:
+            raise ValueError("No common points in FDataIrregular object")
+
+        sum_function = np.nansum if skipna else np.sum
+        sum_values = sum_function(common_values, axis=0)
+
+        if skipna:
+            count_values = np.sum(~np.isnan(common_values), axis=0)
+        else:
+            count_values = np.full(sum_values.shape, self.n_samples)
+
+        if min_count > 0:
+            count_values[count_values < min_count] = np.nan
+
+        mean_values = sum_values / count_values
+        
+        return FDataIrregular(
+            start_indices=np.array([0]),
+            points=common_points,
+            values=mean_values,
+            sample_names=(None,),
+        )
 
     def var(self: T, correction: int = 0) -> T:
         """Compute the variance of all the samples.


### PR DESCRIPTION
Update mean an sum functions for FData, FDataGrid, FDataIrregular and FDataBasis to correctly handle NaN values in coefficients.

Fixes #642


## Describe the proposed changes
Edit the mean function from FData so that it only becomes a parameter check, leaving the checks as it is.
Add an auxiliar function in FDataGrid that works for mean, sum and var, and simply calls the relevant np.sum/nansum, mean/nanmean, var/nanvar when relevant depending on the skipna parameter, have the mean and sum function work with this auxiliar function.
Add a mean function in FDataBasis that calculates the means for the coefficients when the functions have no nan values in the coefficients, otherwise it is not considered for the calculations.
Add a mean function in FDataIrregular that calculates the mean based on the mean_counts parameter and depending on skipna or not.

- [X] I have performed a self-review of my code
- [X] The code conforms to the style used in this package
- [X] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [X] I have added thorough tests for the new/changed functionality
