### PR TITLE
Make `fdasrsf` dependency optional

### DIFF
--- a/asv_benchmarks/benchmarks/preprocessing/__init__.py
+++ b/asv_benchmarks/benchmarks/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+"""ASV tests for preprocessing utilities."""

--- a/asv_benchmarks/benchmarks/preprocessing/missing/__init__.py
+++ b/asv_benchmarks/benchmarks/preprocessing/missing/__init__.py
@@ -1,0 +1,1 @@
+"""ASV tests for utilities related with the handling of missing values."""

--- a/asv_benchmarks/benchmarks/preprocessing/missing/missing.py
+++ b/asv_benchmarks/benchmarks/preprocessing/missing/missing.py
@@ -24,7 +24,7 @@ class MissingValuesInterpolationCurves:
         na_probability: float,
     ) -> None:
         """Create the data for the test."""
-        self.rng = np.random.default_rng()
+        self.rng = np.random.default_rng(seed)
         size = (n_samples, n_points)
         na_positions = self.rng.choice(
             [True, False],

--- a/asv_benchmarks/benchmarks/preprocessing/registration/__init__.py
+++ b/asv_benchmarks/benchmarks/preprocessing/registration/__init__.py
@@ -1,0 +1,1 @@
+"""ASV tests for registration utilities."""

--- a/asv_benchmarks/benchmarks/preprocessing/registration/fisher_rao.py
+++ b/asv_benchmarks/benchmarks/preprocessing/registration/fisher_rao.py
@@ -1,0 +1,43 @@
+"""Benchmarks for dealing with Fisher-Rao elastic registration."""
+
+import numpy as np
+from asv_runner.benchmarks.mark import parameterize
+
+from skfda.datasets import make_multimodal_samples
+from skfda.preprocessing.registration import FisherRaoElasticRegistration
+
+seed = 715839
+
+
+@parameterize({
+    "n_samples": [10, 100, 1000],
+    "n_points": [10, 100, 125],
+})
+class FisherRaoRegistration:
+    """Performance of Fisher-Rao registration."""
+
+    timeout=120
+
+    def setup(
+        self,
+        n_samples: int,
+        n_points: int,
+    ) -> None:
+        """Create the data for the test."""
+        self.rng = np.random.default_rng(seed)
+
+        self.data = make_multimodal_samples(
+            n_samples=n_samples,
+            points_per_dim=n_points,
+            n_modes=2,
+            random_state=self.rng,
+        )
+        self.transformer = FisherRaoElasticRegistration()
+
+    def time_fisher_rao_registration(
+        self,
+        n_samples: int,
+        n_points: int,
+    ) -> None:
+        """Time the interpolation of missing values."""
+        self.transformer.fit_transform(self.data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ enable_error_code = "ignore-without-code"
 
 [[tool.mypy.overrides]]
 module = [
+  "asv_runner.*",
   "cartopy.*",
 	"fdasrsf.*",
   "findiff.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dynamic = ["version"]
 
 dependencies = [
 	"dcor",
-	"fdasrsf>=2.2.0, !=2.5.7",
 	"findiff",
 	"lazy_loader",
 	"matplotlib",
@@ -59,6 +58,9 @@ docs = [
   "sphinx>=3",
   "sphinx-gallery>=0.19",
   "sphinxcontrib-bibtex",
+]
+fdasrsf = [
+  "fdasrsf>=2.2.0, !=2.5.7",
 ]
 test = [
   "numpy>=2.2", # Changes in array representation.

--- a/skfda/_utils/__init__.py
+++ b/skfda/_utils/__init__.py
@@ -20,6 +20,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "_same_domain",
             "_to_grid",
             "_to_grid_points",
+            "evaluate_fdatagrid_linear_interpolation",
             "function_to_fdatabasis",
             "nquad_vec",
         ],
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
         _same_domain as _same_domain,
         _to_grid as _to_grid,
         _to_grid_points as _to_grid_points,
+        evaluate_fdatagrid_linear_interpolation as evaluate_fdatagrid_linear_interpolation,
         function_to_fdatabasis as function_to_fdatabasis,
         nquad_vec as nquad_vec,
     )

--- a/skfda/_utils/_utils.py
+++ b/skfda/_utils/_utils.py
@@ -653,9 +653,11 @@ def evaluate_fdatagrid_linear_interpolation(
     indexes[indexes >= len(grid_points)] = len(grid_points) - 1
     indexes_prev = indexes - 1
 
+    grid_points_prev = grid_points[indexes_prev]
+
     interp_parameter = (
-        (evaluation_points - grid_points[indexes_prev])
-        / (grid_points[indexes] - grid_points[indexes_prev])
+        (evaluation_points - grid_points_prev)
+        / (grid_points[indexes] - grid_points_prev)
     )
 
     left = np.take(data_matrix, indices=indexes_prev, axis=1)

--- a/skfda/_utils/_utils.py
+++ b/skfda/_utils/_utils.py
@@ -637,3 +637,28 @@ def function_to_fdatabasis(
     coefs = np.linalg.solve(gram_matrix, inner_prod)
 
     return FDataBasis(new_basis, coefs.T)
+
+
+def evaluate_fdatagrid_linear_interpolation(
+    fdatagrid: FDataGrid,
+    evaluation_points: NDArrayFloat,
+) -> NDArrayFloat:
+    """Evaluate the functions at some points using linear interpolation."""
+    data_matrix = fdatagrid.data_matrix[..., 0]
+    grid_points = fdatagrid.grid_points[0]
+
+    indexes = np.searchsorted(grid_points, evaluation_points, side='left')
+    # Allow for extrapolation and extreme cases
+    indexes[indexes < 1] = 1
+    indexes[indexes >= len(grid_points)] = len(grid_points) - 1
+    indexes_prev = indexes - 1
+
+    interp_parameter = (
+        (evaluation_points - grid_points[indexes_prev])
+        / (grid_points[indexes] - grid_points[indexes_prev])
+    )
+
+    left = np.take(data_matrix, indices=indexes_prev, axis=1)
+    right = np.take(data_matrix, indices=indexes, axis=1)
+
+    return (1 - interp_parameter) * left + interp_parameter * right

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -11,6 +11,13 @@ from numpy.lib.stride_tricks import sliding_window_view
 from scipy.interpolate import PchipInterpolator, make_interp_spline
 from typing_extensions import override
 
+try:
+    from fdasrsf.utility_functions import optimum_reparam
+    _has_fdasrsf = True
+except ImportError:
+    optimum_reparam = None
+    _has_fdasrsf = False
+
 if TYPE_CHECKING:
     from ..representation import FDataGrid
     from ..typing._base import DomainRangeLike
@@ -747,6 +754,63 @@ def dynamic_programming_match(  # noqa: WPS210
         grid_points=grid_points,
     )
 
+def elastic_registration_match(  # noqa: WPS210
+    original: FDataGrid,
+    target: FDataGrid,
+    *,
+    penalty: float = 0,
+    grid_dim: int,
+) -> FDataGrid:
+    """
+    Matching subroutine for elastic registration.
+
+    It uses the ``fdasrsf`` package when possible, as that is 8-10 times
+    faster for large inputs. If not possible, it falls back to using
+    :func:`dynamic_programming_match`, which is written in.
+
+    Args:
+        original: Functions to be aligned.
+        target: Target function(s) to align to.
+        penalty: The penalization factor. The default, 0, is no penalization.
+        grid_dim: Dimension of the grid used in the alignment algorithm. Only
+            the direct lines from points whose grid separation with the
+            candidate point is less or equal than ``grid_dim`` are considered.
+
+    Returns:
+        The warpings that align the functions using the DP algorithm.
+
+    """
+    from ..representation import FDataGrid
+
+    if _has_fdasrsf:
+        assert optimum_reparam
+        warpings = optimum_reparam(
+            np.ascontiguousarray(target.data_matrix[0, ..., 0]),
+            np.ascontiguousarray(normalize_scale(original.grid_points[0])),
+            np.ascontiguousarray(original.data_matrix[..., 0].T),
+            method="DP2",
+            lam=penalty,
+            grid_dim=grid_dim,
+        ).T
+
+        return normalize_warping(
+                FDataGrid(
+                data_matrix=warpings,
+                grid_points=original.grid_points,
+            ),
+        )
+
+    line_energy = L2LineEnergy(
+        penalty=penalty,
+        slope_scaling=True,
+    )
+
+    return dynamic_programming_match(
+        original=original,
+        target=target,
+        line_energy_function=line_energy,
+        grid_dim=grid_dim,
+    )
 
 def invert_warping(
     warping: FDataGrid,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-from scipy.integrate import simpson
+from scipy.integrate import trapezoid
 from scipy.interpolate import PchipInterpolator
 
 if TYPE_CHECKING:
@@ -33,6 +33,7 @@ class LineEnergyFunction(Protocol):
         *,
         row: int,
         column: int,
+        grid_dim: int | None = None,
     ) -> NDArrayFloat:
         """Returns energies of all lines from each candidate point."""
 
@@ -200,6 +201,7 @@ class L2LineEnergy:
         *,
         row: int,
         column: int,
+        grid_dim: int | None = None,
     ) -> NDArrayFloat:
         r"""
         Compute the line energies for the :math:`L^2` distance.
@@ -219,6 +221,10 @@ class L2LineEnergy:
             target: Target function(s) to align to.
             row: The row index of the candidate point.
             column: The column index of the candidate point.
+            grid_dim: Dimension of the grid used in the alignment
+                algorithm. Only the direct lines from points whose grid
+                separation with the candidate point is less or equal than
+                ``grid_dim`` are considered.
 
         Returns:
             Energy of direct line warpings to the candidate point.
@@ -250,9 +256,9 @@ class L2LineEnergy:
             ...    row=3,
             ...    column=3,
             ... )
-            array([[[ 0.14583333,  0.375     ,  0.55208333],
-                    [ 0.        ,  0.14583333,  0.328125  ],
-                    [ 0.04166667,  0.        ,  0.01041667]]])
+            array([[[ 0.109375  ,  0.30859375,  0.47558594],
+                    [ 0.        ,  0.046875  ,  0.10546875],
+                    [ 0.03125   ,  0.        ,  0.0078125 ]]])
 
             Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
             This is because they correspond to linear warpings that align
@@ -267,22 +273,63 @@ class L2LineEnergy:
             ...    row=2,
             ...    column=1,
             ... )
-            array([[[ 0.0625],
-                    [ 0.    ]]])
+            array([[[ 0.04166667],
+                    [ 0.        ]]])
 
             This has again 0 energy at ``(1, 0)``, because it is possible to
             align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
 
+            With the parameter ``grid_dim`` we can control the size of the
+            grid used, so that the algorithm is still tractable with many
+            points:
+
+            >>> complete_grid = l2_line_energy(
+            ...    original,
+            ...    target,
+            ...    row=3,
+            ...    column=3,
+            ... )
+
+            >>> grid_1 = l2_line_energy(
+            ...    original,
+            ...    target,
+            ...    row=3,
+            ...    column=3,
+            ...    grid_dim = 1,
+            ... )
+            >>> grid_1
+            array([[[ 0.0078125]]])
+
+            >>> grid_2 = l2_line_energy(
+            ...    original,
+            ...    target,
+            ...    row=3,
+            ...    column=3,
+            ...    grid_dim = 2,
+            ... )
+            >>> grid_2
+            array([[[ 0.046875  ,  0.10546875],
+                    [ 0.        ,  0.0078125 ]]])
+
+            As you can see, the results correspond to the lower-right part
+            of the complete grid.
+
         """
+        if grid_dim is None:
+            grid_dim = max(row, column)
+
         grid_points = original.grid_points[0]
+
+        first_row_index = max(0, row - grid_dim)
+        first_column_index = max(0, column - grid_dim)
 
         t_row = grid_points[row]
         t_column = grid_points[column]
 
-        t_i = grid_points[:row, None]
-        t_j = grid_points[:column, None]
+        t_i = grid_points[first_row_index:row, None]
+        t_j = grid_points[first_column_index:column, None]
 
-        t = grid_points[:row + 1]
+        t = grid_points[first_row_index:row + 1]
         l_vec = (t - t_i) / (t_row - t_i)
         l_matrix = l_vec[:, None, :]
         w = (1 - l_matrix) * t_j + l_matrix * t_column
@@ -291,18 +338,32 @@ class L2LineEnergy:
         x_t = original(w.reshape(-1)).reshape((len(original), *w.shape))
 
         # Shape: N x t
-        y_t = target.data_matrix[:, :row + 1, 0]
+        y_t = target.data_matrix[:, first_row_index:row + 1, 0]
 
         integrand = (x_t - y_t[:, None, None, :])**2
 
-        # Set to 0 the parts that do not contribute to the integral
-        integrand = np.swapaxes(np.triu(np.swapaxes(integrand, 1, 2)), 1, 2)
-
         identity = np.eye(len(t))
-        quadrature_weights = simpson(
+        quadrature_weights = trapezoid(
             y=identity,
             x=t,
         )
+
+        # We set the weights of unused points to 0
+        quadrature_weights = np.triu(
+            np.tile(quadrature_weights, (len(t_i), 1)),
+        )
+
+        # Final correction: adjust the weight at the extreme
+        # We need to remove t_i - t_{i-1} only at the leftmost point
+        interval_lenghts = np.diff(t, prepend=t[0])[:-1]
+        quadrature_weights_diag = np.diagonal(quadrature_weights)
+        np.fill_diagonal(
+            quadrature_weights,
+            quadrature_weights_diag - interval_lenghts / 2,
+        )
+
+        # Add column dimension
+        quadrature_weights = quadrature_weights[:, None, :]
 
         integral = np.sum(integrand * quadrature_weights, axis=-1)
 
@@ -316,6 +377,7 @@ def dynamic_programming_match(  # noqa: WPS210
     target: FDataGrid,
     *,
     line_energy_function: LineEnergyFunction,
+    grid_dim: int | None = None,
 ) -> FDataGrid:
     r"""
     Find an optimal warping to transform a set of curves into another.
@@ -361,6 +423,9 @@ def dynamic_programming_match(  # noqa: WPS210
         target: Target function(s) to align to.
         line_energy_function: Function used to compute the energy for a line
             segment of the warpings.
+        grid_dim: Dimension of the grid used in the alignment algorithm. Only
+            the direct lines from points whose grid separation with the
+            candidate point is less or equal than ``grid_dim`` are considered.
 
     Returns:
         The warpings that align the functions using the DP algorithm.
@@ -423,6 +488,8 @@ def dynamic_programming_match(  # noqa: WPS210
     n_samples = original.n_samples
     grid_points = original.grid_points[0]
     n_points = len(grid_points)
+    if grid_dim is None:
+        grid_dim = n_points
 
     arange_idx = np.arange(n_samples)
 
@@ -437,7 +504,14 @@ def dynamic_programming_match(  # noqa: WPS210
 
     for row in range(1, n_points):
         for column in range(1, n_points):
-            candidate_points_partial_energy = energy[:, :row, :column]
+            first_row_index = max(0, row - grid_dim)
+            first_column_index = max(0, column - grid_dim)
+
+            candidate_points_partial_energy = energy[
+                :,
+                first_row_index:row,
+                first_column_index:column,
+            ]
 
             # This can be further vectorized and extracted
             # out of the loop, but not sure if it is worth it.
@@ -448,6 +522,7 @@ def dynamic_programming_match(  # noqa: WPS210
                 target,
                 row=row,
                 column=column,
+                grid_dim=grid_dim,
             )
             partial_energies = (
                 candidate_points_partial_energy + candidate_points_line_energy
@@ -462,6 +537,8 @@ def dynamic_programming_match(  # noqa: WPS210
                 min_idx,
                 partial_energies.shape[1:],
             )
+            rows_idx += first_row_index
+            columns_idx += first_column_index
             row_indexes[:, row, column] = rows_idx
             column_indexes[:, row, column] = columns_idx
             energy[:, row, column] = ravel_partial_energies[

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-from scipy.interpolate import PchipInterpolator
+from scipy.interpolate import make_interp_spline, PchipInterpolator
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -432,35 +432,11 @@ class L2LineEnergy(LineEnergyFunction):
             prepend=self.grid_points[0],
         )
 
-        data_matrix = original.data_matrix[..., 0]
-
-        self.data_diff = np.diff(
-            data_matrix,
-            prepend=data_matrix[:, :1],
+        self.interpolator = make_interp_spline(
+            self.grid_points,
+            original.data_matrix[..., 0].mT,
+            k=1,
         )
-
-        padding_col = np.zeros((data_matrix.shape[0], 1))
-
-        self.left_grid_points = np.concat(
-            (self.grid_points[:1], self.grid_points),
-        )
-
-        diff = np.concat(
-            (self.data_diff, padding_col),
-            axis=1,
-        )
-
-        # First lenght is 0, so skip it
-        # It will only be used multiplied by 0 in that case, anyway
-        diff[:, 1:-1] /= self.interval_lenghts[1:]
-
-        self.left_and_diff = np.stack((
-            np.concat(
-                (data_matrix[:, :1], data_matrix),
-                axis=1,
-            ),
-            diff,
-        ))
 
     @override
     def dp_change_row(
@@ -513,28 +489,6 @@ class L2LineEnergy(LineEnergyFunction):
         quadrature_weights = quadrature_weights[:, None, :]
         self.quadrature_weights = quadrature_weights
 
-    def evaluate_fdatagrid_linear_interpolation(
-        self,
-        evaluation_points: NDArrayFloat,
-    ) -> NDArrayFloat:
-        """Evaluate the functions at some points using linear interpolation."""
-        indexes = np.searchsorted(
-            self.grid_points,
-            evaluation_points,
-            side="left",
-        )
-        # Extrapolation is not necessary, as the warping values are inside the
-        # domain
-
-        grid_points_prev = self.left_grid_points[indexes]
-
-        interp_parameter = evaluation_points - grid_points_prev
-
-        left, data_diff = np.take(self.left_and_diff, indices=indexes, axis=2)
-
-        left += interp_parameter * data_diff
-        return left  # type: ignore[no-any-return]
-
     @override
     def __call__(  # noqa: WPS210
         self,
@@ -586,7 +540,7 @@ class L2LineEnergy(LineEnergyFunction):
         w = t_j + l_matrix * (t_column - t_j)
 
         # Shape: N x row x column x t
-        x_t =self.evaluate_fdatagrid_linear_interpolation(w)
+        x_t = np.moveaxis(self.interpolator(w), -1, 0)
 
         w_slope = (t_column - t_j.T) / total_interval_length
         w_slope_root = np.sqrt(w_slope)
@@ -594,12 +548,17 @@ class L2LineEnergy(LineEnergyFunction):
         if self.slope_scaling:
             x_t *= w_slope_root[None, ..., None]
 
-        integrand = (x_t - self.y_t)**2
+        integrand = x_t
+        integrand -= self.y_t
 
-        quadrature_weights = self.quadrature_weights
-
-        integrand *= quadrature_weights
-        integral = np.sum(integrand, axis=-1)
+        # Compute integrand**2 * quadrature_weights and
+        # sum over the last axis.
+        integral = np.einsum(
+            "nijk,nijk,ijk->nij",
+            integrand,
+            integrand,
+            self.quadrature_weights,
+        )
 
         roughness = self.penalty * (
             (1 - w_slope_root)**2 * total_interval_length

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -801,19 +801,25 @@ class L2LineEnergy(LineEnergyFunction):
             x_t *= warping_slopes_root[None, ..., None]
 
         y_t_reshaped = y_t[:, :, None, None, None, :]
-        integrand = x_t
+        integrand = x_t  # x_t is not used anymore
         integrand -= y_t_reshaped
-        integrand **= 2
-        integrand *= quadrature_weights
 
-        integral = np.sum(integrand, axis=-1)
+        # Compute integrand**2 * quadrature_weights and
+        # sum over the last axis.
+        integral = np.einsum(
+            "nxyijk,nxyijk,xyijk->nxyij",
+            integrand,
+            integrand,
+            quadrature_weights,
+        )
 
         roughness = self.penalty * (
             (1 - warping_slopes_root)**2
             * distances_to_endpoint[:, None, :, None]
         )
 
-        return integral + roughness  # type: ignore[no-any-return]
+        integral += roughness
+        return integral # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -4,7 +4,7 @@ This module contains routines related to the registration procedure.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.interpolate import PchipInterpolator
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def invert_warping(
     warping: FDataGrid,
     *,
-    output_points: Optional[ArrayLike] = None,
+    output_points: ArrayLike | None = None,
 ) -> FDataGrid:
     r"""
     Compute the inverse of a diffeomorphism.
@@ -128,7 +128,7 @@ def normalize_scale(
 
 def normalize_warping(
     warping: FDataGrid,
-    domain_range: Optional[DomainRangeLike] = None,
+    domain_range: DomainRangeLike | None = None,
 ) -> FDataGrid:
     r"""
     Rescale a warping to normalize their :term:`domain`.

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -4,11 +4,10 @@ This module contains routines related to the registration procedure.
 """
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-from scipy.interpolate import PchipInterpolator, make_interp_spline
+from scipy.interpolate import PchipInterpolator
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -22,16 +21,55 @@ class LineEnergyFunction(Protocol):
     Computes the energies of line segments.
 
     Returns the matrix containing the partial energies of all line
-    segments between all candidate point and all targets.
+    segments between a candidate point and the target.
 
     """
-    @abstractmethod
+    def dp_start(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        grid_dim: int,
+    ) -> None:
+        """
+        Called at the start of the DP algorithm.
+
+        This can be used to cache the needed values that are the
+        same for each row and column.
+
+        """
+
+    def dp_change_row(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        row: int,
+        grid_dim: int,
+    ) -> None:
+        """
+        Called when a row is changed in the DP algorithm.
+
+        This can be used to cache the needed values that are the
+        same for each row.
+
+        Note:
+            There is no analog function for columns, as the column
+            always change (and it requires less computations, because
+            the integral domain does not change).
+
+        """
+
     def __call__(
         self,
         /,
         original: FDataGrid,
         target: FDataGrid,
         *,
+        row: int,
+        column: int,
         grid_dim: int,
     ) -> NDArrayFloat:
         """Returns energies of all lines from each candidate point."""
@@ -215,17 +253,39 @@ class L2LineEnergy(LineEnergyFunction):
 
         >>> grid_dim = len(grid_points)
 
-        We will consider the final case ``row = 3``, ``column=3``.
-        >>> line_energies = l2_line_energy(
+        Before calling it, the DP algorithm will call the ``dp_start``
+        method, at the beginning of the algorithm, to give the opportunity to
+        cache variables that are common for all the candidate points.
+
+        >>> l2_line_energy.dp_start(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ... )
-        >>> line_energies[:, 3, 3]
-        array([[[        nan,         nan,         nan,         nan],
-                [        nan,  0.109375  ,  0.30859375,  0.47558594],
-                [        nan,  0.        ,  0.046875  ,  0.10546875],
-                [        nan,  0.03125   ,  0.        ,  0.0078125 ]]])
+
+        We will consider the final case ``row = 3``, ``column=3``. Before
+        calling the function, the DP algorithm will call ``dp_change_row``
+        whenever the row is changed, to give the opportunity to
+        cache variables that are common for all the candidate points in
+        the same row.
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        array([[[ 0.109375  ,  0.30859375,  0.47558594],
+                [ 0.        ,  0.046875  ,  0.10546875],
+                [ 0.03125   ,  0.        ,  0.0078125 ]]])
 
         Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
         This is because they correspond to linear warpings that align
@@ -234,11 +294,21 @@ class L2LineEnergy(LineEnergyFunction):
 
         Now consider a possible intermediate case with ``row = 2`` and
         ``column=1``:
-        >>> line_energies[:, 2, 1]
-        array([[[        nan,         nan,         nan,         nan],
-                [        nan,         nan,         nan,         nan],
-                [        nan,         nan,         nan,  0.04166667],
-                [        nan,         nan,         nan,  0.        ]]])
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=2,
+        ... )
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=2,
+        ...    column=1,
+        ... )
+        array([[[ 0.04166667],
+                [ 0.        ]]])
 
         This has again 0 energy at ``(1, 0)``, because it is possible to
         align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
@@ -249,22 +319,52 @@ class L2LineEnergy(LineEnergyFunction):
 
         >>> grid_dim = 1
 
-        >>> grid_1 = l2_line_energy(
+        >>> l2_line_energy.dp_start(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ... )
-        >>> grid_1[:, 3, 3]
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> grid_1 = l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        >>> grid_1
         array([[[ 0.0078125]]])
 
         >>> grid_dim = 2
+
+        >>> l2_line_energy.dp_start(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ... )
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
 
         >>> grid_2 = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
         ... )
-        >>> grid_2[:, 3, 3]
+        >>> grid_2
         array([[[ 0.046875  ,  0.10546875],
                 [ 0.        ,  0.0078125 ]]])
 
@@ -278,16 +378,29 @@ class L2LineEnergy(LineEnergyFunction):
 
         >>> grid_dim = len(grid_points)
 
-        >>> line_energies = l2_line_energy(
+        >>> l2_line_energy.dp_start(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ... )
-        >>> line_energies[:, 3, 3]
-        array([[[        nan,         nan,         nan,         nan],
-                [        nan,  0.109375  ,  0.39438019,  0.72558594],
-                [        nan,  0.08578644,  0.046875  ,  0.14836197],
-                [        nan,  0.28125   ,  0.04289322,  0.0078125 ]]])
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        array([[[ 0.109375  ,  0.39438019,  0.72558594],
+                [ 0.08578644,  0.046875  ,  0.14836197],
+                [ 0.28125   ,  0.04289322,  0.0078125 ]]])
 
         Note that the terms on the main diagonal are not penalized in this
         case, as there is no difference in slope with respect to the
@@ -304,419 +417,123 @@ class L2LineEnergy(LineEnergyFunction):
         self.penalty = penalty
         self.slope_scaling = slope_scaling
 
-    def compute_row_interval_lengths(
+    @override
+    def dp_start(
         self,
-        *,
-        grid_points: NDArrayFloat,
-        grid_dim: int,
-    ) -> NDArrayFloat:
-        """
-        Compute the interval lengths of the candidates for each row/column.
-
-        Args:
-            grid_points: Points of the grid.
-            grid_dim: Dimension of the grid used in the alignment
-                algorithm.
-
-        Returns:
-            A M x ``grid_points`` matrix containing for each row (or column)
-            the interval lengths of all of the points in its grid of
-            candidates.
-
-        Examples:
-            >>> import numpy as np
-            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            array([[  nan,   nan,   nan],
-                   [  nan,   nan,  0.5 ],
-                   [  nan,  0.5 ,  0.25],
-                   [ 0.5 ,  0.25,  0.05],
-                   [ 0.25,  0.05,  0.2 ]])
-
-        """
-        interval_lengths = np.diff(grid_points)
-
-        interval_lengths_expanded = np.concat((
-            np.full((grid_dim), fill_value=np.nan),
-            interval_lengths,
-        ))
-
-        # M x grid_dim
-        return np.lib.stride_tricks.sliding_window_view(
-            interval_lengths_expanded,
-            window_shape=grid_dim,
-        )
-
-    def compute_distances_to_endpoint(
-        self,
-        *,
-        row_interval_lengths: NDArrayFloat,
-    ) -> NDArrayFloat:
-        """
-        Compute the distance to the endpoint of the candidates.
-
-        Args:
-            row_interval_lengths: The array of interval lengths per row.
-
-        Returns:
-            A M x ``grid_points`` matrix containing for each row (or column)
-            the distance of all of the points in its grid of
-            candidates to itself.
-
-        Examples:
-            >>> import numpy as np
-            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> energy.compute_distances_to_endpoint(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            array([[  nan,   nan,   nan],
-                   [  nan,   nan,  0.5 ],
-                   [  nan,  0.75,  0.25],
-                   [ 0.8 ,  0.3 ,  0.05],
-                   [ 0.5 ,  0.25,  0.2 ]])
-
-        """
-        return np.cumulative_sum(
-            row_interval_lengths[:, ::-1],
-            axis=1,
-        )[:, ::-1]
-
-    def compute_warping_slopes(
-        self,
-        *,
-        distances_to_endpoint: NDArrayFloat,
-    ) -> NDArrayFloat:
-        """
-        Compute the y-diffs and slopes of the linear warpings for all points.
-
-        Args:
-            distances_to_endpoint: Array of distances of each candidate point
-                to its endpoint.
-
-        Returns:
-            The array of slopes, that is, an
-            M x M x ``grid_dim`` x ``grid_dim`` array containing
-            the warping slopes.
-
-        Examples:
-            >>> import numpy as np
-
-            Regular case:
-            >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            >>> slopes = energy.compute_warping_slopes(
-            ...     distances_to_endpoint=distances_to_endpoint,
-            ... )
-
-            >>> slopes[2, 3]
-            array([[ nan,  nan,  nan],
-                   [ 1.5,  1. ,  0.5],
-                   [ 3. ,  2. ,  1. ]])
-
-            Irregular case:
-            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            >>> slopes = energy.compute_warping_slopes(
-            ...     distances_to_endpoint=distances_to_endpoint,
-            ... )
-            >>> slopes[2, 3]
-            array([[        nan,         nan,         nan],
-                   [ 1.06666667,  0.4       ,  0.06666667],
-                   [ 3.2       ,  1.2       ,  0.2       ]])
-
-        """
-        return (
-            distances_to_endpoint[None, :, None, :]
-            / distances_to_endpoint[:, None, :, None]
-        )
-
-    def compute_warpings(
-        self,
-        *,
-        slopes: NDArrayFloat,
-        grid_points: NDArrayFloat,
-        distances_to_endpoint: NDArrayFloat,
-    ) -> NDArrayFloat:
-        """
-        Compute the linear warpings and slopes for all points.
-
-        Args:
-            slopes: The warping slopes.
-            grid_points: The grid points in which functions are
-                measured.
-            distances_to_endpoint: The distance of each candidate
-                point to its endpoint.
-
-        Returns:
-            The array of warpings, that is, an
-            M x M x ``grid_dim`` x ``grid_dim`` x ``(grid_dim + 1)``
-            array, containing for each row and column the
-            warpings to each candidate, evaluated at the
-            grid points.
-
-        Examples:
-            >>> import numpy as np
-
-            Regular case:
-            >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            >>> slopes = energy.compute_warping_slopes(
-            ...     distances_to_endpoint=distances_to_endpoint,
-            ... )
-            >>> warpings = energy.compute_warpings(
-            ...     slopes=slopes,
-            ...     grid_points=grid_points,
-            ...     distances_to_endpoint=distances_to_endpoint,
-            ... )
-            >>> warpings[2, 3]
-            array([[[ 0.   ,  0.   ,  0.   ,  0.   ],
-                    [ 0.   ,  0.   ,  0.   ,  0.   ],
-                    [ 0.   ,  0.   ,  0.   ,  0.   ]],
-                   [[ 0.   ,  0.   ,  0.375,  0.75 ],
-                    [ 0.   ,  0.25 ,  0.5  ,  0.75 ],
-                    [ 0.   ,  0.5  ,  0.625,  0.75 ]],
-                   [[ 0.   , -0.75 ,  0.   ,  0.75 ],
-                    [ 0.   , -0.25 ,  0.25 ,  0.75 ],
-                    [ 0.   ,  0.25 ,  0.5  ,  0.75 ]]])
-
-            Irregular case:
-            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            >>> slopes = energy.compute_warping_slopes(
-            ...     distances_to_endpoint=distances_to_endpoint,
-            ... )
-            >>> warpings = energy.compute_warpings(
-            ...     slopes=slopes,
-            ...     grid_points=grid_points,
-            ...     distances_to_endpoint=distances_to_endpoint,
-            ... )
-            >>> warpings[2, 3]
-            array([[[      0.   ,       0.   ,       0.   ,       0.   ],
-                    [      0.   ,       0.   ,       0.   ,       0.   ],
-                    [      0.   ,       0.   ,       0.   ,       0.   ]],
-                   [[      0.   ,  0.        ,  0.53333333,  0.8       ],
-                    [      0.   ,  0.5       ,  0.7       ,  0.8       ],
-                    [      0.   ,  0.75      ,  0.78333333,  0.8       ]],
-                   [[      0.   , -1.6       ,  0.        ,  0.8       ],
-                    [      0.   , -0.1       ,  0.5       ,  0.8       ],
-                    [      0.   ,  0.65      ,  0.75      ,  0.8       ]]])
-
-        """
-        endpoint_values = grid_points[None, :, None, None, None]
-
-        distances_to_endpoint_expanded = np.concat(
-            (
-                distances_to_endpoint,
-                np.zeros((distances_to_endpoint.shape[0], 1)),
-            ),
-            axis=1,
-        )
-
-        diffs = (
-            slopes[..., None]
-            * distances_to_endpoint_expanded[:, None, None, None, :]
-        )
-
-        warpings = endpoint_values - diffs
-        warpings[np.isnan(warpings)] = 0
-        return warpings
-
-    def compute_quadrature_weights(
-        self,
-        *,
-        row_interval_lengths: NDArrayFloat,
-    ) -> NDArrayFloat:
-        """
-        Return the quadrature weights.
-
-        We use trapezoidal quadrature.
-
-        Args:
-            row_interval_lengths: Length of the intervals for each row.
-
-        Returns:
-            Matrix of quadrature weights. It has the shape
-            M x 1 x ``grid_dim`` x 1 x (``grid_dim`` + 1).
-
-        Examples:
-            Regular case:
-            >>> import numpy as np
-            >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> energy.compute_quadrature_weights(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            array([[[[[ 0.   ,  0.   ,  0.   ,  0.   ]],
-                     [[ 0.   ,  0.   ,  0.   ,  0.   ]],
-                     [[ 0.   ,  0.   ,  0.   ,  0.   ]]]],
-                   [[[[ 0.   ,  0.   ,  0.125,  0.125]],
-                     [[ 0.   ,  0.   ,  0.125,  0.125]],
-                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
-                   [[[[ 0.   ,  0.125,  0.25 ,  0.125]],
-                     [[ 0.   ,  0.125,  0.25 ,  0.125]],
-                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
-                   [[[[ 0.125,  0.25 ,  0.25 ,  0.125]],
-                     [[ 0.   ,  0.125,  0.25 ,  0.125]],
-                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
-                   [[[[ 0.125,  0.25 ,  0.25 ,  0.125]],
-                     [[ 0.   ,  0.125,  0.25 ,  0.125]],
-                     [[ 0.   ,  0.   ,  0.125,  0.125]]]]])
-
-            Irregular case:
-            >>> import numpy as np
-            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
-
-            >>> energy = L2LineEnergy()
-            >>> row_interval_lengths = energy.compute_row_interval_lengths(
-            ...     grid_points=grid_points,
-            ...     grid_dim=3,
-            ... )
-            >>> energy.compute_quadrature_weights(
-            ...     row_interval_lengths=row_interval_lengths,
-            ... )
-            array([[[[[ 0.   ,  0.   ,  0.   ,  0.   ]],
-                     [[ 0.   ,  0.   ,  0.   ,  0.   ]],
-                     [[ 0.   ,  0.   ,  0.   ,  0.   ]]]],
-                   [[[[ 0.   ,  0.   ,  0.25 ,  0.25 ]],
-                     [[ 0.   ,  0.   ,  0.25 ,  0.25 ]],
-                     [[ 0.   ,  0.   ,  0.25 ,  0.25 ]]]],
-                   [[[[ 0.   ,  0.25 ,  0.375,  0.125]],
-                     [[ 0.   ,  0.25 ,  0.375,  0.125]],
-                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
-                   [[[[ 0.25 ,  0.375,  0.15 ,  0.025]],
-                     [[ 0.   ,  0.125,  0.15 ,  0.025]],
-                     [[ 0.   ,  0.   ,  0.025,  0.025]]]],
-                   [[[[ 0.125,  0.15 ,  0.125,  0.1  ]],
-                     [[ 0.   ,  0.025,  0.125,  0.1  ]],
-                     [[ 0.   ,  0.   ,  0.1  ,  0.1  ]]]]])
-
-        """
-        grid_dim = row_interval_lengths.shape[1]
-
-        row_interval_lengths_expanded = np.concat(
-            (
-                np.zeros((row_interval_lengths.shape[0], 1)),
-                row_interval_lengths,
-                np.zeros((row_interval_lengths.shape[0], 1)),
-            ),
-            axis=1,
-        )
-
-        # Remove NaN
-        row_interval_lengths_expanded[
-            np.isnan(row_interval_lengths_expanded)
-        ] = 0
-
-        row_interval_lengths_left = row_interval_lengths_expanded[:, :-1]
-        row_interval_lengths_right = row_interval_lengths_expanded[:, 1:]
-
-        quadrature_weights_vec = (
-            row_interval_lengths_left + row_interval_lengths_right
-        ) / 2
-
-        quadrature_weights_mat = np.moveaxis(
-            np.tile(
-                quadrature_weights_vec.mT,
-                (grid_dim, 1, 1),
-            ),
-            -1,
-            0,
-        )
-
-        # We set the weights of unused points to 0
-        quadrature_weights = np.triu(
-            quadrature_weights_mat,
-        )
-
-        all_idx = np.arange(row_interval_lengths.shape[0])[:, None]
-        idx = np.arange(grid_dim)
-
-        # Final correction: adjust the weight at the extreme
-        # We need to remove t_i - t_{i-1} only at the leftmost point
-        quadrature_weights[all_idx, idx, idx] -= (
-            row_interval_lengths_left[:, :-1] / 2
-        )
-
-        # Add column dimension
-        return quadrature_weights[:, None, :, None, :]
-
-    def evaluate_target(
-        self,
+        /,
+        original: FDataGrid,
         target: FDataGrid,
         *,
         grid_dim: int,
+    ) -> None:
+        self.grid_points = original.grid_points[0]
+        self.interval_lenghts = np.diff(
+            self.grid_points,
+            prepend=self.grid_points[0],
+        )
+
+        data_matrix = original.data_matrix[..., 0]
+
+        self.data_diff = np.diff(
+            data_matrix,
+            prepend=data_matrix[:, :1],
+        )
+
+        padding_col = np.zeros((data_matrix.shape[0], 1))
+
+        self.left_grid_points = np.concat(
+            (self.grid_points[:1], self.grid_points),
+        )
+
+        diff = np.concat(
+            (self.data_diff, padding_col),
+            axis=1,
+        )
+
+        # First lenght is 0, so skip it
+        # It will only be used multiplied by 0 in that case, anyway
+        diff[:, 1:-1] /= self.interval_lenghts[1:]
+
+        self.left_and_diff = np.stack((
+            np.concat(
+                (data_matrix[:, :1], data_matrix),
+                axis=1,
+            ),
+            diff,
+        ))
+
+    @override
+    def dp_change_row(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        row: int,
+        grid_dim: int,
+    ) -> None:
+        first_row_index = max(0, row - grid_dim)
+        t_row = self.grid_points[row]
+        t_i = self.grid_points[first_row_index:row, None]
+        self.total_interval_length = t_row - t_i
+
+        t = self.grid_points[first_row_index:row + 1]
+        self.l_matrix = (
+            (t - t_i) / self.total_interval_length
+        )[:, None, :]
+
+        self.y_t = target.data_matrix[
+            :,
+            None,
+            None,
+            first_row_index:row + 1,
+            0,
+        ]
+
+        row_interval_lenghts = self.interval_lenghts[
+            first_row_index:row + 1
+        ]
+        quadrature_weights = row_interval_lenghts / 2
+        quadrature_weights[:-1] += row_interval_lenghts[1:] / 2
+
+        # We set the weights of unused points to 0
+        quadrature_weights = np.triu(
+            np.tile(quadrature_weights, (len(t_i), 1)),
+        )
+
+        # Final correction: adjust the weight at the extreme
+        # We need to remove t_i - t_{i-1} only at the leftmost point
+        quadrature_weights_diag = np.diagonal(quadrature_weights)
+        np.fill_diagonal(
+            quadrature_weights,
+            quadrature_weights_diag - row_interval_lenghts[:-1] / 2,
+        )
+
+        # Add column dimension
+        quadrature_weights = quadrature_weights[:, None, :]
+        self.quadrature_weights = quadrature_weights
+
+    def evaluate_fdatagrid_linear_interpolation(
+        self,
+        evaluation_points: NDArrayFloat,
     ) -> NDArrayFloat:
-        """
-        Evaluate target and return the values for each candidate point.
-
-        Args:
-            target: The target function to evaluate.
-            grid_dim: The dimension of the grid of candidate points.
-
-        Returns:
-            A N x `row` array with the evaluated points for each row.
-
-        """
-        data_matrix = target.data_matrix[..., 0]
-        data_matrix_expanded = np.concat(
-            (np.zeros((data_matrix.shape[0], grid_dim)), data_matrix),
-            axis=1,
+        """Evaluate the functions at some points using linear interpolation."""
+        indexes = np.searchsorted(
+            self.grid_points,
+            evaluation_points,
+            side="left",
         )
+        # Extrapolation is not necessary, as the warping values are inside the
+        # domain
 
-        return np.lib.stride_tricks.sliding_window_view(
-            data_matrix_expanded,
-            window_shape=grid_dim + 1,
-            axis=1,
-        )
+        grid_points_prev = self.left_grid_points[indexes]
 
+        interp_parameter = evaluation_points - grid_points_prev
+
+        left, data_diff = np.take(self.left_and_diff, indices=indexes, axis=2)
+
+        left += interp_parameter * data_diff
+        return left  # type: ignore[no-any-return]
 
     @override
     def __call__(  # noqa: WPS210
@@ -724,14 +541,15 @@ class L2LineEnergy(LineEnergyFunction):
         original: FDataGrid,
         target: FDataGrid,
         *,
+        row: int,
+        column: int,
         grid_dim: int,
     ) -> NDArrayFloat:
         r"""
         Compute the line energies for the :math:`L^2` distance.
 
-        This computes the energy line matrix for each row ``row`` and each
-        column ``column``. This is, for each row ``i`` and column ``j``, with
-        ``i < row`` and ``j < column``, the following distance:
+        This computes, for each row ``i`` and column ``j``, with ``i < row``
+        and ``j < column`` the following distance:
 
         .. math::
             d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
@@ -743,77 +561,52 @@ class L2LineEnergy(LineEnergyFunction):
         Args:
             original: Functions to be aligned.
             target: Target function(s) to align to.
+            row: The row index of the candidate point.
+            column: The column index of the candidate point.
             grid_dim: Dimension of the grid used in the alignment
                 algorithm. Only the direct lines from points whose grid
                 separation with the candidate point is less or equal than
                 ``grid_dim`` are considered.
 
         Returns:
-            Energy of direct line warpings to the candidate points. It has the
-            shape M x M x ``grid_dim`` x ``grid_dim``.
+            Energy of direct line warpings to the candidate point.
 
         """
-        grid_points = original.grid_points[0]
+        grid_points = self.grid_points
 
-        row_interval_lengths = self.compute_row_interval_lengths(
-            grid_points=grid_points,
-            grid_dim=grid_dim,
-        )
+        first_column_index = max(0, column - grid_dim)
 
-        distances_to_endpoint = self.compute_distances_to_endpoint(
-            row_interval_lengths=row_interval_lengths,
-        )
+        t_column = grid_points[column]
 
-        warping_slopes = self.compute_warping_slopes(
-            distances_to_endpoint=distances_to_endpoint,
-        )
+        t_j = grid_points[first_column_index:column, None]
 
-        warpings = self.compute_warpings(
-            slopes = warping_slopes,
-            grid_points=grid_points,
-            distances_to_endpoint = distances_to_endpoint,
-        )
+        total_interval_length = self.total_interval_length
 
-        quadrature_weights = self.compute_quadrature_weights(
-            row_interval_lengths=row_interval_lengths,
-        )
+        l_matrix = self.l_matrix
+        w = t_j + l_matrix * (t_column - t_j)
 
         # Shape: N x row x column x t
+        x_t =self.evaluate_fdatagrid_linear_interpolation(w)
 
-        # Linear interpolation
-        interpolator = make_interp_spline(
-            grid_points,
-            original.data_matrix[..., 0].mT,
-            k=1,
-        )
-
-        x_t = np.moveaxis(interpolator(warpings), -1, 0)
-
-        # Shape: N x t
-        y_t = self.evaluate_target(
-            target,
-            grid_dim=grid_dim,
-        )
-
-        warping_slopes_root = np.sqrt(warping_slopes)
+        w_slope = (t_column - t_j.T) / total_interval_length
+        w_slope_root = np.sqrt(w_slope)
 
         if self.slope_scaling:
-            x_t *= warping_slopes_root[None, ..., None]
+            x_t *= w_slope_root[None, ..., None]
 
-        y_t_reshaped = y_t[:, :, None, None, None, :]
-        integrand = x_t
-        integrand -= y_t_reshaped
-        integrand **= 2
+        integrand = (x_t - self.y_t)**2
+
+        quadrature_weights = self.quadrature_weights
+
         integrand *= quadrature_weights
-
         integral = np.sum(integrand, axis=-1)
 
         roughness = self.penalty * (
-            (1 - warping_slopes_root)**2
-            * distances_to_endpoint[:, None, :, None]
+            (1 - w_slope_root)**2 * total_interval_length
         )
 
-        return integral + roughness  # type: ignore[no-any-return]
+        integral += roughness
+        return integral  # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,
@@ -945,13 +738,20 @@ def dynamic_programming_match(  # noqa: WPS210
     energy[:, :, 0] = np.inf
     energy[:, 0, 0] = 0
 
-    line_energies = line_energy_function(
+    line_energy_function.dp_start(
         original,
         target,
         grid_dim=grid_dim,
     )
 
     for row in range(1, n_points):
+
+        line_energy_function.dp_change_row(
+            original,
+            target,
+            grid_dim=grid_dim,
+            row=row,
+        )
 
         for column in range(1, n_points):
             first_row_index = max(0, row - grid_dim)
@@ -963,14 +763,17 @@ def dynamic_programming_match(  # noqa: WPS210
                 first_column_index:column,
             ]
 
-            candidate_points_line_energy = line_energies[
-                :,
-                row,
-                column,
-                -candidate_points_partial_energy.shape[1]:,
-                -candidate_points_partial_energy.shape[2]:,
-            ]
-
+            # This can be further vectorized and extracted
+            # out of the loop, but not sure if it is worth it.
+            # In particular, the memory usage could be much higher for
+            # almost no performance gains.
+            candidate_points_line_energy = line_energy_function(
+                original,
+                target,
+                row=row,
+                column=column,
+                grid_dim=grid_dim,
+            )
             partial_energies = (
                 candidate_points_partial_energy + candidate_points_line_energy
             )

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -322,6 +322,25 @@ class L2LineEnergy:
             As you can see, the results correspond to the lower-right part
             of the complete grid.
 
+            It is also possible to penalize deviations from the identity
+            function:
+
+            >>> l2_line_energy = L2LineEnergy(penalty=1)
+
+            >>> l2_line_energy(
+            ...    original,
+            ...    target,
+            ...    row=3,
+            ...    column=3,
+            ... )
+            array([[[ 0.109375  ,  0.39438019,  0.72558594],
+                    [ 0.08578644,  0.046875  ,  0.14836197],
+                    [ 0.28125   ,  0.04289322,  0.0078125 ]]])
+
+            Note that the terms on the main diagonal are not penalized in this
+            case, as there is no difference in slope with respect to the
+            identity function.
+
         """
         if grid_dim is None:
             grid_dim = max(row, column)
@@ -337,8 +356,10 @@ class L2LineEnergy:
         t_i = grid_points[first_row_index:row, None]
         t_j = grid_points[first_column_index:column, None]
 
+        total_interval_length = t_row - t_i
+
         t = grid_points[first_row_index:row + 1]
-        l_vec = (t - t_i) / (t_row - t_i)
+        l_vec = (t - t_i) / total_interval_length
         l_matrix = l_vec[:, None, :]
         w = (1 - l_matrix) * t_j + l_matrix * t_column
 
@@ -348,7 +369,7 @@ class L2LineEnergy:
         # Shape: N x t
         y_t = target.data_matrix[:, first_row_index:row + 1, 0]
 
-        w_slope = (t_column - t_j.T) / (t_row - t_i)
+        w_slope = (t_column - t_j.T) / total_interval_length
         w_slope_root = np.sqrt(w_slope)
 
         if self.slope_scaling:
@@ -381,7 +402,9 @@ class L2LineEnergy:
 
         integral = np.sum(integrand * quadrature_weights, axis=-1)
 
-        roughness = self.penalty * (1 - w_slope_root)**2
+        roughness = self.penalty * (
+            (1 - w_slope_root)**2 * total_interval_length
+        )
 
         return integral + roughness  # type: ignore[no-any-return]
 

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -31,7 +31,6 @@ class LineEnergyFunction(Protocol):
         original: FDataGrid,
         target: FDataGrid,
         *,
-        grid_points: NDArrayFloat,
         row: int,
         column: int,
     ) -> NDArrayFloat:
@@ -174,108 +173,143 @@ def _dp_recover_warpings(
     return na_interpolator.transform(warpings)
 
 
-def l2_line_energy(
-    original: FDataGrid,
-    target: FDataGrid,
-    *,
-    grid_points: NDArrayFloat,
-    row: int,
-    column: int,
-) -> NDArrayFloat:
+class L2LineEnergy:
     r"""
-    Compute the line energies for the :math:`L^2` distance.
+    L2 line energy with roughness penalty.
 
-    This computes, for each row ``i`` and column ``j``, with ``i < row`` and
-    ```j < column`` the following distance:
+    The energy computed is:
 
     .. math::
-        d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
+            d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
+            + \lambda (1 - \sqrt{w'(t)})^2
 
-    where :math:`w`, the warping, is a straight line, that is,
-    :math:`w(t) = (1 - l) t_j + l t_column` with
-    :math:`l = (t - t_i) / (t_{row} - t_i)`.
+    where :math:`\lambda` is the penalty factor.
 
-    Examples:
-        Consider a simple case with 4 irregularly sampled discretization
-        points:
-
-        >>> import numpy as np
-        >>> grid_points = np.array([0, 0.5, 0.75, 1])
-
-        We use the identity function :math:`x(t) = t` and the piecewise linear
-        function :math:`y(t) = \max(0, 2t - 1)`:
-
-        >>> from skfda import FDataGrid
-        >>> original = FDataGrid(grid_points, grid_points=grid_points)
-        >>> target = FDataGrid(
-        ...     np.maximum(0, 2 * grid_points - 1),
-        ...     grid_points=grid_points,
-        ... )
-
-        We will consider the final case ``row = 3``, ``column=3``:
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_points=grid_points,
-        ...    row=3,
-        ...    column=3,
-        ... )
-        array([[[ 0.14583333,  0.375     ,  0.55208333],
-                [ 0.        ,  0.14583333,  0.328125  ],
-                [ 0.04166667,  0.        ,  0.01041667]]])
-
-        Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
-        This is because they correspond to linear warpings that align
-        perfectly :math:`x` in the intervals :math:`(0.5, 1)` and
-        :math:`(0.75, 1)`, respectively.
-
-        Now consider a possible intermediate case with ``row = 2`` and
-        ``column=1``:
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_points=grid_points,
-        ...    row=2,
-        ...    column=1,
-        ... )
-        array([[[ 0.0625],
-                [ 0.    ]]])
-
-        This has again 0 energy at ``(1, 0)``, because it is possible to
-        align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
+    Args:
+        penalty: The penalization factor. The default, 0, is no penalization.
 
     """
-    t_row = grid_points[row]
-    t_column = grid_points[column]
 
-    t_i = grid_points[:row, None]
-    t_j = grid_points[:column, None]
+    def __init__(self, penalty: float = 0) -> None:
+        self.penalty = penalty
 
-    t = grid_points[:row + 1]
-    l_vec = (t - t_i) / (t_row - t_i)
-    l_matrix = l_vec[:, None, :]
-    w = (1 - l_matrix) * t_j + l_matrix * t_column
+    def __call__(  # noqa: WPS210
+        self,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        row: int,
+        column: int,
+    ) -> NDArrayFloat:
+        r"""
+        Compute the line energies for the :math:`L^2` distance.
 
-    # Shape: N x row x column x t
-    x_t = original(w.reshape(-1)).reshape((len(original), *w.shape))
+        This computes, for each row ``i`` and column ``j``, with ``i < row``
+        and ``j < column`` the following distance:
 
-    # Shape: N x t
-    y_t = target.data_matrix[:, :row + 1, 0]
+        .. math::
+            d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
 
-    integrand = (x_t - y_t[:, None, None, :])**2
+        where :math:`w`, the warping, is a straight line, that is,
+        :math:`w(t) = (1 - l) t_j + l t_column` with
+        :math:`l = (t - t_i) / (t_{row} - t_i)`.
 
-    # Set to 0 the parts that do not contribute to the integral
-    integrand = np.swapaxes(np.triu(np.swapaxes(integrand, 1, 2)), 1, 2)
+        Args:
+            original: Functions to be aligned.
+            target: Target function(s) to align to.
+            row: The row index of the candidate point.
+            column: The column index of the candidate point.
 
-    identity = np.eye(len(t))
-    quadrature_weights = simpson(
-        y=identity,
-        x=t,
-    )
+        Returns:
+            Energy of direct line warpings to the candidate point.
 
-    integral = np.sum(integrand * quadrature_weights, axis=-1)
+        Examples:
+            Consider a simple case with 4 irregularly sampled discretization
+            points:
 
-    return integral  # type: ignore[no-any-return]
+            >>> import numpy as np
+            >>> grid_points = np.array([0, 0.5, 0.75, 1])
+
+            We use the identity function :math:`x(t) = t` and the piecewise
+            linear function :math:`y(t) = \max(0, 2t - 1)`:
+
+            >>> from skfda import FDataGrid
+            >>> original = FDataGrid(grid_points, grid_points=grid_points)
+            >>> target = FDataGrid(
+            ...     np.maximum(0, 2 * grid_points - 1),
+            ...     grid_points=grid_points,
+            ... )
+
+            Consider the default case with no penalization:
+            >>> l2_line_energy = L2LineEnergy()
+
+            We will consider the final case ``row = 3``, ``column=3``:
+            >>> l2_line_energy(
+            ...    original,
+            ...    target,
+            ...    row=3,
+            ...    column=3,
+            ... )
+            array([[[ 0.14583333,  0.375     ,  0.55208333],
+                    [ 0.        ,  0.14583333,  0.328125  ],
+                    [ 0.04166667,  0.        ,  0.01041667]]])
+
+            Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
+            This is because they correspond to linear warpings that align
+            perfectly :math:`x` in the intervals :math:`(0.5, 1)` and
+            :math:`(0.75, 1)`, respectively.
+
+            Now consider a possible intermediate case with ``row = 2`` and
+            ``column=1``:
+            >>> l2_line_energy(
+            ...    original,
+            ...    target,
+            ...    row=2,
+            ...    column=1,
+            ... )
+            array([[[ 0.0625],
+                    [ 0.    ]]])
+
+            This has again 0 energy at ``(1, 0)``, because it is possible to
+            align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
+
+        """
+        grid_points = original.grid_points[0]
+
+        t_row = grid_points[row]
+        t_column = grid_points[column]
+
+        t_i = grid_points[:row, None]
+        t_j = grid_points[:column, None]
+
+        t = grid_points[:row + 1]
+        l_vec = (t - t_i) / (t_row - t_i)
+        l_matrix = l_vec[:, None, :]
+        w = (1 - l_matrix) * t_j + l_matrix * t_column
+
+        # Shape: N x row x column x t
+        x_t = original(w.reshape(-1)).reshape((len(original), *w.shape))
+
+        # Shape: N x t
+        y_t = target.data_matrix[:, :row + 1, 0]
+
+        integrand = (x_t - y_t[:, None, None, :])**2
+
+        # Set to 0 the parts that do not contribute to the integral
+        integrand = np.swapaxes(np.triu(np.swapaxes(integrand, 1, 2)), 1, 2)
+
+        identity = np.eye(len(t))
+        quadrature_weights = simpson(
+            y=identity,
+            x=t,
+        )
+
+        integral = np.sum(integrand * quadrature_weights, axis=-1)
+
+        w_slope = (t_column - t_j.T) / (t_row - t_i)
+        roughness = self.penalty * (1 - np.sqrt(w_slope))**2
+
+        return integral + roughness  # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,
@@ -332,77 +366,58 @@ def dynamic_programming_match(  # noqa: WPS210
         The warpings that align the functions using the DP algorithm.
 
     Examples:
-        Consider a simple case with 5 irregularly sampled discretization
+        Consider a simple case with 100 equally spaced discretization
         points:
 
         >>> import numpy as np
-        >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
+        >>> grid_points = np.linspace(0, 1, 100)
 
-        We want to align the identity function :math:`x_1(t) = t` and the
-        function :math:`x_2(t) = \min(2t, 1)`
-        to the piecewise linear
-        function :math:`y(t) = \max(0, 2t - 1)`:
+        We want to align the functions :math:`x_1(t) = t**2` and the
+        function :math:`x_2(t) = \sin(\frac{\pi}{2} t)`
+        to the identity function :math:`y(t) = t`.
+        All these are functions that start and end at the same points ((0, 0)
+        and (1, 1), respectively), and they are monotonic. Thus, the exact,
+        expected solution for the registration problem with the identity is
+        that the warpings are their inverses:
 
         >>> from skfda import FDataGrid
         >>> original = FDataGrid(
         ...     [
-        ...         grid_points,
-        ...         np.minimum(2 * grid_points, 1),
+        ...         grid_points**2,
+        ...         np.sin(np.pi / 2 * grid_points),
         ...     ],
         ...     grid_points=grid_points,
         ... )
         >>> target = FDataGrid(
-        ...     np.maximum(0, 2 * grid_points - 1),
+        ...     grid_points,
         ...     grid_points=grid_points,
         ... )
 
+        We limit the grid size, for performance reasons:
+        >>> l2_line_energy = L2LineEnergy()
         >>> warpings = dynamic_programming_match(
         ...     original,
         ...     target,
         ...     line_energy_function=l2_line_energy,
+        ...     grid_dim=7,
         ... )
-        >>> warpings
-        FDataGrid(
-            array([[[ 0.  ],
-                    [ 0.  ],
-                    [ 0.  ],
-                    [ 0.5 ],
-                    [ 1.  ]],
-                   [[ 0.  ],
-                    [ 0.  ],
-                    [ 0.  ],
-                    [ 0.25],
-                    [ 1.  ]]]),
-            grid_points=(array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]),),
-        ...)
 
-        >>> eval_target = target(grid_points[..., None])
-        >>> eval_target
-        array([[[ 0. ],
-                [ 0. ],
-                [ 0. ],
-                [ 0.5],
-                [ 1. ]]])
-        >>> eval_warped = original(
-        ...     warpings(grid_points[..., None]),
-        ...     aligned=False,
+        We check now that the found warpings are close to their inverses:
+        >>> np.allclose(
+        ...     warpings.data_matrix[0, ..., 0],
+        ...     np.sqrt(grid_points),
+        ...     atol=0.05,
         ... )
-        >>> eval_warped
-        array([[[ 0. ],
-                [ 0. ],
-                [ 0. ],
-                [ 0.5],
-                [ 1. ]],
-               [[ 0. ],
-                [ 0. ],
-                [ 0. ],
-                [ 0.5],
-                [ 1. ]]])
-        >>> np.allclose(eval_warped[0], eval_target)
+        True
+        >>> np.allclose(
+        ...     warpings.data_matrix[1, ..., 0],
+        ...     2 / np.pi * np.arcsin(grid_points),
+        ...     atol=0.05,
+        ... )
         True
 
-        >>> np.allclose(eval_warped[1], eval_target)
-        True
+        Note that the allowed slopes are restricted by the grid, and thus
+        a small discrepancy is expected.
 
     """
     n_samples = original.n_samples
@@ -413,7 +428,7 @@ def dynamic_programming_match(  # noqa: WPS210
 
     row_indexes = np.zeros((n_samples, n_points, n_points), dtype=np.int64)
     column_indexes = np.zeros((n_samples, n_points, n_points), dtype=np.int64)
-    energy = np.zeros((n_samples, n_points, n_points))
+    energy = np.full((n_samples, n_points, n_points), fill_value=np.inf)
 
     # Discourage jumps from (0, 0) at the beginning
     energy[:, 0, :] = np.inf
@@ -431,7 +446,6 @@ def dynamic_programming_match(  # noqa: WPS210
             candidate_points_line_energy = line_energy_function(
                 original,
                 target,
-                grid_points=grid_points,
                 row=row,
                 column=column,
             )

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -224,6 +224,186 @@ def _refine_grid(
         grid[-1:],
     ))
 
+
+def _compute_integral_lockstep(
+    original: FDataGrid,
+    target: FDataGrid,
+    *,
+    row: int,
+    grid_dim: int,
+    starting_point_index: NDArrayInt,
+    warping_intercepts: NDArrayFloat,
+    warping_slopes: NDArrayFloat,
+    slope_scaling: bool,
+) -> NDArrayFloat:
+    r"""
+    Computes the integral in a lockstep manner, to guarantee accuracy.
+
+    We need to compute the integral of a piecewise function. However, the
+    points at which the function changes slope are not the original ones,
+    but the union of the original grid, and the warped one.
+
+    We can compute this iterating along both curves in a lockstep way.
+    This should not be very inefficient, as there are only 2 times
+    `grid_dim` points.
+
+    Args:
+        original: Functions to be aligned.
+        target: Target function(s) to align to.
+        row: The row index of the candidate point.
+        grid_dim: Dimension of the grid used in the alignment
+            algorithm. Only the direct lines from points whose grid
+            separation with the candidate point is less or equal than
+            ``grid_dim`` are considered.
+        starting_point_index: The index where each warping starts.
+        warping_intercepts: Intercepts of the warping functions.
+        warping_slopes: Slopes of the warping functions.
+        slope_scaling: Wether to scale the original data by the square root
+            of the slope of the interval. This is necessary when we work with
+            the SRSF of the curves instead of with the curves themselves.
+
+    Examples:
+        Consider a simple case with 4 irregularly sampled discretization
+        points:
+
+        >>> import numpy as np
+        >>> grid_points = np.array([0, 0.5, 0.75, 1])
+
+        We use the identity function :math:`x(t) = t` and the piecewise
+        linear function :math:`y(t) = \max(0, 2t - 1)`:
+
+        >>> from skfda import FDataGrid
+        >>> original = FDataGrid(grid_points, grid_points=grid_points)
+        >>> target = FDataGrid(
+        ...     np.maximum(0, 2 * grid_points - 1),
+        ...     grid_points=grid_points,
+        ... )
+
+        Consider the case with the identity warping. The integral should be
+        then 1 / 3.
+
+        >>> _compute_integral_lockstep(
+        ...     original=original,
+        ...     target=target,
+        ...     row=len(grid_points) - 1,
+        ...     grid_dim=len(grid_points),
+        ...     starting_point_index=None,
+        ...     warping_intercepts=0,
+        ...     warping_slopes=1,
+        ...     slope_scaling=False,
+        ... )
+
+        Consider the warping :math:`w(t) = 2t - 1`:
+
+    """
+    warping_slopes_root = np.sqrt(warping_slopes)
+    starting_point_index = np.clip(
+        np.arange(row - grid_dim, row, dtype=np.int64), 
+        0,
+        row,
+    )
+    grid_points = original.grid_points[0]
+    starting_point = grid_points[starting_point_index]
+
+    integrals: float | NDArrayFloat = 0
+
+    point_current = grid_points[starting_point_index]
+
+    original_idx_current = np.copy(starting_point_index)
+    target_idx_current = np.copy(starting_point_index)
+
+    original_value_current = original.data_matrix[:, original_idx_current]
+    target_value_current = target.data_matrix[:, target_idx_current]
+
+    # Loop here until the intervals are fully travelled
+    for _ in range(2 * grid_dim):
+
+        original_idx_next = np.clip(original_idx_current + 1, None, row)
+        target_idx_next = np.clip(target_idx_current + 1, None, row)
+
+        original_point_candidate = (
+            warping_intercepts
+            + warping_slopes * grid_points[original_idx_next]
+        )
+        target_point_candidate = grid_points[target_idx_next]
+
+        next_is_original = (
+            original_point_candidate < target_point_candidate
+        )
+        point_next = np.where(
+            next_is_original,
+            original_point_candidate,
+            target_point_candidate,
+        )
+
+        original_value_current = original.data_matrix[:, original_idx_current]
+        target_value_current = target.data_matrix[:, target_idx_current]
+
+        original_slope_current = (
+            original.data_matrix[:, original_idx_next]
+            - original_value_current
+        ) / (original_point_candidate - point_current)[:, None]
+
+        target_slope_current = (
+            target.data_matrix[:, target_idx_next] - target_value_current
+        ) / (target_point_candidate - point_current)[:, None]
+
+        point_step = point_next - point_current
+
+        original_value_next = (
+            original_value_current
+            + original_slope_current * point_step[:, None]
+        )
+        target_value_next = (
+            target_value_current
+            + target_slope_current * point_step[:, None]
+        )
+
+        x_left = (
+            original_value_current * warping_slopes_root
+            if slope_scaling
+            else original_value_current
+        )
+        x_right = (
+            original_value_next * warping_slopes_root
+            if slope_scaling
+            else original_value_next
+        )
+
+        # Integrate (x-y)^2 over an interval where (x-y) is linear.
+        # Thus f(t) = x(t) - y(t) = at + b
+        # And it follows that the integral between t_0 and t_1 of f^2(t) is
+        # I = Δt/3 (f(t_0)^2 + f(t_0)f(t_1) + f(t_1)^2)
+        left = x_left - target_value_current
+        right = x_right - target_value_next
+
+        interval_integral = (
+            point_step[:, None] / 3 * (left**2 + left * right + right**2)
+        )
+
+        # Remove contribution of warpings that do not have this interval
+        interval_integral[:, point_current < starting_point] = 0
+
+        integrals += interval_integral
+
+        # Update times
+        point_current = point_next
+        original_idx_current = np.where(
+            next_is_original,
+            original_idx_next,
+            original_idx_current,
+        )
+        target_idx_current = np.where(
+            next_is_original,
+            target_idx_current,
+            target_idx_next,
+        )
+        original_value_current = original_value_next
+        target_value_current = target_value_next
+
+    return integrals
+
+
 class L2LineEnergy(LineEnergyFunction):
     r"""
     L2 line energy with roughness penalty.
@@ -475,8 +655,9 @@ class L2LineEnergy(LineEnergyFunction):
         r"""
         Compute the line energies for the :math:`L^2` distance.
 
-        This computes, for each row ``i`` and column ``j``, with ``i < row``
-        and ``j < column`` the following distance:
+        The computation is performed in parallel for each column `column`.
+        For each row ``i`` and column ``j``, with ``i < row``
+        and ``j < column`` it computes the following distance:
 
         .. math::
             d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
@@ -489,7 +670,6 @@ class L2LineEnergy(LineEnergyFunction):
             original: Functions to be aligned.
             target: Target function(s) to align to.
             row: The row index of the candidate point.
-            column: The column index of the candidate point.
             grid_dim: Dimension of the grid used in the alignment
                 algorithm. Only the direct lines from points whose grid
                 separation with the candidate point is less or equal than
@@ -529,6 +709,17 @@ class L2LineEnergy(LineEnergyFunction):
 
         warping_slopes = t_column_minus_t_j.mT / self.total_interval_length
         warping_slopes_root = np.sqrt(warping_slopes)
+
+        integral = _compute_integral_lockstep(
+            original=original,
+            target=target,
+            row=row,
+            grid_dim=grid_dim,
+            starting_point_index=all_t_j,
+            warping_intercepts=all_t_j,
+            warping_slopes=warping_slopes,
+            slope_scaling=self.slope_scaling,
+        )
 
         x_t = np.moveaxis(self.interpolator(warpings), -1, 1)
 

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -4,10 +4,11 @@ This module contains routines related to the registration procedure.
 """
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-from scipy.interpolate import PchipInterpolator
+from scipy.interpolate import PchipInterpolator, make_interp_spline
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -21,55 +22,16 @@ class LineEnergyFunction(Protocol):
     Computes the energies of line segments.
 
     Returns the matrix containing the partial energies of all line
-    segments between a candidate point and the target.
+    segments between all candidate point and all targets.
 
     """
-    def dp_start(
-        self,
-        /,
-        original: FDataGrid,
-        target: FDataGrid,
-        *,
-        grid_dim: int,
-    ) -> None:
-        """
-        Called at the start of the DP algorithm.
-
-        This can be used to cache the needed values that are the
-        same for each row and column.
-
-        """
-
-    def dp_change_row(
-        self,
-        /,
-        original: FDataGrid,
-        target: FDataGrid,
-        *,
-        row: int,
-        grid_dim: int,
-    ) -> None:
-        """
-        Called when a row is changed in the DP algorithm.
-
-        This can be used to cache the needed values that are the
-        same for each row.
-
-        Note:
-            There is no analog function for columns, as the column
-            always change (and it requires less computations, because
-            the integral domain does not change).
-
-        """
-
+    @abstractmethod
     def __call__(
         self,
         /,
         original: FDataGrid,
         target: FDataGrid,
         *,
-        row: int,
-        column: int,
         grid_dim: int,
     ) -> NDArrayFloat:
         """Returns energies of all lines from each candidate point."""
@@ -253,39 +215,17 @@ class L2LineEnergy(LineEnergyFunction):
 
         >>> grid_dim = len(grid_points)
 
-        Before calling it, the DP algorithm will call the ``dp_start``
-        method, at the beginning of the algorithm, to give the opportunity to
-        cache variables that are common for all the candidate points.
-
-        >>> l2_line_energy.dp_start(
+        We will consider the final case ``row = 3``, ``column=3``.
+        >>> line_energies = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ... )
-
-        We will consider the final case ``row = 3``, ``column=3``. Before
-        calling the function, the DP algorithm will call ``dp_change_row``
-        whenever the row is changed, to give the opportunity to
-        cache variables that are common for all the candidate points in
-        the same row.
-
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ... )
-
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ...    column=3,
-        ... )
-        array([[[ 0.109375  ,  0.30859375,  0.47558594],
-                [ 0.        ,  0.046875  ,  0.10546875],
-                [ 0.03125   ,  0.        ,  0.0078125 ]]])
+        >>> line_energies[:, 3, 3]
+        array([[[        nan,         nan,         nan,         nan],
+                [        nan,  0.109375  ,  0.30859375,  0.47558594],
+                [        nan,  0.        ,  0.046875  ,  0.10546875],
+                [        nan,  0.03125   ,  0.        ,  0.0078125 ]]])
 
         Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
         This is because they correspond to linear warpings that align
@@ -294,21 +234,11 @@ class L2LineEnergy(LineEnergyFunction):
 
         Now consider a possible intermediate case with ``row = 2`` and
         ``column=1``:
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=2,
-        ... )
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=2,
-        ...    column=1,
-        ... )
-        array([[[ 0.04166667],
-                [ 0.        ]]])
+        >>> line_energies[:, 2, 1]
+        array([[[        nan,         nan,         nan,         nan],
+                [        nan,         nan,         nan,         nan],
+                [        nan,         nan,         nan,  0.04166667],
+                [        nan,         nan,         nan,  0.        ]]])
 
         This has again 0 energy at ``(1, 0)``, because it is possible to
         align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
@@ -319,52 +249,22 @@ class L2LineEnergy(LineEnergyFunction):
 
         >>> grid_dim = 1
 
-        >>> l2_line_energy.dp_start(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ... )
-
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ... )
-
         >>> grid_1 = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
-        ...    row=3,
-        ...    column=3,
         ... )
-        >>> grid_1
+        >>> grid_1[:, 3, 3]
         array([[[ 0.0078125]]])
 
         >>> grid_dim = 2
-
-        >>> l2_line_energy.dp_start(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ... )
-
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ... )
 
         >>> grid_2 = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
-        ...    row=3,
-        ...    column=3,
         ... )
-        >>> grid_2
+        >>> grid_2[:, 3, 3]
         array([[[ 0.046875  ,  0.10546875],
                 [ 0.        ,  0.0078125 ]]])
 
@@ -378,29 +278,16 @@ class L2LineEnergy(LineEnergyFunction):
 
         >>> grid_dim = len(grid_points)
 
-        >>> l2_line_energy.dp_start(
+        >>> line_energies = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ... )
-
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ... )
-
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ...    column=3,
-        ... )
-        array([[[ 0.109375  ,  0.39438019,  0.72558594],
-                [ 0.08578644,  0.046875  ,  0.14836197],
-                [ 0.28125   ,  0.04289322,  0.0078125 ]]])
+        >>> line_energies[:, 3, 3]
+        array([[[        nan,         nan,         nan,         nan],
+                [        nan,  0.109375  ,  0.39438019,  0.72558594],
+                [        nan,  0.08578644,  0.046875  ,  0.14836197],
+                [        nan,  0.28125   ,  0.04289322,  0.0078125 ]]])
 
         Note that the terms on the main diagonal are not penalized in this
         case, as there is no difference in slope with respect to the
@@ -417,123 +304,419 @@ class L2LineEnergy(LineEnergyFunction):
         self.penalty = penalty
         self.slope_scaling = slope_scaling
 
-    @override
-    def dp_start(
+    def compute_row_interval_lengths(
         self,
-        /,
-        original: FDataGrid,
-        target: FDataGrid,
         *,
+        grid_points: NDArrayFloat,
         grid_dim: int,
-    ) -> None:
-        self.grid_points = original.grid_points[0]
-        self.interval_lenghts = np.diff(
-            self.grid_points,
-            prepend=self.grid_points[0],
+    ) -> NDArrayFloat:
+        """
+        Compute the interval lengths of the candidates for each row/column.
+
+        Args:
+            grid_points: Points of the grid.
+            grid_dim: Dimension of the grid used in the alignment
+                algorithm.
+
+        Returns:
+            A M x ``grid_points`` matrix containing for each row (or column)
+            the interval lengths of all of the points in its grid of
+            candidates.
+
+        Examples:
+            >>> import numpy as np
+            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            array([[  nan,   nan,   nan],
+                   [  nan,   nan,  0.5 ],
+                   [  nan,  0.5 ,  0.25],
+                   [ 0.5 ,  0.25,  0.05],
+                   [ 0.25,  0.05,  0.2 ]])
+
+        """
+        interval_lengths = np.diff(grid_points)
+
+        interval_lengths_expanded = np.concat((
+            np.full((grid_dim), fill_value=np.nan),
+            interval_lengths,
+        ))
+
+        # M x grid_dim
+        return np.lib.stride_tricks.sliding_window_view(
+            interval_lengths_expanded,
+            window_shape=grid_dim,
         )
 
-        data_matrix = original.data_matrix[..., 0]
+    def compute_distances_to_endpoint(
+        self,
+        *,
+        row_interval_lengths: NDArrayFloat,
+    ) -> NDArrayFloat:
+        """
+        Compute the distance to the endpoint of the candidates.
 
-        self.data_diff = np.diff(
-            data_matrix,
-            prepend=data_matrix[:, :1],
+        Args:
+            row_interval_lengths: The array of interval lengths per row.
+
+        Returns:
+            A M x ``grid_points`` matrix containing for each row (or column)
+            the distance of all of the points in its grid of
+            candidates to itself.
+
+        Examples:
+            >>> import numpy as np
+            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> energy.compute_distances_to_endpoint(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            array([[  nan,   nan,   nan],
+                   [  nan,   nan,  0.5 ],
+                   [  nan,  0.75,  0.25],
+                   [ 0.8 ,  0.3 ,  0.05],
+                   [ 0.5 ,  0.25,  0.2 ]])
+
+        """
+        return np.cumulative_sum(
+            row_interval_lengths[:, ::-1],
+            axis=1,
+        )[:, ::-1]
+
+    def compute_warping_slopes(
+        self,
+        *,
+        distances_to_endpoint: NDArrayFloat,
+    ) -> NDArrayFloat:
+        """
+        Compute the y-diffs and slopes of the linear warpings for all points.
+
+        Args:
+            distances_to_endpoint: Array of distances of each candidate point
+                to its endpoint.
+
+        Returns:
+            The array of slopes, that is, an
+            M x M x ``grid_dim`` x ``grid_dim`` array containing
+            the warping slopes.
+
+        Examples:
+            >>> import numpy as np
+
+            Regular case:
+            >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            >>> slopes = energy.compute_warping_slopes(
+            ...     distances_to_endpoint=distances_to_endpoint,
+            ... )
+
+            >>> slopes[2, 3]
+            array([[ nan,  nan,  nan],
+                   [ 1.5,  1. ,  0.5],
+                   [ 3. ,  2. ,  1. ]])
+
+            Irregular case:
+            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            >>> slopes = energy.compute_warping_slopes(
+            ...     distances_to_endpoint=distances_to_endpoint,
+            ... )
+            >>> slopes[2, 3]
+            array([[        nan,         nan,         nan],
+                   [ 1.06666667,  0.4       ,  0.06666667],
+                   [ 3.2       ,  1.2       ,  0.2       ]])
+
+        """
+        return (
+            distances_to_endpoint[None, :, None, :]
+            / distances_to_endpoint[:, None, :, None]
         )
 
-        padding_col = np.zeros((data_matrix.shape[0], 1))
+    def compute_warpings(
+        self,
+        *,
+        slopes: NDArrayFloat,
+        grid_points: NDArrayFloat,
+        distances_to_endpoint: NDArrayFloat,
+    ) -> NDArrayFloat:
+        """
+        Compute the linear warpings and slopes for all points.
 
-        self.left_grid_points = np.concat(
-            (self.grid_points[:1], self.grid_points),
-        )
+        Args:
+            slopes: The warping slopes.
+            grid_points: The grid points in which functions are
+                measured.
+            distances_to_endpoint: The distance of each candidate
+                point to its endpoint.
 
-        diff = np.concat(
-            (self.data_diff, padding_col),
+        Returns:
+            The array of warpings, that is, an
+            M x M x ``grid_dim`` x ``grid_dim`` x ``(grid_dim + 1)``
+            array, containing for each row and column the
+            warpings to each candidate, evaluated at the
+            grid points.
+
+        Examples:
+            >>> import numpy as np
+
+            Regular case:
+            >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            >>> slopes = energy.compute_warping_slopes(
+            ...     distances_to_endpoint=distances_to_endpoint,
+            ... )
+            >>> warpings = energy.compute_warpings(
+            ...     slopes=slopes,
+            ...     grid_points=grid_points,
+            ...     distances_to_endpoint=distances_to_endpoint,
+            ... )
+            >>> warpings[2, 3]
+            array([[[ 0.   ,  0.   ,  0.   ,  0.   ],
+                    [ 0.   ,  0.   ,  0.   ,  0.   ],
+                    [ 0.   ,  0.   ,  0.   ,  0.   ]],
+                   [[ 0.   ,  0.   ,  0.375,  0.75 ],
+                    [ 0.   ,  0.25 ,  0.5  ,  0.75 ],
+                    [ 0.   ,  0.5  ,  0.625,  0.75 ]],
+                   [[ 0.   , -0.75 ,  0.   ,  0.75 ],
+                    [ 0.   , -0.25 ,  0.25 ,  0.75 ],
+                    [ 0.   ,  0.25 ,  0.5  ,  0.75 ]]])
+
+            Irregular case:
+            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> distances_to_endpoint = energy.compute_distances_to_endpoint(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            >>> slopes = energy.compute_warping_slopes(
+            ...     distances_to_endpoint=distances_to_endpoint,
+            ... )
+            >>> warpings = energy.compute_warpings(
+            ...     slopes=slopes,
+            ...     grid_points=grid_points,
+            ...     distances_to_endpoint=distances_to_endpoint,
+            ... )
+            >>> warpings[2, 3]
+            array([[[      0.   ,       0.   ,       0.   ,       0.   ],
+                    [      0.   ,       0.   ,       0.   ,       0.   ],
+                    [      0.   ,       0.   ,       0.   ,       0.   ]],
+                   [[      0.   ,  0.        ,  0.53333333,  0.8       ],
+                    [      0.   ,  0.5       ,  0.7       ,  0.8       ],
+                    [      0.   ,  0.75      ,  0.78333333,  0.8       ]],
+                   [[      0.   , -1.6       ,  0.        ,  0.8       ],
+                    [      0.   , -0.1       ,  0.5       ,  0.8       ],
+                    [      0.   ,  0.65      ,  0.75      ,  0.8       ]]])
+
+        """
+        endpoint_values = grid_points[None, :, None, None, None]
+
+        distances_to_endpoint_expanded = np.concat(
+            (
+                distances_to_endpoint,
+                np.zeros((distances_to_endpoint.shape[0], 1)),
+            ),
             axis=1,
         )
 
-        # First lenght is 0, so skip it
-        # It will only be used multiplied by 0 in that case, anyway
-        diff[:, 1:-1] /= self.interval_lenghts[1:]
+        diffs = (
+            slopes[..., None]
+            * distances_to_endpoint_expanded[:, None, None, None, :]
+        )
 
-        self.left_and_diff = np.stack((
-            np.concat(
-                (data_matrix[:, :1], data_matrix),
-                axis=1,
-            ),
-            diff,
-        ))
+        warpings = endpoint_values - diffs
+        warpings[np.isnan(warpings)] = 0
+        return warpings
 
-    @override
-    def dp_change_row(
+    def compute_quadrature_weights(
         self,
-        /,
-        original: FDataGrid,
-        target: FDataGrid,
         *,
-        row: int,
-        grid_dim: int,
-    ) -> None:
-        first_row_index = max(0, row - grid_dim)
-        t_row = self.grid_points[row]
-        t_i = self.grid_points[first_row_index:row, None]
-        self.total_interval_length = t_row - t_i
+        row_interval_lengths: NDArrayFloat,
+    ) -> NDArrayFloat:
+        """
+        Return the quadrature weights.
 
-        t = self.grid_points[first_row_index:row + 1]
-        self.l_matrix = (
-            (t - t_i) / self.total_interval_length
-        )[:, None, :]
+        We use trapezoidal quadrature.
 
-        self.y_t = target.data_matrix[
-            :,
-            None,
-            None,
-            first_row_index:row + 1,
+        Args:
+            row_interval_lengths: Length of the intervals for each row.
+
+        Returns:
+            Matrix of quadrature weights. It has the shape
+            M x 1 x ``grid_dim`` x 1 x (``grid_dim`` + 1).
+
+        Examples:
+            Regular case:
+            >>> import numpy as np
+            >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> energy.compute_quadrature_weights(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            array([[[[[ 0.   ,  0.   ,  0.   ,  0.   ]],
+                     [[ 0.   ,  0.   ,  0.   ,  0.   ]],
+                     [[ 0.   ,  0.   ,  0.   ,  0.   ]]]],
+                   [[[[ 0.   ,  0.   ,  0.125,  0.125]],
+                     [[ 0.   ,  0.   ,  0.125,  0.125]],
+                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
+                   [[[[ 0.   ,  0.125,  0.25 ,  0.125]],
+                     [[ 0.   ,  0.125,  0.25 ,  0.125]],
+                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
+                   [[[[ 0.125,  0.25 ,  0.25 ,  0.125]],
+                     [[ 0.   ,  0.125,  0.25 ,  0.125]],
+                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
+                   [[[[ 0.125,  0.25 ,  0.25 ,  0.125]],
+                     [[ 0.   ,  0.125,  0.25 ,  0.125]],
+                     [[ 0.   ,  0.   ,  0.125,  0.125]]]]])
+
+            Irregular case:
+            >>> import numpy as np
+            >>> grid_points = np.array([0, 0.5, 0.75, 0.8, 1])
+
+            >>> energy = L2LineEnergy()
+            >>> row_interval_lengths = energy.compute_row_interval_lengths(
+            ...     grid_points=grid_points,
+            ...     grid_dim=3,
+            ... )
+            >>> energy.compute_quadrature_weights(
+            ...     row_interval_lengths=row_interval_lengths,
+            ... )
+            array([[[[[ 0.   ,  0.   ,  0.   ,  0.   ]],
+                     [[ 0.   ,  0.   ,  0.   ,  0.   ]],
+                     [[ 0.   ,  0.   ,  0.   ,  0.   ]]]],
+                   [[[[ 0.   ,  0.   ,  0.25 ,  0.25 ]],
+                     [[ 0.   ,  0.   ,  0.25 ,  0.25 ]],
+                     [[ 0.   ,  0.   ,  0.25 ,  0.25 ]]]],
+                   [[[[ 0.   ,  0.25 ,  0.375,  0.125]],
+                     [[ 0.   ,  0.25 ,  0.375,  0.125]],
+                     [[ 0.   ,  0.   ,  0.125,  0.125]]]],
+                   [[[[ 0.25 ,  0.375,  0.15 ,  0.025]],
+                     [[ 0.   ,  0.125,  0.15 ,  0.025]],
+                     [[ 0.   ,  0.   ,  0.025,  0.025]]]],
+                   [[[[ 0.125,  0.15 ,  0.125,  0.1  ]],
+                     [[ 0.   ,  0.025,  0.125,  0.1  ]],
+                     [[ 0.   ,  0.   ,  0.1  ,  0.1  ]]]]])
+
+        """
+        grid_dim = row_interval_lengths.shape[1]
+
+        row_interval_lengths_expanded = np.concat(
+            (
+                np.zeros((row_interval_lengths.shape[0], 1)),
+                row_interval_lengths,
+                np.zeros((row_interval_lengths.shape[0], 1)),
+            ),
+            axis=1,
+        )
+
+        # Remove NaN
+        row_interval_lengths_expanded[
+            np.isnan(row_interval_lengths_expanded)
+        ] = 0
+
+        row_interval_lengths_left = row_interval_lengths_expanded[:, :-1]
+        row_interval_lengths_right = row_interval_lengths_expanded[:, 1:]
+
+        quadrature_weights_vec = (
+            row_interval_lengths_left + row_interval_lengths_right
+        ) / 2
+
+        quadrature_weights_mat = np.moveaxis(
+            np.tile(
+                quadrature_weights_vec.mT,
+                (grid_dim, 1, 1),
+            ),
+            -1,
             0,
-        ]
-
-        row_interval_lenghts = self.interval_lenghts[
-            first_row_index:row + 1
-        ]
-        quadrature_weights = row_interval_lenghts / 2
-        quadrature_weights[:-1] += row_interval_lenghts[1:] / 2
+        )
 
         # We set the weights of unused points to 0
         quadrature_weights = np.triu(
-            np.tile(quadrature_weights, (len(t_i), 1)),
+            quadrature_weights_mat,
         )
+
+        all_idx = np.arange(row_interval_lengths.shape[0])[:, None]
+        idx = np.arange(grid_dim)
 
         # Final correction: adjust the weight at the extreme
         # We need to remove t_i - t_{i-1} only at the leftmost point
-        quadrature_weights_diag = np.diagonal(quadrature_weights)
-        np.fill_diagonal(
-            quadrature_weights,
-            quadrature_weights_diag - row_interval_lenghts[:-1] / 2,
+        quadrature_weights[all_idx, idx, idx] -= (
+            row_interval_lengths_left[:, :-1] / 2
         )
 
         # Add column dimension
-        quadrature_weights = quadrature_weights[:, None, :]
-        self.quadrature_weights = quadrature_weights
+        return quadrature_weights[:, None, :, None, :]
 
-    def evaluate_fdatagrid_linear_interpolation(
+    def evaluate_target(
         self,
-        evaluation_points: NDArrayFloat,
+        target: FDataGrid,
+        *,
+        grid_dim: int,
     ) -> NDArrayFloat:
-        """Evaluate the functions at some points using linear interpolation."""
-        indexes = np.searchsorted(
-            self.grid_points,
-            evaluation_points,
-            side="left",
+        """
+        Evaluate target and return the values for each candidate point.
+
+        Args:
+            target: The target function to evaluate.
+            grid_dim: The dimension of the grid of candidate points.
+
+        Returns:
+            A N x `row` array with the evaluated points for each row.
+
+        """
+        data_matrix = target.data_matrix[..., 0]
+        data_matrix_expanded = np.concat(
+            (np.zeros((data_matrix.shape[0], grid_dim)), data_matrix),
+            axis=1,
         )
-        # Extrapolation is not necessary, as the warping values are inside the
-        # domain
 
-        grid_points_prev = self.left_grid_points[indexes]
+        return np.lib.stride_tricks.sliding_window_view(
+            data_matrix_expanded,
+            window_shape=grid_dim + 1,
+            axis=1,
+        )
 
-        interp_parameter = evaluation_points - grid_points_prev
-
-        left, data_diff = np.take(self.left_and_diff, indices=indexes, axis=2)
-
-        left += interp_parameter * data_diff
-        return left  # type: ignore[no-any-return]
 
     @override
     def __call__(  # noqa: WPS210
@@ -541,15 +724,14 @@ class L2LineEnergy(LineEnergyFunction):
         original: FDataGrid,
         target: FDataGrid,
         *,
-        row: int,
-        column: int,
         grid_dim: int,
     ) -> NDArrayFloat:
         r"""
         Compute the line energies for the :math:`L^2` distance.
 
-        This computes, for each row ``i`` and column ``j``, with ``i < row``
-        and ``j < column`` the following distance:
+        This computes the energy line matrix for each row ``row`` and each
+        column ``column``. This is, for each row ``i`` and column ``j``, with
+        ``i < row`` and ``j < column``, the following distance:
 
         .. math::
             d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
@@ -561,52 +743,77 @@ class L2LineEnergy(LineEnergyFunction):
         Args:
             original: Functions to be aligned.
             target: Target function(s) to align to.
-            row: The row index of the candidate point.
-            column: The column index of the candidate point.
             grid_dim: Dimension of the grid used in the alignment
                 algorithm. Only the direct lines from points whose grid
                 separation with the candidate point is less or equal than
                 ``grid_dim`` are considered.
 
         Returns:
-            Energy of direct line warpings to the candidate point.
+            Energy of direct line warpings to the candidate points. It has the
+            shape M x M x ``grid_dim`` x ``grid_dim``.
 
         """
-        grid_points = self.grid_points
+        grid_points = original.grid_points[0]
 
-        first_column_index = max(0, column - grid_dim)
+        row_interval_lengths = self.compute_row_interval_lengths(
+            grid_points=grid_points,
+            grid_dim=grid_dim,
+        )
 
-        t_column = grid_points[column]
+        distances_to_endpoint = self.compute_distances_to_endpoint(
+            row_interval_lengths=row_interval_lengths,
+        )
 
-        t_j = grid_points[first_column_index:column, None]
+        warping_slopes = self.compute_warping_slopes(
+            distances_to_endpoint=distances_to_endpoint,
+        )
 
-        total_interval_length = self.total_interval_length
+        warpings = self.compute_warpings(
+            slopes = warping_slopes,
+            grid_points=grid_points,
+            distances_to_endpoint = distances_to_endpoint,
+        )
 
-        l_matrix = self.l_matrix
-        w = t_j + l_matrix * (t_column - t_j)
+        quadrature_weights = self.compute_quadrature_weights(
+            row_interval_lengths=row_interval_lengths,
+        )
 
         # Shape: N x row x column x t
-        x_t =self.evaluate_fdatagrid_linear_interpolation(w)
 
-        w_slope = (t_column - t_j.T) / total_interval_length
-        w_slope_root = np.sqrt(w_slope)
+        # Linear interpolation
+        interpolator = make_interp_spline(
+            grid_points,
+            original.data_matrix[..., 0].mT,
+            k=1,
+        )
+
+        x_t = np.moveaxis(interpolator(warpings), -1, 0)
+
+        # Shape: N x t
+        y_t = self.evaluate_target(
+            target,
+            grid_dim=grid_dim,
+        )
+
+        warping_slopes_root = np.sqrt(warping_slopes)
 
         if self.slope_scaling:
-            x_t *= w_slope_root[None, ..., None]
+            x_t *= warping_slopes_root[None, ..., None]
 
-        integrand = (x_t - self.y_t)**2
-
-        quadrature_weights = self.quadrature_weights
-
+        y_t_reshaped = y_t[:, :, None, None, None, :]
+        integrand = x_t
+        integrand -= y_t_reshaped
+        integrand **= 2
         integrand *= quadrature_weights
+
         integral = np.sum(integrand, axis=-1)
 
         roughness = self.penalty * (
-            (1 - w_slope_root)**2 * total_interval_length
+            (1 - warping_slopes_root)**2
+            * distances_to_endpoint[:, None, :, None]
         )
 
-        integral += roughness
-        return integral  # type: ignore[no-any-return]
+        return integral + roughness  # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,
@@ -738,20 +945,13 @@ def dynamic_programming_match(  # noqa: WPS210
     energy[:, :, 0] = np.inf
     energy[:, 0, 0] = 0
 
-    line_energy_function.dp_start(
+    line_energies = line_energy_function(
         original,
         target,
         grid_dim=grid_dim,
     )
 
     for row in range(1, n_points):
-
-        line_energy_function.dp_change_row(
-            original,
-            target,
-            grid_dim=grid_dim,
-            row=row,
-        )
 
         for column in range(1, n_points):
             first_row_index = max(0, row - grid_dim)
@@ -763,17 +963,14 @@ def dynamic_programming_match(  # noqa: WPS210
                 first_column_index:column,
             ]
 
-            # This can be further vectorized and extracted
-            # out of the loop, but not sure if it is worth it.
-            # In particular, the memory usage could be much higher for
-            # almost no performance gains.
-            candidate_points_line_energy = line_energy_function(
-                original,
-                target,
-                row=row,
-                column=column,
-                grid_dim=grid_dim,
-            )
+            candidate_points_line_energy = line_energies[
+                :,
+                row,
+                column,
+                -candidate_points_partial_energy.shape[1]:,
+                -candidate_points_partial_energy.shape[2]:,
+            ]
+
             partial_energies = (
                 candidate_points_partial_energy + candidate_points_line_energy
             )

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
+import numba
 from scipy.interpolate import PchipInterpolator, make_interp_spline
 from typing_extensions import override
 
@@ -717,6 +718,86 @@ class L2LineEnergy(LineEnergyFunction):
             axis=1,
         )
 
+    @staticmethod
+    def compute_integral_generic(
+        *,
+        grid_points: NDArrayFloat,
+        original_data_matrix: NDArrayFloat,
+        warpings: NDArrayFloat,
+        y_t: NDArrayFloat,
+        warping_slopes_root: NDArrayFloat,
+        quadrature_weights: NDArrayFloat,
+        roughness: NDArrayFloat,
+        slope_scaling: bool
+    ) -> NDArrayFloat:
+        # Linear interpolation
+        interpolator = make_interp_spline(
+            grid_points,
+            original_data_matrix.mT,
+            k=1,
+        )
+
+        x_t = np.moveaxis(interpolator(warpings), -1, 0)
+
+        if slope_scaling:
+            x_t *= warping_slopes_root[None, ..., None]
+
+        y_t_reshaped = y_t[:, :, None, None, None, :]
+        integrand = x_t  # x_t is not used anymore
+        integrand -= y_t_reshaped
+
+        # Compute integrand**2 * quadrature_weights and
+        # sum over the last axis.
+        integral = np.einsum(
+            "nxyijk,nxyijk,xyijk->nxyij",
+            integrand,
+            integrand,
+            quadrature_weights,
+        )
+
+        integral += roughness
+        return integral
+
+    @staticmethod
+    @numba.jit
+    def compute_integral_numba(
+        *,
+        grid_points: NDArrayFloat,
+        original_data_matrix: NDArrayFloat,
+        warpings: NDArrayFloat,
+        y_t: NDArrayFloat,
+        warping_slopes_root: NDArrayFloat,
+        quadrature_weights: NDArrayFloat,
+        roughness: NDArrayFloat,
+        slope_scaling: bool
+    ) -> NDArrayFloat:
+        # Linear interpolation
+        x_t = np.empty((original_data_matrix.shape[0], *warpings.shape))
+
+        for sample in range(x_t.shape[0]):
+            x_t[sample] = np.reshape(
+                np.interp(
+                    warpings.ravel(),
+                    grid_points,
+                    original_data_matrix[sample],
+                ),
+                shape=warpings.shape,
+            )
+
+        if slope_scaling:
+            x_t *= warping_slopes_root[None, ..., None]
+
+        y_t_reshaped = y_t[:, :, None, None, None, :]
+        integrand = x_t  # x_t is not used anymore
+        integrand -= y_t_reshaped
+
+        integrand **= 2
+        integrand *= quadrature_weights
+
+        integral = np.sum(integrand, axis=-1)
+
+        integral += roughness
+        return integral
 
     @override
     def __call__(  # noqa: WPS210
@@ -778,16 +859,12 @@ class L2LineEnergy(LineEnergyFunction):
             row_interval_lengths=row_interval_lengths,
         )
 
-        # Shape: N x row x column x t
+        warping_slopes_root = np.sqrt(warping_slopes)
 
-        # Linear interpolation
-        interpolator = make_interp_spline(
-            grid_points,
-            original.data_matrix[..., 0].mT,
-            k=1,
+        roughness = self.penalty * (
+            (1 - warping_slopes_root)**2
+            * distances_to_endpoint[:, None, :, None]
         )
-
-        x_t = np.moveaxis(interpolator(warpings), -1, 0)
 
         # Shape: N x t
         y_t = self.evaluate_target(
@@ -795,31 +872,16 @@ class L2LineEnergy(LineEnergyFunction):
             grid_dim=grid_dim,
         )
 
-        warping_slopes_root = np.sqrt(warping_slopes)
-
-        if self.slope_scaling:
-            x_t *= warping_slopes_root[None, ..., None]
-
-        y_t_reshaped = y_t[:, :, None, None, None, :]
-        integrand = x_t  # x_t is not used anymore
-        integrand -= y_t_reshaped
-
-        # Compute integrand**2 * quadrature_weights and
-        # sum over the last axis.
-        integral = np.einsum(
-            "nxyijk,nxyijk,xyijk->nxyij",
-            integrand,
-            integrand,
-            quadrature_weights,
+        return self.compute_integral_numba(
+            grid_points=grid_points,
+            original_data_matrix=original.data_matrix[..., 0],
+            warpings=warpings,
+            y_t=y_t,
+            warping_slopes_root=warping_slopes_root,
+            quadrature_weights=quadrature_weights,
+            roughness=roughness,
+            slope_scaling=self.slope_scaling,
         )
-
-        roughness = self.penalty * (
-            (1 - warping_slopes_root)**2
-            * distances_to_endpoint[:, None, :, None]
-        )
-
-        integral += roughness
-        return integral # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -10,8 +10,6 @@ import numpy as np
 from scipy.interpolate import PchipInterpolator
 from typing_extensions import override
 
-from ._utils import evaluate_fdatagrid_linear_interpolation
-
 if TYPE_CHECKING:
     from ..representation import FDataGrid
     from ..typing._base import DomainRangeLike
@@ -434,6 +432,36 @@ class L2LineEnergy(LineEnergyFunction):
             prepend=self.grid_points[0],
         )
 
+        data_matrix = original.data_matrix[..., 0]
+
+        self.data_diff = np.diff(
+            data_matrix,
+            prepend=data_matrix[:, :1],
+        )
+
+        padding_col = np.zeros((data_matrix.shape[0], 1))
+
+        self.left_grid_points = np.concat(
+            (self.grid_points[:1], self.grid_points),
+        )
+
+        diff = np.concat(
+            (self.data_diff, padding_col),
+            axis=1,
+        )
+
+        # First lenght is 0, so skip it
+        # It will only be used multiplied by 0 in that case, anyway
+        diff[:, 1:-1] /= self.interval_lenghts[1:]
+
+        self.left_and_diff = np.stack((
+            np.concat(
+                (data_matrix[:, :1], data_matrix),
+                axis=1,
+            ),
+            diff,
+        ))
+
     @override
     def dp_change_row(
         self,
@@ -454,7 +482,13 @@ class L2LineEnergy(LineEnergyFunction):
             (t - t_i) / self.total_interval_length
         )[:, None, :]
 
-        self.y_t = target.data_matrix[:, first_row_index:row + 1, 0]
+        self.y_t = target.data_matrix[
+            :,
+            None,
+            None,
+            first_row_index:row + 1,
+            0,
+        ]
 
         row_interval_lenghts = self.interval_lenghts[
             first_row_index:row + 1
@@ -478,6 +512,28 @@ class L2LineEnergy(LineEnergyFunction):
         # Add column dimension
         quadrature_weights = quadrature_weights[:, None, :]
         self.quadrature_weights = quadrature_weights
+
+    def evaluate_fdatagrid_linear_interpolation(
+        self,
+        evaluation_points: NDArrayFloat,
+    ) -> NDArrayFloat:
+        """Evaluate the functions at some points using linear interpolation."""
+        indexes = np.searchsorted(
+            self.grid_points,
+            evaluation_points,
+            side="left",
+        )
+        # Extrapolation is not necessary, as the warping values are inside the
+        # domain
+
+        grid_points_prev = self.left_grid_points[indexes]
+
+        interp_parameter = evaluation_points - grid_points_prev
+
+        left, data_diff = np.take(self.left_and_diff, indices=indexes, axis=2)
+
+        left += interp_parameter * data_diff
+        return left  # type: ignore[no-any-return]
 
     @override
     def __call__(  # noqa: WPS210
@@ -527,17 +583,10 @@ class L2LineEnergy(LineEnergyFunction):
         total_interval_length = self.total_interval_length
 
         l_matrix = self.l_matrix
-        w = (1 - l_matrix) * t_j + l_matrix * t_column
-        w_flat = w.reshape(-1)
+        w = t_j + l_matrix * (t_column - t_j)
 
         # Shape: N x row x column x t
-        x_t_flat = evaluate_fdatagrid_linear_interpolation(original, w_flat)
-        x_t = x_t_flat.reshape(
-            (len(original), *w.shape),
-        )
-
-        # Shape: N x t
-        y_t = self.y_t
+        x_t =self.evaluate_fdatagrid_linear_interpolation(w)
 
         w_slope = (t_column - t_j.T) / total_interval_length
         w_slope_root = np.sqrt(w_slope)
@@ -545,7 +594,7 @@ class L2LineEnergy(LineEnergyFunction):
         if self.slope_scaling:
             x_t *= w_slope_root[None, ..., None]
 
-        integrand = (x_t - y_t[:, None, None, :])**2
+        integrand = (x_t - self.y_t)**2
 
         quadrature_weights = self.quadrature_weights
 

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -549,13 +549,15 @@ class L2LineEnergy(LineEnergyFunction):
 
         quadrature_weights = self.quadrature_weights
 
-        integral = np.sum(integrand * quadrature_weights, axis=-1)
+        integrand *= quadrature_weights
+        integral = np.sum(integrand, axis=-1)
 
         roughness = self.penalty * (
             (1 - w_slope_root)**2 * total_interval_length
         )
 
-        return integral + roughness  # type: ignore[no-any-return]
+        integral += roughness
+        return integral  # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-from scipy.interpolate import make_interp_spline, PchipInterpolator
+from numpy.lib.stride_tricks import sliding_window_view
+from scipy.interpolate import PchipInterpolator, make_interp_spline
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -40,28 +41,6 @@ class LineEnergyFunction(Protocol):
 
         """
 
-    def dp_change_row(
-        self,
-        /,
-        original: FDataGrid,
-        target: FDataGrid,
-        *,
-        row: int,
-        grid_dim: int,
-    ) -> None:
-        """
-        Called when a row is changed in the DP algorithm.
-
-        This can be used to cache the needed values that are the
-        same for each row.
-
-        Note:
-            There is no analog function for columns, as the column
-            always change (and it requires less computations, because
-            the integral domain does not change).
-
-        """
-
     def __call__(
         self,
         /,
@@ -69,7 +48,6 @@ class LineEnergyFunction(Protocol):
         target: FDataGrid,
         *,
         row: int,
-        column: int,
         grid_dim: int,
     ) -> NDArrayFloat:
         """Returns energies of all lines from each candidate point."""
@@ -263,29 +241,19 @@ class L2LineEnergy(LineEnergyFunction):
         ...    grid_dim=grid_dim,
         ... )
 
-        We will consider the final case ``row = 3``, ``column=3``. Before
-        calling the function, the DP algorithm will call ``dp_change_row``
-        whenever the row is changed, to give the opportunity to
-        cache variables that are common for all the candidate points in
-        the same row.
+        We will consider the final case ``row = 3``, ``column=3``.
 
-        >>> l2_line_energy.dp_change_row(
+        >>> energies = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ...    row=3,
         ... )
-
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ...    column=3,
-        ... )
-        array([[[ 0.109375  ,  0.30859375,  0.47558594],
-                [ 0.        ,  0.046875  ,  0.10546875],
-                [ 0.03125   ,  0.        ,  0.0078125 ]]])
+        >>> energies[:, 3]
+        array([[[        inf,         inf,         inf,         inf],
+                [        inf,  0.109375  ,  0.30859375,  0.47558594],
+                [        inf,  0.        ,  0.046875  ,  0.10546875],
+                [        inf,  0.03125   ,  0.        ,  0.0078125 ]]])
 
         Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
         This is because they correspond to linear warpings that align
@@ -294,21 +262,18 @@ class L2LineEnergy(LineEnergyFunction):
 
         Now consider a possible intermediate case with ``row = 2`` and
         ``column=1``:
-        >>> l2_line_energy.dp_change_row(
+
+        >>> energies = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ...    row=2,
         ... )
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=2,
-        ...    column=1,
-        ... )
-        array([[[ 0.04166667],
-                [ 0.        ]]])
+        >>> energies[:, 1]
+        array([[[        inf,         inf,         inf,         inf],
+                [        inf,         inf,         inf,         inf],
+                [        inf,         inf,         inf,  0.04166667],
+                [        inf,         inf,         inf,  0.        ]]])
 
         This has again 0 energy at ``(1, 0)``, because it is possible to
         align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
@@ -325,21 +290,13 @@ class L2LineEnergy(LineEnergyFunction):
         ...    grid_dim=grid_dim,
         ... )
 
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ... )
-
         >>> grid_1 = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ...    row=3,
-        ...    column=3,
         ... )
-        >>> grid_1
+        >>> grid_1[:, 3]
         array([[[ 0.0078125]]])
 
         >>> grid_dim = 2
@@ -350,21 +307,13 @@ class L2LineEnergy(LineEnergyFunction):
         ...    grid_dim=grid_dim,
         ... )
 
-        >>> l2_line_energy.dp_change_row(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ... )
-
         >>> grid_2 = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ...    row=3,
-        ...    column=3,
         ... )
-        >>> grid_2
+        >>> grid_2[:, 3]
         array([[[ 0.046875  ,  0.10546875],
                 [ 0.        ,  0.0078125 ]]])
 
@@ -384,23 +333,17 @@ class L2LineEnergy(LineEnergyFunction):
         ...    grid_dim=grid_dim,
         ... )
 
-        >>> l2_line_energy.dp_change_row(
+        >>> energies = l2_line_energy(
         ...    original,
         ...    target,
         ...    grid_dim=grid_dim,
         ...    row=3,
         ... )
-
-        >>> l2_line_energy(
-        ...    original,
-        ...    target,
-        ...    grid_dim=grid_dim,
-        ...    row=3,
-        ...    column=3,
-        ... )
-        array([[[ 0.109375  ,  0.39438019,  0.72558594],
-                [ 0.08578644,  0.046875  ,  0.14836197],
-                [ 0.28125   ,  0.04289322,  0.0078125 ]]])
+        >>> energies[:, 3]
+        array([[[        inf,         inf,         inf,         inf],
+                [        inf,  0.109375  ,  0.39438019,  0.72558594],
+                [        inf,  0.08578644,  0.046875  ,  0.14836197],
+                [        inf,  0.28125   ,  0.04289322,  0.0078125 ]]])    
 
         Note that the terms on the main diagonal are not penalized in this
         case, as there is no difference in slope with respect to the
@@ -427,9 +370,19 @@ class L2LineEnergy(LineEnergyFunction):
         grid_dim: int,
     ) -> None:
         self.grid_points = original.grid_points[0]
-        self.interval_lenghts = np.diff(
+        self.grid_points_extended = np.pad(
+            self.grid_points,
+            (grid_dim, 0),
+            constant_values=np.nan,
+        )
+        interval_lenghts = np.diff(
             self.grid_points,
             prepend=self.grid_points[0],
+        )
+        self.interval_lenghts_extended = np.pad(
+            interval_lenghts,
+            (grid_dim, 0),
+            constant_values=np.nan,
         )
 
         self.interpolator = make_interp_spline(
@@ -438,8 +391,22 @@ class L2LineEnergy(LineEnergyFunction):
             k=1,
         )
 
-    @override
-    def dp_change_row(
+        self.target_data_matrix_extended = np.concat(
+            (
+            np.full(
+                (
+                    target.data_matrix.shape[0],
+                    grid_dim, 
+                    target.data_matrix.shape[2],
+                ),
+                fill_value=0,
+            ),
+            target.data_matrix,
+            ),
+            axis=1,
+        )
+
+    def compute_row_quantities(
         self,
         /,
         original: FDataGrid,
@@ -448,33 +415,32 @@ class L2LineEnergy(LineEnergyFunction):
         row: int,
         grid_dim: int,
     ) -> None:
-        first_row_index = max(0, row - grid_dim)
         t_row = self.grid_points[row]
-        t_i = self.grid_points[first_row_index:row, None]
+        t_i = self.grid_points_extended[row:row + grid_dim, None]
         self.total_interval_length = t_row - t_i
 
-        t = self.grid_points[first_row_index:row + 1]
+        t = self.grid_points_extended[row:row + grid_dim + 1]
         self.l_matrix = (
             (t - t_i) / self.total_interval_length
         )[:, None, :]
 
-        self.y_t = target.data_matrix[
+        self.y_t = self.target_data_matrix_extended[
             :,
             None,
             None,
-            first_row_index:row + 1,
+            row:row + grid_dim + 1,
             0,
         ]
 
-        row_interval_lenghts = self.interval_lenghts[
-            first_row_index:row + 1
+        row_interval_lenghts = self.interval_lenghts_extended[
+            row:row + grid_dim + 1
         ]
         quadrature_weights = row_interval_lenghts / 2
         quadrature_weights[:-1] += row_interval_lenghts[1:] / 2
 
         # We set the weights of unused points to 0
         quadrature_weights = np.triu(
-            np.tile(quadrature_weights, (len(t_i), 1)),
+            np.tile(quadrature_weights, (grid_dim, 1)),
         )
 
         # Final correction: adjust the weight at the extreme
@@ -487,6 +453,7 @@ class L2LineEnergy(LineEnergyFunction):
 
         # Add column dimension
         quadrature_weights = quadrature_weights[:, None, :]
+        quadrature_weights[np.isnan(quadrature_weights)] = 0
         self.quadrature_weights = quadrature_weights
 
     @override
@@ -496,7 +463,6 @@ class L2LineEnergy(LineEnergyFunction):
         target: FDataGrid,
         *,
         row: int,
-        column: int,
         grid_dim: int,
     ) -> NDArrayFloat:
         r"""
@@ -526,27 +492,43 @@ class L2LineEnergy(LineEnergyFunction):
             Energy of direct line warpings to the candidate point.
 
         """
+        self.compute_row_quantities(
+            original=original,
+            target=target,
+            row=row,
+            grid_dim=grid_dim,
+        )
+
         grid_points = self.grid_points
+        grid_points_extended = np.concat((
+            np.full((grid_dim,), fill_value=np.nan),
+            self.grid_points,
+        ))
 
-        first_column_index = max(0, column - grid_dim)
-
-        t_column = grid_points[column]
-
-        t_j = grid_points[first_column_index:column, None]
-
-        total_interval_length = self.total_interval_length
+        all_t_j = sliding_window_view(
+            grid_points_extended,
+            grid_dim,
+        )[:-1]
 
         l_matrix = self.l_matrix
-        w = t_j + l_matrix * (t_column - t_j)
 
-        # Shape: N x row x column x t
-        x_t = np.moveaxis(self.interpolator(w), -1, 0)
+        t_column_minus_t_j = (grid_points[:, None] - all_t_j)[..., None]
 
-        w_slope = (t_column - t_j.T) / total_interval_length
-        w_slope_root = np.sqrt(w_slope)
+        warpings = (
+            all_t_j[:, None, :, None]
+            + l_matrix[None, ...] * t_column_minus_t_j[:, None, :, :]
+        )
+        warpings[np.isnan(warpings)] = 0
+
+        warping_slopes = t_column_minus_t_j.mT / self.total_interval_length
+        warping_slopes_root = np.sqrt(warping_slopes)
+
+        x_t = np.moveaxis(self.interpolator(warpings), -1, 1)
 
         if self.slope_scaling:
-            x_t *= w_slope_root[None, ..., None]
+            x_t *= warping_slopes_root[:, None, ..., None]
+
+        total_interval_length = self.total_interval_length
 
         integrand = x_t
         integrand -= self.y_t
@@ -554,18 +536,22 @@ class L2LineEnergy(LineEnergyFunction):
         # Compute integrand**2 * quadrature_weights and
         # sum over the last axis.
         integral = np.einsum(
-            "nijk,nijk,ijk->nij",
+            "cnijk,cnijk,ijk->cnij",
             integrand,
             integrand,
             self.quadrature_weights,
         )
 
-        roughness = self.penalty * (
-            (1 - w_slope_root)**2 * total_interval_length
+        all_roughness = self.penalty * (
+            (1 - warping_slopes_root)**2 * total_interval_length
         )
 
-        integral += roughness
-        return integral  # type: ignore[no-any-return]
+        integral += all_roughness[:, None, ...]
+
+        line_energies =  np.moveaxis(integral, 0, 1)
+        line_energies[np.isnan(line_energies)] = np.inf
+
+        return line_energies
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,
@@ -690,7 +676,13 @@ def dynamic_programming_match(  # noqa: WPS210
 
     row_indexes = np.zeros((n_samples, n_points, n_points), dtype=np.int64)
     column_indexes = np.zeros((n_samples, n_points, n_points), dtype=np.int64)
-    energy = np.full((n_samples, n_points, n_points), fill_value=np.inf)
+    padded_energy = np.full(
+        (n_samples, n_points + grid_dim, n_points + grid_dim),
+        fill_value=np.inf,
+    )
+    # This is a view, used for convenience. It should be changed when
+    # supporting non-NumPy arrays.
+    energy = padded_energy[:, grid_dim:, grid_dim:]
 
     # Discourage jumps from (0, 0) at the beginning
     energy[:, 0, :] = np.inf
@@ -705,55 +697,49 @@ def dynamic_programming_match(  # noqa: WPS210
 
     for row in range(1, n_points):
 
-        line_energy_function.dp_change_row(
+        partial_energies = line_energy_function(
             original,
             target,
-            grid_dim=grid_dim,
             row=row,
+            grid_dim=grid_dim,
         )
 
-        for column in range(1, n_points):
-            first_row_index = max(0, row - grid_dim)
-            first_column_index = max(0, column - grid_dim)
+        candidate_points_partial_energies = sliding_window_view(
+            padded_energy,
+            grid_dim,
+            axis=2,
+        )
 
-            candidate_points_partial_energy = energy[
+        partial_energies += np.moveaxis(
+            candidate_points_partial_energies[
                 :,
-                first_row_index:row,
-                first_column_index:column,
-            ]
+                row:row + grid_dim,
+                :-1,
+                :,
+            ],
+            2,
+            1,
+        )
 
-            # This can be further vectorized and extracted
-            # out of the loop, but not sure if it is worth it.
-            # In particular, the memory usage could be much higher for
-            # almost no performance gains.
-            candidate_points_line_energy = line_energy_function(
-                original,
-                target,
-                row=row,
-                column=column,
-                grid_dim=grid_dim,
-            )
-            partial_energies = (
-                candidate_points_partial_energy + candidate_points_line_energy
-            )
+        ravel_partial_energies = np.reshape(
+            partial_energies,
+            (n_samples, n_points, -1),
+        )
+        min_idx = np.argmin(ravel_partial_energies, axis=-1)
+        rows_idx, columns_idx = np.unravel_index(
+            min_idx,
+            partial_energies.shape[2:],
+        )
+        rows_idx += row - grid_dim
+        columns_idx += np.arange(n_points)[None, :] - grid_dim
+        row_indexes[:, row] = rows_idx
+        column_indexes[:, row] = columns_idx
 
-            ravel_partial_energies = np.reshape(
-                partial_energies,
-                (n_samples, -1),
-            )
-            min_idx = np.argmin(ravel_partial_energies, axis=-1)
-            rows_idx, columns_idx = np.unravel_index(
-                min_idx,
-                partial_energies.shape[1:],
-            )
-            rows_idx += first_row_index
-            columns_idx += first_column_index
-            row_indexes[:, row, column] = rows_idx
-            column_indexes[:, row, column] = columns_idx
-            energy[:, row, column] = ravel_partial_energies[
-                arange_idx,
-                min_idx,
-            ]
+        energy[:, row, :] = ravel_partial_energies[
+            arange_idx[:, None],
+            np.arange(n_points)[None, :],
+            min_idx,
+        ]
 
     return _dp_recover_warpings(
         row_indexes=row_indexes,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -188,11 +188,19 @@ class L2LineEnergy:
 
     Args:
         penalty: The penalization factor. The default, 0, is no penalization.
+        slope_scaling: Wether to scale the original data by the square root
+            of the slope of the interval. This is necessary when we work with
+            the SRSF of the curves instead of with the curves themselves.
 
     """
 
-    def __init__(self, penalty: float = 0) -> None:
+    def __init__(
+        self,
+        penalty: float = 0,
+        slope_scaling: bool = False,
+    ) -> None:
         self.penalty = penalty
+        self.slope_scaling = slope_scaling
 
     def __call__(  # noqa: WPS210
         self,
@@ -340,6 +348,12 @@ class L2LineEnergy:
         # Shape: N x t
         y_t = target.data_matrix[:, first_row_index:row + 1, 0]
 
+        w_slope = (t_column - t_j.T) / (t_row - t_i)
+        w_slope_root = np.sqrt(w_slope)
+
+        if self.slope_scaling:
+            x_t *= w_slope_root[None, ..., None]
+
         integrand = (x_t - y_t[:, None, None, :])**2
 
         identity = np.eye(len(t))
@@ -367,8 +381,7 @@ class L2LineEnergy:
 
         integral = np.sum(integrand * quadrature_weights, axis=-1)
 
-        w_slope = (t_column - t_j.T) / (t_row - t_i)
-        roughness = self.penalty * (1 - np.sqrt(w_slope))**2
+        roughness = self.penalty * (1 - w_slope_root)**2
 
         return integral + roughness  # type: ignore[no-any-return]
 

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -8,7 +8,6 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-import numba
 from scipy.interpolate import PchipInterpolator, make_interp_spline
 from typing_extensions import override
 
@@ -718,86 +717,6 @@ class L2LineEnergy(LineEnergyFunction):
             axis=1,
         )
 
-    @staticmethod
-    def compute_integral_generic(
-        *,
-        grid_points: NDArrayFloat,
-        original_data_matrix: NDArrayFloat,
-        warpings: NDArrayFloat,
-        y_t: NDArrayFloat,
-        warping_slopes_root: NDArrayFloat,
-        quadrature_weights: NDArrayFloat,
-        roughness: NDArrayFloat,
-        slope_scaling: bool
-    ) -> NDArrayFloat:
-        # Linear interpolation
-        interpolator = make_interp_spline(
-            grid_points,
-            original_data_matrix.mT,
-            k=1,
-        )
-
-        x_t = np.moveaxis(interpolator(warpings), -1, 0)
-
-        if slope_scaling:
-            x_t *= warping_slopes_root[None, ..., None]
-
-        y_t_reshaped = y_t[:, :, None, None, None, :]
-        integrand = x_t  # x_t is not used anymore
-        integrand -= y_t_reshaped
-
-        # Compute integrand**2 * quadrature_weights and
-        # sum over the last axis.
-        integral = np.einsum(
-            "nxyijk,nxyijk,xyijk->nxyij",
-            integrand,
-            integrand,
-            quadrature_weights,
-        )
-
-        integral += roughness
-        return integral
-
-    @staticmethod
-    @numba.jit
-    def compute_integral_numba(
-        *,
-        grid_points: NDArrayFloat,
-        original_data_matrix: NDArrayFloat,
-        warpings: NDArrayFloat,
-        y_t: NDArrayFloat,
-        warping_slopes_root: NDArrayFloat,
-        quadrature_weights: NDArrayFloat,
-        roughness: NDArrayFloat,
-        slope_scaling: bool
-    ) -> NDArrayFloat:
-        # Linear interpolation
-        x_t = np.empty((original_data_matrix.shape[0], *warpings.shape))
-
-        for sample in range(x_t.shape[0]):
-            x_t[sample] = np.reshape(
-                np.interp(
-                    warpings.ravel(),
-                    grid_points,
-                    original_data_matrix[sample],
-                ),
-                shape=warpings.shape,
-            )
-
-        if slope_scaling:
-            x_t *= warping_slopes_root[None, ..., None]
-
-        y_t_reshaped = y_t[:, :, None, None, None, :]
-        integrand = x_t  # x_t is not used anymore
-        integrand -= y_t_reshaped
-
-        integrand **= 2
-        integrand *= quadrature_weights
-
-        integral = np.sum(integrand, axis=-1)
-
-        integral += roughness
-        return integral
 
     @override
     def __call__(  # noqa: WPS210
@@ -859,12 +778,16 @@ class L2LineEnergy(LineEnergyFunction):
             row_interval_lengths=row_interval_lengths,
         )
 
-        warping_slopes_root = np.sqrt(warping_slopes)
+        # Shape: N x row x column x t
 
-        roughness = self.penalty * (
-            (1 - warping_slopes_root)**2
-            * distances_to_endpoint[:, None, :, None]
+        # Linear interpolation
+        interpolator = make_interp_spline(
+            grid_points,
+            original.data_matrix[..., 0].mT,
+            k=1,
         )
+
+        x_t = np.moveaxis(interpolator(warpings), -1, 0)
 
         # Shape: N x t
         y_t = self.evaluate_target(
@@ -872,16 +795,31 @@ class L2LineEnergy(LineEnergyFunction):
             grid_dim=grid_dim,
         )
 
-        return self.compute_integral_numba(
-            grid_points=grid_points,
-            original_data_matrix=original.data_matrix[..., 0],
-            warpings=warpings,
-            y_t=y_t,
-            warping_slopes_root=warping_slopes_root,
-            quadrature_weights=quadrature_weights,
-            roughness=roughness,
-            slope_scaling=self.slope_scaling,
+        warping_slopes_root = np.sqrt(warping_slopes)
+
+        if self.slope_scaling:
+            x_t *= warping_slopes_root[None, ..., None]
+
+        y_t_reshaped = y_t[:, :, None, None, None, :]
+        integrand = x_t  # x_t is not used anymore
+        integrand -= y_t_reshaped
+
+        # Compute integrand**2 * quadrature_weights and
+        # sum over the last axis.
+        integral = np.einsum(
+            "nxyijk,nxyijk,xyijk->nxyij",
+            integrand,
+            integrand,
+            quadrature_weights,
         )
+
+        roughness = self.penalty * (
+            (1 - warping_slopes_root)**2
+            * distances_to_endpoint[:, None, :, None]
+        )
+
+        integral += roughness
+        return integral # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -801,25 +801,19 @@ class L2LineEnergy(LineEnergyFunction):
             x_t *= warping_slopes_root[None, ..., None]
 
         y_t_reshaped = y_t[:, :, None, None, None, :]
-        integrand = x_t  # x_t is not used anymore
+        integrand = x_t
         integrand -= y_t_reshaped
+        integrand **= 2
+        integrand *= quadrature_weights
 
-        # Compute integrand**2 * quadrature_weights and
-        # sum over the last axis.
-        integral = np.einsum(
-            "nxyijk,nxyijk,xyijk->nxyij",
-            integrand,
-            integrand,
-            quadrature_weights,
-        )
+        integral = np.sum(integrand, axis=-1)
 
         roughness = self.penalty * (
             (1 - warping_slopes_root)**2
             * distances_to_endpoint[:, None, :, None]
         )
 
-        integral += roughness
-        return integral # type: ignore[no-any-return]
+        return integral + roughness  # type: ignore[no-any-return]
 
 def dynamic_programming_match(  # noqa: WPS210
     original: FDataGrid,

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -4,16 +4,462 @@ This module contains routines related to the registration procedure.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
+from scipy.integrate import simpson
 from scipy.interpolate import PchipInterpolator
-
-from ..typing._base import DomainRangeLike
-from ..typing._numpy import ArrayLike, NDArrayFloat
 
 if TYPE_CHECKING:
     from ..representation import FDataGrid
+    from ..typing._base import DomainRangeLike
+    from ..typing._numpy import ArrayLike, NDArrayFloat, NDArrayInt
+
+
+class LineEnergyFunction(Protocol):
+    """
+    Computes the energies of line segments.
+
+    Returns the matrix containing the partial energies of all line
+    segments between a candidate point and the target.
+
+    """
+
+    def __call__(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        grid_points: NDArrayFloat,
+        row: int,
+        column: int,
+    ) -> NDArrayFloat:
+        """Returns energies of all lines from each candidate point."""
+
+
+def _dp_recover_warpings(
+    row_indexes: NDArrayInt,
+    column_indexes: NDArrayInt,
+    grid_points: NDArrayFloat,
+) -> FDataGrid:
+    """
+    Recover the warpings from the dynamic programming algorithm.
+
+    It goes backwards, from the last point, using the row and column indexes
+    we stored for each point (containing the index of the best candidate
+    point).
+
+    This is iterative and cannot be vectorized, except over samples. Moreover,
+    the number of line segments for each warping may be different. In order to
+    solve that, we use masking for setting only the fixed values, leaving the
+    others as NaN, and then we do linear interpolation over the NaN values.
+
+    Args:
+        row_indexes: Array containing for each position the index of the
+            previous row in the path.
+        column_indexes: Array containing for each position the index of the
+            previous column in the path.
+        grid_points: Grid points of the functions.
+
+    Return:
+        Reconstructed paths.
+
+    Examples:
+        Consider a simple case with 4 discretization points:
+
+        >>> import numpy as np
+        >>> grid_points = np.array([0, 0.33, 0.66, 1])
+
+        We have two samples, and the following indexes matrices (we set to -1
+        the  unused entries for clarity):
+
+        >>> row_indexes = np.array(
+        ...     [
+        ...         [
+        ...             [-1, -1, -1, -1],
+        ...             [-1, -1,  0, -1],
+        ...             [-1, -1, -1, -1],
+        ...             [-1, -1, -1,  1],
+        ...         ],
+        ...         [
+        ...             [-1, -1, -1, -1],
+        ...             [ 0, -1, -1, -1],
+        ...             [-1, -1,  1, -1],
+        ...             [-1, -1, -1,  2],
+        ...         ],
+        ...     ]
+        ... )
+        >>> column_indexes = np.array(
+        ...     [
+        ...         [
+        ...             [-1, -1, -1, -1],
+        ...             [-1, -1,  0, -1],
+        ...             [-1, -1, -1, -1],
+        ...             [-1, -1, -1,  2],
+        ...         ],
+        ...         [
+        ...             [-1, -1, -1, -1],
+        ...             [ 0, -1, -1, -1],
+        ...             [-1, -1,  0, -1],
+        ...             [-1, -1, -1,  2],
+        ...         ],
+        ...     ]
+        ... )
+
+        >>> warpings = _dp_recover_warpings(
+        ...     row_indexes=row_indexes,
+        ...     column_indexes=column_indexes,
+        ...     grid_points=grid_points,
+        ... )
+        >>> warpings.data_matrix
+        array([[[ 0.        ],
+                [ 0.66      ],
+                [ 0.82746269],
+                [ 1.        ]],
+               [[ 0.        ],
+                [ 0.        ],
+                [ 0.66      ],
+                [ 1.        ]]])
+
+    """
+    from ..preprocessing.missing import MissingValuesInterpolation
+    from ..representation import FDataGrid
+
+    n_samples = row_indexes.shape[0]
+    n_points = grid_points.shape[0]
+
+    # Recover the warpings
+    times = np.zeros((n_samples, n_points))
+
+    previous_row_idx: NDArrayInt = np.full(
+        (n_samples,),
+        fill_value=n_points - 1,
+    )
+    previous_column_idx: NDArrayInt = np.full(
+        (n_samples,),
+        fill_value=n_points - 1,
+    )
+
+    arange_idx = np.arange(n_samples)
+
+    for time_idx in reversed(range(n_points)):
+
+        # 1 if we have to set a warping value in this time index, 0 if not
+        index_match = previous_row_idx == time_idx
+
+        warping_values = grid_points[previous_column_idx]
+
+        # We will left as NaN the times to be interpolated linearly.
+        times[:, time_idx] = np.where(index_match, warping_values, np.nan)
+
+        # Find new indexes.
+        previous_row_idx = np.where(
+            index_match,
+            row_indexes[arange_idx, time_idx, previous_column_idx],
+            previous_row_idx,
+        )
+        previous_column_idx = np.where(
+            index_match,
+            column_indexes[arange_idx, time_idx, previous_column_idx],
+            previous_column_idx,
+        )
+
+    warpings = FDataGrid(
+        data_matrix=times,
+        grid_points=grid_points,
+    )
+
+    na_interpolator = MissingValuesInterpolation[FDataGrid]()
+    return na_interpolator.transform(warpings)
+
+
+def l2_line_energy(
+    original: FDataGrid,
+    target: FDataGrid,
+    *,
+    grid_points: NDArrayFloat,
+    row: int,
+    column: int,
+) -> NDArrayFloat:
+    r"""
+    Compute the line energies for the :math:`L^2` distance.
+
+    This computes, for each row ``i`` and column ``j``, with ``i < row`` and
+    ```j < column`` the following distance:
+
+    .. math::
+        d(x, y) = \int_{t_i}^{t_{row}} (x(w(t)) - y(t))^2 dt
+
+    where :math:`w`, the warping, is a straight line, that is,
+    :math:`w(t) = (1 - l) t_j + l t_column` with
+    :math:`l = (t - t_i) / (t_{row} - t_i)`.
+
+    Examples:
+        Consider a simple case with 4 irregularly sampled discretization
+        points:
+
+        >>> import numpy as np
+        >>> grid_points = np.array([0, 0.5, 0.75, 1])
+
+        We use the identity function :math:`x(t) = t` and the piecewise linear
+        function :math:`y(t) = \max(0, 2t - 1)`:
+
+        >>> from skfda import FDataGrid
+        >>> original = FDataGrid(grid_points, grid_points=grid_points)
+        >>> target = FDataGrid(
+        ...     np.maximum(0, 2 * grid_points - 1),
+        ...     grid_points=grid_points,
+        ... )
+
+        We will consider the final case ``row = 3``, ``column=3``:
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_points=grid_points,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        array([[[ 0.14583333,  0.375     ,  0.55208333],
+                [ 0.        ,  0.14583333,  0.328125  ],
+                [ 0.04166667,  0.        ,  0.01041667]]])
+
+        Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
+        This is because they correspond to linear warpings that align
+        perfectly :math:`x` in the intervals :math:`(0.5, 1)` and
+        :math:`(0.75, 1)`, respectively.
+
+        Now consider a possible intermediate case with ``row = 2`` and
+        ``column=1``:
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_points=grid_points,
+        ...    row=2,
+        ...    column=1,
+        ... )
+        array([[[ 0.0625],
+                [ 0.    ]]])
+
+        This has again 0 energy at ``(1, 0)``, because it is possible to
+        align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
+
+    """
+    t_row = grid_points[row]
+    t_column = grid_points[column]
+
+    t_i = grid_points[:row, None]
+    t_j = grid_points[:column, None]
+
+    t = grid_points[:row + 1]
+    l_vec = (t - t_i) / (t_row - t_i)
+    l_matrix = l_vec[:, None, :]
+    w = (1 - l_matrix) * t_j + l_matrix * t_column
+
+    # Shape: N x row x column x t
+    x_t = original(w.reshape(-1)).reshape((len(original), *w.shape))
+
+    # Shape: N x t
+    y_t = target.data_matrix[:, :row + 1, 0]
+
+    integrand = (x_t - y_t[:, None, None, :])**2
+
+    # Set to 0 the parts that do not contribute to the integral
+    integrand = np.swapaxes(np.triu(np.swapaxes(integrand, 1, 2)), 1, 2)
+
+    identity = np.eye(len(t))
+    quadrature_weights = simpson(
+        y=identity,
+        x=t,
+    )
+
+    integral = np.sum(integrand * quadrature_weights, axis=-1)
+
+    return integral  # type: ignore[no-any-return]
+
+def dynamic_programming_match(  # noqa: WPS210
+    original: FDataGrid,
+    target: FDataGrid,
+    *,
+    line_energy_function: LineEnergyFunction,
+) -> FDataGrid:
+    r"""
+    Find an optimal warping to transform a set of curves into another.
+
+    The following assumes that functions are curves in the [0, 1] interval.
+
+    The optimal warping would be one that minimizes the :math:`L^2` distance
+    between the warped function and the target function, called the cost
+    function:
+
+    .. math::
+        \hat{\gamma} = \arg \min_{\gamma \in \Gamma}
+        \int_0^1 (x_1(\gamma(t)) - x_2(t))^2 dt.
+
+    Ideally the optimal warping for the whole function would also be the
+    optimal warping to adjust any part of the function.
+    Thus, we can define a partial cost function
+
+    .. math::
+        E(s, t, \gamma) = \int_s^t (x_1(\gamma(\tau)) - x_2(\tau))^2 d\tau.
+
+    With that definition, the original cost function is
+    :math:`E(0, 1, \gamma)`.
+
+    We can then attempt to minimize the global cost function by discretizing
+    the warping and minimize the partial cost function at each segment.
+
+    As the warping has to be monotonic, the idea is to define a warping as a
+    piecewise function in a :math:`t \times t` grid, with the constraint that
+    the first line segment starts at (0, 0), the final one ends at (1, 1),
+    and each line segment goes from the end of the previous one (i, j), to
+    a point (i + Δi, j + Δj), with Δi and Δj non-negative.
+
+    Then we can, using dynamic programming, compute the minimum partial cost
+    at each point (i, j), considering the partial costs for each point
+    (i', j') with i'< i and j' < j and the partial cost of a line from (i', j')
+    to (i, j).
+
+    The algorithm as described is quadratic in t.
+
+    Args:
+        original: Functions to be aligned.
+        target: Target function(s) to align to.
+        line_energy_function: Function used to compute the energy for a line
+            segment of the warpings.
+
+    Returns:
+        The warpings that align the functions using the DP algorithm.
+
+    Examples:
+        Consider a simple case with 5 irregularly sampled discretization
+        points:
+
+        >>> import numpy as np
+        >>> grid_points = np.array([0, 0.25, 0.5, 0.75, 1])
+
+        We want to align the identity function :math:`x_1(t) = t` and the
+        function :math:`x_2(t) = \min(2t, 1)`
+        to the piecewise linear
+        function :math:`y(t) = \max(0, 2t - 1)`:
+
+        >>> from skfda import FDataGrid
+        >>> original = FDataGrid(
+        ...     [
+        ...         grid_points,
+        ...         np.minimum(2 * grid_points, 1),
+        ...     ],
+        ...     grid_points=grid_points,
+        ... )
+        >>> target = FDataGrid(
+        ...     np.maximum(0, 2 * grid_points - 1),
+        ...     grid_points=grid_points,
+        ... )
+
+        >>> warpings = dynamic_programming_match(
+        ...     original,
+        ...     target,
+        ...     line_energy_function=l2_line_energy,
+        ... )
+        >>> warpings
+        FDataGrid(
+            array([[[ 0.  ],
+                    [ 0.  ],
+                    [ 0.  ],
+                    [ 0.5 ],
+                    [ 1.  ]],
+                   [[ 0.  ],
+                    [ 0.  ],
+                    [ 0.  ],
+                    [ 0.25],
+                    [ 1.  ]]]),
+            grid_points=(array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]),),
+        ...)
+
+        >>> eval_target = target(grid_points[..., None])
+        >>> eval_target
+        array([[[ 0. ],
+                [ 0. ],
+                [ 0. ],
+                [ 0.5],
+                [ 1. ]]])
+        >>> eval_warped = original(
+        ...     warpings(grid_points[..., None]),
+        ...     aligned=False,
+        ... )
+        >>> eval_warped
+        array([[[ 0. ],
+                [ 0. ],
+                [ 0. ],
+                [ 0.5],
+                [ 1. ]],
+               [[ 0. ],
+                [ 0. ],
+                [ 0. ],
+                [ 0.5],
+                [ 1. ]]])
+        >>> np.allclose(eval_warped[0], eval_target)
+        True
+
+        >>> np.allclose(eval_warped[1], eval_target)
+        True
+
+    """
+    n_samples = original.n_samples
+    grid_points = original.grid_points[0]
+    n_points = len(grid_points)
+
+    arange_idx = np.arange(n_samples)
+
+    row_indexes = np.zeros((n_samples, n_points, n_points), dtype=np.int64)
+    column_indexes = np.zeros((n_samples, n_points, n_points), dtype=np.int64)
+    energy = np.zeros((n_samples, n_points, n_points))
+
+    # Discourage jumps from (0, 0) at the beginning
+    energy[:, 0, :] = np.inf
+    energy[:, :, 0] = np.inf
+    energy[:, 0, 0] = 0
+
+    for row in range(1, n_points):
+        for column in range(1, n_points):
+            candidate_points_partial_energy = energy[:, :row, :column]
+
+            # This can be further vectorized and extracted
+            # out of the loop, but not sure if it is worth it.
+            # In particular, the memory usage could be much higher for
+            # almost no performance gains.
+            candidate_points_line_energy = line_energy_function(
+                original,
+                target,
+                grid_points=grid_points,
+                row=row,
+                column=column,
+            )
+            partial_energies = (
+                candidate_points_partial_energy + candidate_points_line_energy
+            )
+
+            ravel_partial_energies = np.reshape(
+                partial_energies,
+                (n_samples, -1),
+            )
+            min_idx = np.argmin(ravel_partial_energies, axis=-1)
+            rows_idx, columns_idx = np.unravel_index(
+                min_idx,
+                partial_energies.shape[1:],
+            )
+            row_indexes[:, row, column] = rows_idx
+            column_indexes[:, row, column] = columns_idx
+            energy[:, row, column] = ravel_partial_energies[
+                arange_idx,
+                min_idx,
+            ]
+
+    return _dp_recover_warpings(
+        row_indexes=row_indexes,
+        column_indexes=column_indexes,
+        grid_points=grid_points,
+    )
 
 
 def invert_warping(

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
-from scipy.integrate import trapezoid
 from scipy.interpolate import PchipInterpolator
+
+from ._utils import evaluate_fdatagrid_linear_interpolation
 
 if TYPE_CHECKING:
     from ..representation import FDataGrid
@@ -362,9 +363,13 @@ class L2LineEnergy:
         l_vec = (t - t_i) / total_interval_length
         l_matrix = l_vec[:, None, :]
         w = (1 - l_matrix) * t_j + l_matrix * t_column
+        w_flat = w.reshape(-1)
 
         # Shape: N x row x column x t
-        x_t = original(w.reshape(-1)).reshape((len(original), *w.shape))
+        x_t_flat = evaluate_fdatagrid_linear_interpolation(original, w_flat)
+        x_t = x_t_flat.reshape(
+            (len(original), *w.shape),
+        )
 
         # Shape: N x t
         y_t = target.data_matrix[:, first_row_index:row + 1, 0]
@@ -377,11 +382,9 @@ class L2LineEnergy:
 
         integrand = (x_t - y_t[:, None, None, :])**2
 
-        identity = np.eye(len(t))
-        quadrature_weights = trapezoid(
-            y=identity,
-            x=t,
-        )
+        interval_lenghts = np.diff(t, prepend=t[0])
+        quadrature_weights = interval_lenghts / 2
+        quadrature_weights[:-1] += interval_lenghts[1:] / 2
 
         # We set the weights of unused points to 0
         quadrature_weights = np.triu(
@@ -390,11 +393,10 @@ class L2LineEnergy:
 
         # Final correction: adjust the weight at the extreme
         # We need to remove t_i - t_{i-1} only at the leftmost point
-        interval_lenghts = np.diff(t, prepend=t[0])[:-1]
         quadrature_weights_diag = np.diagonal(quadrature_weights)
         np.fill_diagonal(
             quadrature_weights,
-            quadrature_weights_diag - interval_lenghts / 2,
+            quadrature_weights_diag - interval_lenghts[:-1] / 2,
         )
 
         # Add column dimension

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -196,6 +196,34 @@ def _dp_recover_warpings(
     return na_interpolator.transform(warpings)
 
 
+def _refine_grid(
+    grid: NDArrayFloat,
+    points_between: int,
+) -> NDArrayFloat:
+    """
+    Make a grid finer adding equispaced points between the original ones.
+
+    Args:
+        grid: The grid to refine.
+        points_between: Number of points to add between each pair of points
+            of the grid.
+
+    Returns:
+        A finer grid, including `points_between` equispaced points between each
+        pair of original points. Its length is
+        N + `points_between` * (N - 1), where N is the number of points
+        originally in `grid`.
+
+    """
+    return np.concat((
+        np.linspace(
+            grid[:-1],
+            grid[1:],
+            points_between + 2, # add extremes
+        ).mT[:, :-1].ravel(),
+        grid[-1:],
+    ))
+
 class L2LineEnergy(LineEnergyFunction):
     r"""
     L2 line energy with roughness penalty.
@@ -258,9 +286,9 @@ class L2LineEnergy(LineEnergyFunction):
         ... )
         >>> energies[:, 3]
         array([[[        inf,         inf,         inf,         inf],
-                [        inf,  0.109375  ,  0.30859375,  0.47558594],
-                [        inf,  0.        ,  0.046875  ,  0.10546875],
-                [        inf,  0.03125   ,  0.        ,  0.0078125 ]]])
+                [        inf,  0.084375  ,  0.29234375,  0.45902344],
+                [        inf,  0.        ,  0.041875  ,  0.09421875],
+                [        inf,  0.02125   ,  0.        ,  0.0053125 ]]])
 
         Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
         This is because they correspond to linear warpings that align
@@ -279,7 +307,7 @@ class L2LineEnergy(LineEnergyFunction):
         >>> energies[:, 1]
         array([[[        inf,         inf,         inf,         inf],
                 [        inf,         inf,         inf,         inf],
-                [        inf,         inf,         inf,  0.04166667],
+                [        inf,         inf,         inf,  0.02833333],
                 [        inf,         inf,         inf,  0.        ]]])
 
         This has again 0 energy at ``(1, 0)``, because it is possible to
@@ -304,7 +332,7 @@ class L2LineEnergy(LineEnergyFunction):
         ...    row=3,
         ... )
         >>> grid_1[:, 3]
-        array([[[ 0.0078125]]])
+        array([[[ 0.00585938]]])
 
         >>> grid_dim = 2
 
@@ -321,8 +349,8 @@ class L2LineEnergy(LineEnergyFunction):
         ...    row=3,
         ... )
         >>> grid_2[:, 3]
-        array([[[ 0.046875  ,  0.10546875],
-                [ 0.        ,  0.0078125 ]]])
+        array([[[ 0.04224537,  0.09505208],
+                [ 0.        ,  0.00549769]]])
 
         As it can be seen, the results correspond to the lower-right part
         of the complete grid.
@@ -348,9 +376,9 @@ class L2LineEnergy(LineEnergyFunction):
         ... )
         >>> energies[:, 3]
         array([[[        inf,         inf,         inf,         inf],
-                [        inf,  0.109375  ,  0.39438019,  0.72558594],
-                [        inf,  0.08578644,  0.046875  ,  0.14836197],
-                [        inf,  0.28125   ,  0.04289322,  0.0078125 ]]])    
+                [        inf,  0.084375  ,  0.37813019,  0.70902344],
+                [        inf,  0.08578644,  0.041875  ,  0.13711197],
+                [        inf,  0.27125   ,  0.04289322,  0.0053125 ]]])
 
         Note that the terms on the main diagonal are not penalized in this
         case, as there is no difference in slope with respect to the
@@ -382,35 +410,11 @@ class L2LineEnergy(LineEnergyFunction):
             (grid_dim, 0),
             constant_values=np.nan,
         )
-        interval_lenghts = np.diff(
-            self.grid_points,
-            prepend=self.grid_points[0],
-        )
-        self.interval_lenghts_extended = np.pad(
-            interval_lenghts,
-            (grid_dim, 0),
-            constant_values=np.nan,
-        )
 
         self.interpolator = make_interp_spline(
             self.grid_points,
             original.data_matrix[..., 0].mT,
             k=1,
-        )
-
-        self.target_data_matrix_extended = np.concat(
-            (
-            np.full(
-                (
-                    target.data_matrix.shape[0],
-                    grid_dim, 
-                    target.data_matrix.shape[2],
-                ),
-                fill_value=0,
-            ),
-            target.data_matrix,
-            ),
-            axis=1,
         )
 
     def compute_row_quantities(
@@ -426,37 +430,33 @@ class L2LineEnergy(LineEnergyFunction):
         t_i = self.grid_points_extended[row:row + grid_dim, None]
         self.total_interval_length = t_row - t_i
 
-        t = self.grid_points_extended[row:row + grid_dim + 1]
+        self.integration_grid = _refine_grid(
+            self.grid_points_extended[row:row + grid_dim + 1],
+            grid_dim,
+        )
         self.l_matrix = (
-            (t - t_i) / self.total_interval_length
+            (self.integration_grid - t_i) / self.total_interval_length
         )[:, None, :]
 
-        self.y_t = self.target_data_matrix_extended[
-            :,
-            None,
-            None,
-            row:row + grid_dim + 1,
-            0,
-        ]
+        self.y_t = target(self.integration_grid)[:, None, None, :, 0]
+        self.y_t[np.isnan(self.y_t)] = 0
 
-        row_interval_lenghts = self.interval_lenghts_extended[
-            row:row + grid_dim + 1
-        ]
+        row_interval_lenghts = np.diff(
+            self.integration_grid,
+            prepend=self.integration_grid[0],
+        )
         quadrature_weights = row_interval_lenghts / 2
         quadrature_weights[:-1] += row_interval_lenghts[1:] / 2
 
         # We set the weights of unused points to 0
-        quadrature_weights = np.triu(
-            np.tile(quadrature_weights, (grid_dim, 1)),
-        )
+        quadrature_weights = np.tile(quadrature_weights, (grid_dim, 1))
+        for i in range(grid_dim):
+            row_idx = i * (grid_dim + 1)
+            quadrature_weights[i, :row_idx] = 0
 
-        # Final correction: adjust the weight at the extreme
-        # We need to remove t_i - t_{i-1} only at the leftmost point
-        quadrature_weights_diag = np.diagonal(quadrature_weights)
-        np.fill_diagonal(
-            quadrature_weights,
-            quadrature_weights_diag - row_interval_lenghts[:-1] / 2,
-        )
+            # Final correction: adjust the weight at the extreme
+            # We need to remove t_i - t_{i-1} only at the leftmost point
+            quadrature_weights[i, row_idx] = row_interval_lenghts[row_idx + 1] / 2
 
         # Add column dimension
         quadrature_weights = quadrature_weights[:, None, :]

--- a/skfda/_utils/_warping.py
+++ b/skfda/_utils/_warping.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 from scipy.interpolate import PchipInterpolator
+from typing_extensions import override
 
 from ._utils import evaluate_fdatagrid_linear_interpolation
 
@@ -25,6 +26,43 @@ class LineEnergyFunction(Protocol):
     segments between a candidate point and the target.
 
     """
+    def dp_start(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        grid_dim: int,
+    ) -> None:
+        """
+        Called at the start of the DP algorithm.
+
+        This can be used to cache the needed values that are the
+        same for each row and column.
+
+        """
+
+    def dp_change_row(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        row: int,
+        grid_dim: int,
+    ) -> None:
+        """
+        Called when a row is changed in the DP algorithm.
+
+        This can be used to cache the needed values that are the
+        same for each row.
+
+        Note:
+            There is no analog function for columns, as the column
+            always change (and it requires less computations, because
+            the integral domain does not change).
+
+        """
 
     def __call__(
         self,
@@ -34,7 +72,7 @@ class LineEnergyFunction(Protocol):
         *,
         row: int,
         column: int,
-        grid_dim: int | None = None,
+        grid_dim: int,
     ) -> NDArrayFloat:
         """Returns energies of all lines from each candidate point."""
 
@@ -175,7 +213,7 @@ def _dp_recover_warpings(
     return na_interpolator.transform(warpings)
 
 
-class L2LineEnergy:
+class L2LineEnergy(LineEnergyFunction):
     r"""
     L2 line energy with roughness penalty.
 
@@ -193,16 +231,255 @@ class L2LineEnergy:
             of the slope of the interval. This is necessary when we work with
             the SRSF of the curves instead of with the curves themselves.
 
+    Examples:
+        Consider a simple case with 4 irregularly sampled discretization
+        points:
+
+        >>> import numpy as np
+        >>> grid_points = np.array([0, 0.5, 0.75, 1])
+
+        We use the identity function :math:`x(t) = t` and the piecewise
+        linear function :math:`y(t) = \max(0, 2t - 1)`:
+
+        >>> from skfda import FDataGrid
+        >>> original = FDataGrid(grid_points, grid_points=grid_points)
+        >>> target = FDataGrid(
+        ...     np.maximum(0, 2 * grid_points - 1),
+        ...     grid_points=grid_points,
+        ... )
+
+        Consider the default case with no penalization:
+        >>> l2_line_energy = L2LineEnergy()
+
+        We will consider use the full grid for now:
+
+        >>> grid_dim = len(grid_points)
+
+        Before calling it, the DP algorithm will call the ``dp_start``
+        method, at the beginning of the algorithm, to give the opportunity to
+        cache variables that are common for all the candidate points.
+
+        >>> l2_line_energy.dp_start(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ... )
+
+        We will consider the final case ``row = 3``, ``column=3``. Before
+        calling the function, the DP algorithm will call ``dp_change_row``
+        whenever the row is changed, to give the opportunity to
+        cache variables that are common for all the candidate points in
+        the same row.
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        array([[[ 0.109375  ,  0.30859375,  0.47558594],
+                [ 0.        ,  0.046875  ,  0.10546875],
+                [ 0.03125   ,  0.        ,  0.0078125 ]]])
+
+        Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
+        This is because they correspond to linear warpings that align
+        perfectly :math:`x` in the intervals :math:`(0.5, 1)` and
+        :math:`(0.75, 1)`, respectively.
+
+        Now consider a possible intermediate case with ``row = 2`` and
+        ``column=1``:
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=2,
+        ... )
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=2,
+        ...    column=1,
+        ... )
+        array([[[ 0.04166667],
+                [ 0.        ]]])
+
+        This has again 0 energy at ``(1, 0)``, because it is possible to
+        align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
+
+        With the parameter ``grid_dim`` we can control the size of the
+        grid used, so that the algorithm is still tractable with many
+        points:
+
+        >>> grid_dim = 1
+
+        >>> l2_line_energy.dp_start(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ... )
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> grid_1 = l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        >>> grid_1
+        array([[[ 0.0078125]]])
+
+        >>> grid_dim = 2
+
+        >>> l2_line_energy.dp_start(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ... )
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> grid_2 = l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        >>> grid_2
+        array([[[ 0.046875  ,  0.10546875],
+                [ 0.        ,  0.0078125 ]]])
+
+        As it can be seen, the results correspond to the lower-right part
+        of the complete grid.
+
+        It is also possible to penalize deviations from the identity
+        function:
+
+        >>> l2_line_energy = L2LineEnergy(penalty=1)
+
+        >>> grid_dim = len(grid_points)
+
+        >>> l2_line_energy.dp_start(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ... )
+
+        >>> l2_line_energy.dp_change_row(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ... )
+
+        >>> l2_line_energy(
+        ...    original,
+        ...    target,
+        ...    grid_dim=grid_dim,
+        ...    row=3,
+        ...    column=3,
+        ... )
+        array([[[ 0.109375  ,  0.39438019,  0.72558594],
+                [ 0.08578644,  0.046875  ,  0.14836197],
+                [ 0.28125   ,  0.04289322,  0.0078125 ]]])
+
+        Note that the terms on the main diagonal are not penalized in this
+        case, as there is no difference in slope with respect to the
+        identity function.
+
     """
 
     def __init__(
         self,
+        *,
         penalty: float = 0,
         slope_scaling: bool = False,
     ) -> None:
         self.penalty = penalty
         self.slope_scaling = slope_scaling
 
+    @override
+    def dp_start(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        grid_dim: int,
+    ) -> None:
+        self.grid_points = original.grid_points[0]
+        self.interval_lenghts = np.diff(
+            self.grid_points,
+            prepend=self.grid_points[0],
+        )
+
+    @override
+    def dp_change_row(
+        self,
+        /,
+        original: FDataGrid,
+        target: FDataGrid,
+        *,
+        row: int,
+        grid_dim: int,
+    ) -> None:
+        first_row_index = max(0, row - grid_dim)
+        t_row = self.grid_points[row]
+        t_i = self.grid_points[first_row_index:row, None]
+        self.total_interval_length = t_row - t_i
+
+        t = self.grid_points[first_row_index:row + 1]
+        self.l_matrix = (
+            (t - t_i) / self.total_interval_length
+        )[:, None, :]
+
+        self.y_t = target.data_matrix[:, first_row_index:row + 1, 0]
+
+        row_interval_lenghts = self.interval_lenghts[
+            first_row_index:row + 1
+        ]
+        quadrature_weights = row_interval_lenghts / 2
+        quadrature_weights[:-1] += row_interval_lenghts[1:] / 2
+
+        # We set the weights of unused points to 0
+        quadrature_weights = np.triu(
+            np.tile(quadrature_weights, (len(t_i), 1)),
+        )
+
+        # Final correction: adjust the weight at the extreme
+        # We need to remove t_i - t_{i-1} only at the leftmost point
+        quadrature_weights_diag = np.diagonal(quadrature_weights)
+        np.fill_diagonal(
+            quadrature_weights,
+            quadrature_weights_diag - row_interval_lenghts[:-1] / 2,
+        )
+
+        # Add column dimension
+        quadrature_weights = quadrature_weights[:, None, :]
+        self.quadrature_weights = quadrature_weights
+
+    @override
     def __call__(  # noqa: WPS210
         self,
         original: FDataGrid,
@@ -210,7 +487,7 @@ class L2LineEnergy:
         *,
         row: int,
         column: int,
-        grid_dim: int | None = None,
+        grid_dim: int,
     ) -> NDArrayFloat:
         r"""
         Compute the line energies for the :math:`L^2` distance.
@@ -238,130 +515,18 @@ class L2LineEnergy:
         Returns:
             Energy of direct line warpings to the candidate point.
 
-        Examples:
-            Consider a simple case with 4 irregularly sampled discretization
-            points:
-
-            >>> import numpy as np
-            >>> grid_points = np.array([0, 0.5, 0.75, 1])
-
-            We use the identity function :math:`x(t) = t` and the piecewise
-            linear function :math:`y(t) = \max(0, 2t - 1)`:
-
-            >>> from skfda import FDataGrid
-            >>> original = FDataGrid(grid_points, grid_points=grid_points)
-            >>> target = FDataGrid(
-            ...     np.maximum(0, 2 * grid_points - 1),
-            ...     grid_points=grid_points,
-            ... )
-
-            Consider the default case with no penalization:
-            >>> l2_line_energy = L2LineEnergy()
-
-            We will consider the final case ``row = 3``, ``column=3``:
-            >>> l2_line_energy(
-            ...    original,
-            ...    target,
-            ...    row=3,
-            ...    column=3,
-            ... )
-            array([[[ 0.109375  ,  0.30859375,  0.47558594],
-                    [ 0.        ,  0.046875  ,  0.10546875],
-                    [ 0.03125   ,  0.        ,  0.0078125 ]]])
-
-            Note that the cells ``(1, 0)`` and ``(2, 1)`` have 0 energy.
-            This is because they correspond to linear warpings that align
-            perfectly :math:`x` in the intervals :math:`(0.5, 1)` and
-            :math:`(0.75, 1)`, respectively.
-
-            Now consider a possible intermediate case with ``row = 2`` and
-            ``column=1``:
-            >>> l2_line_energy(
-            ...    original,
-            ...    target,
-            ...    row=2,
-            ...    column=1,
-            ... )
-            array([[[ 0.04166667],
-                    [ 0.        ]]])
-
-            This has again 0 energy at ``(1, 0)``, because it is possible to
-            align perfectly :math:`x` in the interval :math:`(0.5, 0.75)`.
-
-            With the parameter ``grid_dim`` we can control the size of the
-            grid used, so that the algorithm is still tractable with many
-            points:
-
-            >>> complete_grid = l2_line_energy(
-            ...    original,
-            ...    target,
-            ...    row=3,
-            ...    column=3,
-            ... )
-
-            >>> grid_1 = l2_line_energy(
-            ...    original,
-            ...    target,
-            ...    row=3,
-            ...    column=3,
-            ...    grid_dim = 1,
-            ... )
-            >>> grid_1
-            array([[[ 0.0078125]]])
-
-            >>> grid_2 = l2_line_energy(
-            ...    original,
-            ...    target,
-            ...    row=3,
-            ...    column=3,
-            ...    grid_dim = 2,
-            ... )
-            >>> grid_2
-            array([[[ 0.046875  ,  0.10546875],
-                    [ 0.        ,  0.0078125 ]]])
-
-            As you can see, the results correspond to the lower-right part
-            of the complete grid.
-
-            It is also possible to penalize deviations from the identity
-            function:
-
-            >>> l2_line_energy = L2LineEnergy(penalty=1)
-
-            >>> l2_line_energy(
-            ...    original,
-            ...    target,
-            ...    row=3,
-            ...    column=3,
-            ... )
-            array([[[ 0.109375  ,  0.39438019,  0.72558594],
-                    [ 0.08578644,  0.046875  ,  0.14836197],
-                    [ 0.28125   ,  0.04289322,  0.0078125 ]]])
-
-            Note that the terms on the main diagonal are not penalized in this
-            case, as there is no difference in slope with respect to the
-            identity function.
-
         """
-        if grid_dim is None:
-            grid_dim = max(row, column)
+        grid_points = self.grid_points
 
-        grid_points = original.grid_points[0]
-
-        first_row_index = max(0, row - grid_dim)
         first_column_index = max(0, column - grid_dim)
 
-        t_row = grid_points[row]
         t_column = grid_points[column]
 
-        t_i = grid_points[first_row_index:row, None]
         t_j = grid_points[first_column_index:column, None]
 
-        total_interval_length = t_row - t_i
+        total_interval_length = self.total_interval_length
 
-        t = grid_points[first_row_index:row + 1]
-        l_vec = (t - t_i) / total_interval_length
-        l_matrix = l_vec[:, None, :]
+        l_matrix = self.l_matrix
         w = (1 - l_matrix) * t_j + l_matrix * t_column
         w_flat = w.reshape(-1)
 
@@ -372,7 +537,7 @@ class L2LineEnergy:
         )
 
         # Shape: N x t
-        y_t = target.data_matrix[:, first_row_index:row + 1, 0]
+        y_t = self.y_t
 
         w_slope = (t_column - t_j.T) / total_interval_length
         w_slope_root = np.sqrt(w_slope)
@@ -382,25 +547,7 @@ class L2LineEnergy:
 
         integrand = (x_t - y_t[:, None, None, :])**2
 
-        interval_lenghts = np.diff(t, prepend=t[0])
-        quadrature_weights = interval_lenghts / 2
-        quadrature_weights[:-1] += interval_lenghts[1:] / 2
-
-        # We set the weights of unused points to 0
-        quadrature_weights = np.triu(
-            np.tile(quadrature_weights, (len(t_i), 1)),
-        )
-
-        # Final correction: adjust the weight at the extreme
-        # We need to remove t_i - t_{i-1} only at the leftmost point
-        quadrature_weights_diag = np.diagonal(quadrature_weights)
-        np.fill_diagonal(
-            quadrature_weights,
-            quadrature_weights_diag - interval_lenghts[:-1] / 2,
-        )
-
-        # Add column dimension
-        quadrature_weights = quadrature_weights[:, None, :]
+        quadrature_weights = self.quadrature_weights
 
         integral = np.sum(integrand * quadrature_weights, axis=-1)
 
@@ -540,7 +687,21 @@ def dynamic_programming_match(  # noqa: WPS210
     energy[:, :, 0] = np.inf
     energy[:, 0, 0] = 0
 
+    line_energy_function.dp_start(
+        original,
+        target,
+        grid_dim=grid_dim,
+    )
+
     for row in range(1, n_points):
+
+        line_energy_function.dp_change_row(
+            original,
+            target,
+            grid_dim=grid_dim,
+            row=row,
+        )
+
         for column in range(1, n_points):
             first_row_index = max(0, row - grid_dim)
             first_column_index = max(0, column - grid_dim)

--- a/skfda/exploratory/stats/_fisher_rao.py
+++ b/skfda/exploratory/stats/_fisher_rao.py
@@ -7,6 +7,8 @@ import scipy.integrate
 from fdasrsf.utility_functions import optimum_reparam
 
 from ..._utils import invert_warping, normalize_scale
+from ..._utils._warping import L2LineEnergy, dynamic_programming_match
+from ...misc.metrics import l2_distance, l2_norm
 from ...misc.operators import SRSF
 from ...misc.validation import check_fdata_dimensions
 from ...representation import FDataGrid
@@ -249,75 +251,45 @@ def fisher_rao_karcher_mean(
     )
 
     srsf_transformer = SRSF(initial_value=0)
-    fdatagrid_srsf = srsf_transformer.fit_transform(fdatagrid)
+    srsf = srsf_transformer.fit_transform(fdatagrid)
     eval_points = fdatagrid.grid_points[0]
-
-    eval_points_normalized = normalize_scale(eval_points)
-    y_scale = eval_points[-1] - eval_points[0]
 
     interpolation = SplineInterpolation(interpolation_order=3, monotone=True)
 
-    # Discretisation points
-    fdatagrid_normalized = FDataGrid(
-        fdatagrid(eval_points) / y_scale,
-        grid_points=eval_points_normalized,
-    )
-
-    srsf = fdatagrid_srsf(eval_points)[..., 0]
-
     # Initialize with function closest to the L2 mean with the L2 distance
-    centered = (srsf.T - srsf.mean(axis=0, keepdims=True).T).T
-
-    distances = scipy.integrate.simpson(
-        np.square(centered, out=centered),
-        x=eval_points_normalized,
-        axis=1,
-    )
+    distances = l2_distance(srsf, srsf.mean())
 
     # Initialization of iteration
     mu = srsf[np.argmin(distances)]
-    mu_aux = np.empty(mu.shape)
-    mu_1 = np.empty(mu.shape)
+
+    line_energy = L2LineEnergy(
+        penalty,
+        slope_scaling=True,
+    )
 
     # Main iteration
     for _ in range(max_iter):
 
-        gammas_matrix = _elastic_alignment_array(
-            mu,
+        gammas = dynamic_programming_match(
             srsf,
-            eval_points_normalized,
-            penalty,
-            grid_dim,
+            mu,
+            line_energy_function=line_energy,
+            grid_dim=grid_dim,
         )
+        gammas.interpolation = interpolation
 
-        gammas = FDataGrid(
-            gammas_matrix,
-            grid_points=eval_points_normalized,
-            interpolation=interpolation,
-        )
-
-        fdatagrid_normalized = fdatagrid_normalized.compose(gammas)
+        fdatagrid = fdatagrid.compose(gammas)
         srsf = srsf_transformer.transform(
-            fdatagrid_normalized,
-        ).data_matrix[..., 0]
+            fdatagrid,
+        )
 
         # Next iteration
-        mu_1 = srsf.mean(axis=0)
+        mu_1 = srsf.mean()
 
         # Convergence criterion
-        mu_norm = np.sqrt(
-            scipy.integrate.simpson(
-                np.square(mu, out=mu_aux),
-                x=eval_points_normalized,
-            ),
-        )
+        mu_norm = l2_norm(mu)
 
-        mu_diff = np.sqrt(
-            scipy.integrate.simpson(
-                np.square(mu - mu_1, out=mu_aux),
-                x=eval_points_normalized,
-            ),
-        )
+        mu_diff = l2_distance(mu, mu_1)
 
         if mu_diff / mu_norm < tol:
             break
@@ -331,11 +303,7 @@ def fisher_rao_karcher_mean(
 
     # Karcher mean orbit in space L2/Gamma
     karcher_mean = srsf_transformer.inverse_transform(
-        fdatagrid.copy(
-            data_matrix=[mu],
-            grid_points=eval_points,
-            sample_names=("Karcher mean",),
-        ),
+        mu,
     )
 
     if center:

--- a/skfda/exploratory/stats/_fisher_rao.py
+++ b/skfda/exploratory/stats/_fisher_rao.py
@@ -4,58 +4,15 @@ from typing import Any
 
 import numpy as np
 import scipy.integrate
-from fdasrsf.utility_functions import optimum_reparam
 
 from ..._utils import invert_warping, normalize_scale
-from ..._utils._warping import L2LineEnergy, dynamic_programming_match
+from ..._utils._warping import elastic_registration_match
 from ...misc.metrics import l2_distance, l2_norm
 from ...misc.operators import SRSF
 from ...misc.validation import check_fdata_dimensions
 from ...representation import FDataGrid
 from ...representation.interpolation import SplineInterpolation
 from ...typing._numpy import NDArrayFloat
-
-###############################################################################
-# Based on the original implementation of J. Derek Tucker in                  #
-# *fdasrsf_python* (https://github.com/jdtuck/fdasrsf_python)                 #
-# and *ElasticFDA.jl* (https://github.com/jdtuck/ElasticFDA.jl).              #
-###############################################################################
-
-
-def _elastic_alignment_array(
-    template_data: NDArrayFloat,
-    q_data: NDArrayFloat,
-    eval_points: NDArrayFloat,
-    penalty: float,
-    grid_dim: int,
-) -> NDArrayFloat:
-    """
-    Wrap the :func:`optimum_reparam` function of fdasrsf.
-
-    Selects the corresponding routine depending on the dimensions of the
-    arrays.
-
-    Args:
-        template_data: Array with the srsf of the template.
-        q_data: Array with the srsf of the curves
-                to be aligned.
-        eval_points: Discretisation points of the functions.
-        penalty: Penalisation term.
-        grid_dim: Dimension of the grid used in the alignment algorithm.
-
-    Returns:
-        Array with the same shape than q_data with the srsf of
-        the functions aligned to the template(s).
-
-    """
-    return optimum_reparam(  # type: ignore[no-any-return]
-        np.ascontiguousarray(template_data.T),
-        np.ascontiguousarray(eval_points),
-        np.ascontiguousarray(q_data.T),
-        method="DP2",
-        lam=penalty,
-        grid_dim=grid_dim,
-    ).T
 
 
 def _fisher_rao_warping_mean(
@@ -262,18 +219,13 @@ def fisher_rao_karcher_mean(
     # Initialization of iteration
     mu = srsf[np.argmin(distances)]
 
-    line_energy = L2LineEnergy(
-        penalty=penalty,
-        slope_scaling=True,
-    )
-
     # Main iteration
     for _ in range(max_iter):
 
-        gammas = dynamic_programming_match(
+        gammas = elastic_registration_match(
             srsf,
             mu,
-            line_energy_function=line_energy,
+            penalty=penalty,
             grid_dim=grid_dim,
         )
         gammas.interpolation = interpolation

--- a/skfda/exploratory/stats/_fisher_rao.py
+++ b/skfda/exploratory/stats/_fisher_rao.py
@@ -263,7 +263,7 @@ def fisher_rao_karcher_mean(
     mu = srsf[np.argmin(distances)]
 
     line_energy = L2LineEnergy(
-        penalty,
+        penalty=penalty,
         slope_scaling=True,
     )
 

--- a/skfda/preprocessing/feature_construction/_per_class_transformer.py
+++ b/skfda/preprocessing/feature_construction/_per_class_transformer.py
@@ -150,10 +150,10 @@ class PerClassTransformer(
         >>> neigh2 = neigh2.fit(X_train2, y_train2)
         >>> neigh2.predict(X_test2)
         array([ 1,  1,  1,  1,  1,  1,  1,  0,  0,  0,  0,  1,  1,  0,  0,  0,
-                0,  1,  1,  1,  1,  0,  1,  1], dtype=int8)
+                0,  1,  1,  1,  1,  1,  1,  1], dtype=int8)
 
         >>> round(neigh2.score(X_test2, y_test2), 3)
-        0.875
+        0.917
 
     """
 

--- a/skfda/preprocessing/feature_construction/_per_class_transformer.py
+++ b/skfda/preprocessing/feature_construction/_per_class_transformer.py
@@ -119,13 +119,13 @@ class PerClassTransformer(
 
         We can also use a transformer that returns a FData object
         when predicting.
-        In our example we are going to use the Fisher Rao Elastic Registration.
+        In our example we are going to use least-squares shift registration.
 
         >>> from skfda.preprocessing.registration import (
-        ...     FisherRaoElasticRegistration,
+        ...     LeastSquaresShiftRegistration,
         ... )
         >>> t2 = PerClassTransformer(
-        ...     FisherRaoElasticRegistration(),
+        ...     LeastSquaresShiftRegistration(),
         ... )
         >>> x_transformed2 = t2.fit_transform(X, y)
 
@@ -149,11 +149,11 @@ class PerClassTransformer(
         >>> neigh2 = KNeighborsClassifier()
         >>> neigh2 = neigh2.fit(X_train2, y_train2)
         >>> neigh2.predict(X_test2)
-        array([ 1,  1,  1,  1,  1,  1,  1,  0,  0,  0,  0,  1,  1,  0,  0,  0,
-                0,  1,  1,  1,  1,  1,  1,  1], dtype=int8)
+        array([ 0,  1,  1,  0,  1,  1,  1,  0,  0,  0,  0,  1,  1,  0,  0,  0, 
+                0, 1,  1,  1,  1,  1,  1,  1], dtype=int8)
 
         >>> round(neigh2.score(X_test2, y_test2), 3)
-        0.917
+        1.0
 
     """
 

--- a/skfda/preprocessing/registration/_fisher_rao.py
+++ b/skfda/preprocessing/registration/_fisher_rao.py
@@ -8,8 +8,8 @@ import numpy as np
 from sklearn.utils.validation import check_is_fitted
 
 from ..._utils import invert_warping, normalize_scale
+from ..._utils._warping import L2LineEnergy, dynamic_programming_match
 from ...exploratory.stats import fisher_rao_karcher_mean
-from ...exploratory.stats._fisher_rao import _elastic_alignment_array
 from ...misc.operators import SRSF
 from ...misc.validation import check_fdata_dimensions, check_fdata_same_kind
 from ...representation import FDataGrid
@@ -185,24 +185,20 @@ class FisherRaoElasticRegistration(
         # Points of discretization
         output_points = self._output_points
 
-        # Discretizacion in evaluation points
-        q_data = fdatagrid_srsf(output_points)[..., 0]
-        template_data = self._template_srsf(output_points)[..., 0]
-
-        if q_data.shape[0] == 1:
-            q_data = q_data[0]
-
-        if template_data.shape[0] == 1:
-            template_data = template_data[0]
-
         # Values of the warping
-        gamma = _elastic_alignment_array(
-            template_data,
-            q_data,
-            normalize_scale(output_points),
+        line_energy = L2LineEnergy(
             self.penalty,
-            self.grid_dim,
+            slope_scaling=True,
         )
+
+        fdatagrid_gamma = dynamic_programming_match(
+            fdatagrid_srsf,
+            self._template_srsf,
+            line_energy_function=line_energy,
+            grid_dim=self.grid_dim,
+        )
+
+        gamma = fdatagrid_gamma.data_matrix[..., 0]
 
         # Normalize warping to original interval
         gamma = normalize_scale(

--- a/skfda/preprocessing/registration/_fisher_rao.py
+++ b/skfda/preprocessing/registration/_fisher_rao.py
@@ -8,7 +8,7 @@ import numpy as np
 from sklearn.utils.validation import check_is_fitted
 
 from ..._utils import invert_warping, normalize_scale
-from ..._utils._warping import L2LineEnergy, dynamic_programming_match
+from ..._utils._warping import elastic_registration_match
 from ...exploratory.stats import fisher_rao_karcher_mean
 from ...misc.operators import SRSF
 from ...misc.validation import check_fdata_dimensions, check_fdata_same_kind
@@ -186,15 +186,10 @@ class FisherRaoElasticRegistration(
         output_points = self._output_points
 
         # Values of the warping
-        line_energy = L2LineEnergy(
-            penalty=self.penalty,
-            slope_scaling=True,
-        )
-
-        fdatagrid_gamma = dynamic_programming_match(
+        fdatagrid_gamma = elastic_registration_match(
             fdatagrid_srsf,
             self._template_srsf,
-            line_energy_function=line_energy,
+            penalty=self.penalty,
             grid_dim=self.grid_dim,
         )
 

--- a/skfda/preprocessing/registration/_fisher_rao.py
+++ b/skfda/preprocessing/registration/_fisher_rao.py
@@ -187,7 +187,7 @@ class FisherRaoElasticRegistration(
 
         # Values of the warping
         line_energy = L2LineEnergy(
-            self.penalty,
+            penalty=self.penalty,
             slope_scaling=True,
         )
 

--- a/skfda/tests/test_elastic.py
+++ b/skfda/tests/test_elastic.py
@@ -156,6 +156,26 @@ class TestFisherRaoElasticRegistration(unittest.TestCase):
 
         np.testing.assert_allclose(distances, 0, atol=12e-3)
 
+    def test_alignment_constant(self) -> None:
+        """
+        Test alignment of a constant function to another.
+
+        In this case the problem is undetermined (any warping would
+        be valid). However, for clarity purposes we would prefer
+        if we use the identity function as a warping in this case.
+
+        """
+        reg = FisherRaoElasticRegistration(
+            template=FDataGrid(np.ones(100)),
+        )
+        reg.fit_transform(FDataGrid(np.zeros(100)))
+
+        np.testing.assert_allclose(
+            reg.warping_.data_matrix[0, ..., 0],
+            reg.warping_.grid_points[0],
+            atol=12e-3,
+        )
+
     def test_set_alignment(self) -> None:
         """Test alignment 3 curves to set with 3 templates."""
         # Should give same result than test_template_alignment
@@ -326,7 +346,11 @@ class TestElasticDistances(unittest.TestCase):
         """Test of phase distance invariance."""
         f = make_multimodal_samples(n_samples=1, random_state=1)
 
-        phase = fisher_rao_phase_distance(f, 2 * f)
+        # Some regularization is needed, otherwise small fluctuations in the
+        # computation (such as the use of a different quadrature) can cause
+        # differences from the identity in the almost-constant parts of the
+        # functions.
+        phase = fisher_rao_phase_distance(f, 2 * f, lam=1e-3)
 
         np.testing.assert_allclose(phase, 0, atol=1e-7)
 


### PR DESCRIPTION
## Describe the proposed changes

Adds a new implementation of the dynamic programming (DP) algorithm used in elastic registration. The new implementation is written in pure Python, with no dependencies on `fdasrsf`. Unfortunately, it is around 8-10 times slower for large data, so we still keep `fdasrsf` as an *optional* dependency, for those that really need the performance. If `fdasrsf` is present it will be used.

## Additional information

There are several benefits to have our own implementation independent of `fdasrsf`:
- **Convenience**: `fdasrsf` had a lot of problems to compile when Python versions change, or BLAS libraries are not easily found. This was disrupting for both our users and our continuous integration, even when these users do not need to use elastic registration.
- **Learning**: having a pure Python implementation makes easier for people to read and understand the algorithm.
- **Maintenance**: as the algorithm is easier to understand now, it should be also easier to modify, fix and optimize.
- **Web availability**: a medium-term goal of scikit-fda is to be able be used into the web using Pyodide. This opens the door to a lot
of possible uses, including having interactive documentation. However, non-mainstream libraries that are written in C (including `fdasrsf`) are not available in Pyodide. After removing this dependency, I think the only missing thing would be to remove the dependency on Numba.
- **Future extensions**: a long-term goal of scikit-fda is to be able to support all arrays that conform to the array API standard. Having our own implementation in Python will make easier to support other arrays in the future.

All of these make having a Python implementation useful, even if it is (currently) not as performant as the one in `fdasrsf`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
