### PR TITLE
Fix tests in scikit-learn >= 1.7 and pandas >= 2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 	"pandas>=1.0",
 	"rdata",
 	"scikit-datasets[cran]>=0.2.2",
-	"scikit-learn>=0.20",
+	"scikit-learn>=1.6.0",
 	"scipy>=1.6.0",
 	"typing-extensions",
 ]

--- a/skfda/preprocessing/feature_construction/_per_class_transformer.py
+++ b/skfda/preprocessing/feature_construction/_per_class_transformer.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Sequence, Tuple, TypeVar, Union
 import numpy as np
 import pandas as pd
 from sklearn.base import clone
+from sklearn.utils import Tags, get_tags
 from sklearn.utils.validation import check_is_fitted as sklearn_check_is_fitted
 
 from ..._utils import _classifier_get_classes
@@ -165,19 +166,15 @@ class PerClassTransformer(
         self.transformer = transformer
         self.array_output = array_output
 
-    def _more_tags(self) -> Mapping[str, Any]:
-        parent_tags = super()._more_tags()
-        transformer_tags = self.transformer._get_tags()  # noqa: WPS437
+    def __sklearn_tags__(self) -> Tags:
+        tags = super().__sklearn_tags__()
+        transformer_tags = get_tags(self.transformer)
 
-        return {
-            **parent_tags,
-            'allow_nan': transformer_tags['allow_nan'],
-            'non_deterministic': transformer_tags['non_deterministic'],
-            'pairwise': transformer_tags['pairwise'],
-            'requires_positive_X': transformer_tags['requires_positive_X'],
-            'requires_y': True,
-            'X_types': transformer_tags['X_types'],
-        }
+        tags.input_tags = transformer_tags.input_tags
+        tags.target_tags = transformer_tags.target_tags
+        tags.non_deterministic = transformer_tags.non_deterministic
+
+        return tags
 
     def _validate_transformer(
         self,
@@ -206,21 +203,22 @@ class PerClassTransformer(
                 " doesn't",
             )
 
-        tags = self.transformer._get_tags()  # noqa: WPS437
+        tags = get_tags(self.transformer)
 
-        if tags['stateless']:
+        if not tags.requires_fit:
             warnings.warn(
                 f"Parameter 'transformer' with type "
                 f"{type(self.transformer)} should use the data for "
                 f" fitting."
-                f"It should have the 'stateless' tag set to 'False'",
+                f"It should have the 'requires_fit' tag set to 'True'",
             )
 
-        if tags['requires_y']:
+        if tags.target_tags.required:
             warnings.warn(
                 f"Parameter 'transformer' with type "
                 f"{type(self.transformer)} should not use the class label."
-                f"It should have the 'requires_y' tag set to 'False'",
+                f"It should have the 'target_tags.required' tag set to "
+                f"'False'",
             )
 
     def fit(  # type: ignore[override]

--- a/skfda/tests/test_pandas_fdatabasis.py
+++ b/skfda/tests/test_pandas_fdatabasis.py
@@ -365,6 +365,13 @@ class TestInterface(base.BaseInterfaceTests):  # type: ignore[misc]
     def test_contains(self, data: Any, data_missing: Any) -> None:
         pass
 
+    # We do not attempt to implement copy right now.
+    @pytest.mark.skip(reason="Unsupported")
+    def test_array_interface_copy(
+        self,
+        data: Any,
+    ) -> None:
+        pass
 
 class TestArithmeticOps(base.BaseArithmeticOpsTests):  # type: ignore[misc]
 

--- a/skfda/tests/test_pandas_fdatagrid.py
+++ b/skfda/tests/test_pandas_fdatagrid.py
@@ -397,6 +397,14 @@ class TestInterface(base.BaseInterfaceTests):  # type: ignore[misc]
     ) -> None:
         pass
 
+    # We do not attempt to implement copy right now.
+    @pytest.mark.skip(reason="Unsupported")
+    def test_array_interface_copy(
+        self,
+        data: ExtensionArray,
+    ) -> None:
+        pass
+
 
 class TestArithmeticOps(base.BaseArithmeticOpsTests):  # type: ignore[misc]
 


### PR DESCRIPTION
Version 1.7 of scikit-learn removes the old tags API, which was deprecated in version 1.6 with the inclusion of a newer one.

Unfortunately, I think that supporting both is not worth the effort for now, so we bump the minimum scikit-learn version to 1.6 and we switch to the new one.

In addition a new test that we do not currently support was added in Pandas 2.3, so we skip it.

<!--
Thanks for your contribution! Please ensure you have taken a look at
the contribution guidelines:
https://github.com/GAA-UAM/scikit-fda/blob/develop/CONTRIBUTING.md
-->

## References to issues or other PRs
<!--
Include links to the relevant issues and PRs, using the relevant Github
keywords (e.g., Fixes) for closing automatically the issues resolved
on merge (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
If there is no current issue discussing the addition of this functionality, it
is recommended to create one and discuss the feature there.
Otherwise, it is possible for this functionality to be rejected, or to require
considerable changes.
Example: Fixes #42. See also #123.
-->


## Describe the proposed changes


## Additional information


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
