### PR TITLE
Ruff GitHub action executed only on changed files

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,7 @@ jobs:
             **.py
 
       - name: Run Ruff on changed files
-        uses: astral-sh/ruff-action@v2
+        uses: astral-sh/ruff-action@v3
         with:
           version: "0.4.4"
           src: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,8 +16,7 @@ jobs:
 
       - name: Run Ruff on changed files
         if: steps.changed-files.outputs.all_changed_files != ''
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v2
         with:
-          version: "0.11.8"
-          args: ${{ steps.changed-files.outputs.all_changed_files }}
+          src: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -17,5 +17,4 @@ jobs:
       - name: Run Ruff on changed files
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.4.4"
           src: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,21 @@
-name: Ruff
-on: [push, pull_request]
+name: Ruff on Changed Files
+on: [pull_request]
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            **.py
+
+      - name: Run Ruff on changed files
+        uses: astral-sh/ruff-action@v2
+        with:
+          version: "0.4.4"
+          src: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,14 +12,12 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
-            **.py
-
-      - name: Check if any Python files were changed
-        if: steps.changed-files.outputs.all_changed_files == ''
-        run: echo "No Python files changed. Skipping Ruff." && exit 0
+            **/*.py
 
       - name: Run Ruff on changed files
+        if: steps.changed-files.outputs.all_changed_files != ''
         uses: astral-sh/ruff-action@v3
         with:
           version: "0.11.8"
           args: ${{ steps.changed-files.outputs.all_changed_files }}
+

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Run Ruff on changed files
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.11.8"
           src: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,5 @@
 name: Ruff on Changed Files
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   ruff:
@@ -14,8 +14,12 @@ jobs:
           files: |
             **.py
 
+      - name: Check if any Python files were changed
+        if: steps.changed-files.outputs.all_changed_files == ''
+        run: echo "No Python files changed. Skipping Ruff." && exit 0
+
       - name: Run Ruff on changed files
         uses: astral-sh/ruff-action@v3
         with:
           version: "0.11.8"
-          src: ${{ steps.changed-files.outputs.all_changed_files }}
+          args: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## References to issues or other PRs

See #676

## Describe the proposed changes

Ruff GitHub action executed only on changed files

## Additional information

I think that https://github.com/astral-sh/ruff-action/commit/f2e32211077f40bfeab40e16285216924ebea4cb made a mistake since the proposed code doesn't check whether any `.py` files were modified, which can cause it to fail on PRs that don’t include code changes.

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] The code conforms to the style used in this package
- [X] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [X] I have added thorough tests for the new/changed functionality
