### PR TITLE
docs: explain variable selection acronyms

### DIFF
--- a/docs/modules/preprocessing/dim_reduction.rst
+++ b/docs/modules/preprocessing/dim_reduction.rst
@@ -15,6 +15,11 @@ datum.
 The variable selection transformers implemented in scikit-fda are the
 following:
 
+Some variable selection methods are often referred to by acronyms in the
+literature and examples. In particular, ``MaximaHunting`` is abbreviated as
+MH, ``RecursiveMaximaHunting`` as RMH, and ``RKHSVariableSelection`` as RK-VS
+(RKHS variable selection, where RKHS means Reproducing Kernel Hilbert Space).
+
 .. autosummary::
    :toctree: autosummary
 


### PR DESCRIPTION
## References to issues or other PRs

Fixes #516.

## Describe the proposed changes

- Add a short explanation of common variable-selection acronyms in the dimensionality reduction documentation.
- Clarify that `MaximaHunting` is abbreviated as MH, `RecursiveMaximaHunting` as RMH, and `RKHSVariableSelection` as RK-VS.

## Additional information

Validation:

- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`
- Read the Docs build 32858978 failed while loading `docs/conf.py` because `pkg_resources` is unavailable before the documentation build reaches this page.
- Not run locally

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package
- [x] The code is fully documented and typed (docs-only change; no runtime code changed)
- [ ] I have added thorough tests for the new/changed functionality (not applicable, docs-only change)