### PR TITLE
Fix karcher mean only iterating twice

### DIFF
--- a/skfda/exploratory/stats/_fisher_rao.py
+++ b/skfda/exploratory/stats/_fisher_rao.py
@@ -302,7 +302,7 @@ def fisher_rao_karcher_mean(
         ).data_matrix[..., 0]
 
         # Next iteration
-        mu_1 = srsf.mean(axis=0, out=mu_1)
+        mu_1 = srsf.mean(axis=0)
 
         # Convergence criterion
         mu_norm = np.sqrt(

--- a/skfda/preprocessing/feature_construction/_per_class_transformer.py
+++ b/skfda/preprocessing/feature_construction/_per_class_transformer.py
@@ -110,8 +110,8 @@ class PerClassTransformer(
         Finally we can predict and check the score:
 
         >>> neigh1.predict(X_test1)
-        array([ 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,
-            1, 1, 1], dtype=int8)
+        array([ 0,  0,  1,  0,  1,  1,  1,  0,  0,  0,  0,  1,  1,  0,  0,  0,
+                0, 1,  1,  1,  1,  1,  1,  1], dtype=int8)
 
         >>> round(neigh1.score(X_test1, y_test1), 3)
         0.958
@@ -148,11 +148,11 @@ class PerClassTransformer(
         >>> neigh2 = KNeighborsClassifier()
         >>> neigh2 = neigh2.fit(X_train2, y_train2)
         >>> neigh2.predict(X_test2)
-        array([ 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,
-               1, 1, 1], dtype=int8)
+        array([ 1,  1,  1,  1,  1,  1,  1,  0,  0,  0,  0,  1,  1,  0,  0,  0,
+                0,  1,  1,  1,  1,  0,  1,  1], dtype=int8)
 
         >>> round(neigh2.score(X_test2, y_test2), 3)
-        0.917
+        0.875
 
     """
 

--- a/skfda/tests/test_elastic.py
+++ b/skfda/tests/test_elastic.py
@@ -173,17 +173,11 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
 
         values = register([-0.25, -0.1, 0, 0.1, 0.25])
 
-        expected = [
-            [
-                [0.599058], [0.997427], [0.772248], [0.412342], [0.064725],
-            ],
-            [
-                [0.626875], [0.997155], [0.791649], [0.382181], [0.050098],
-            ],
-            [
-                [0.620992], [0.997369], [0.785886], [0.376556], [0.048804],
-            ],
-        ]
+        expected = np.array([
+            [ 0.74600422,  0.95497466,  0.60476075,  0.2328707 ,  0.02170034],
+            [ 0.72551554,  0.96444129,  0.62627011,  0.2472809 ,  0.02393268],
+            [ 0.73169587,  0.961721  ,  0.61982462,  0.24290167,  0.0232434 ],
+        ])[..., None]
 
         np.testing.assert_allclose(values, expected, atol=1e-4)
 
@@ -194,17 +188,11 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
         register = reg.fit_transform(self.unimodal_samples)
 
         values = register([-0.25, -0.1, 0, 0.1, 0.25])
-        expected = [
-            [
-                [0.599058], [0.997427], [0.772248], [0.412342], [0.064725],
-            ],
-            [
-                [0.626875], [0.997155], [0.791649], [0.382181], [0.050098],
-            ],
-            [
-                [0.620992], [0.997369], [0.785886], [0.376556], [0.048804],
-            ],
-        ]
+        expected = np.array([
+            [ 0.74600422,  0.95497466,  0.60476075,  0.2328707 ,  0.02170034],
+            [ 0.72551554,  0.96444129,  0.62627011,  0.2472809 ,  0.02393268],
+            [ 0.73169587,  0.961721  ,  0.61982462,  0.24290167,  0.0232434 ],
+        ])[..., None]
 
         np.testing.assert_allclose(values, expected, atol=1e-4)
 
@@ -244,7 +232,7 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
         reg = FisherRaoElasticRegistration()
         reg.fit(self.unimodal_samples)
         score = reg.score(self.unimodal_samples)
-        np.testing.assert_allclose(score, 0.99938, rtol=1e-5)
+        np.testing.assert_allclose(score, 0.999736, rtol=1e-5)
 
     def test_warping_mean(self) -> None:
         """Test the warping_mean function."""


### PR DESCRIPTION
## Describe the proposed changes
A bug was found in the Karcher mean due to the use of the `out=` parameter: the original mean and the mean of the next iteration were aliasing the same memory, so their difference was always 0.

This caused the Karcher mean function to potentially exit early, not doing all the iterations.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] The code conforms to the style used in this package
- [ ] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
